### PR TITLE
[kernel] cover policy runtime edge cases

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -8,6 +8,10 @@ Complete API documentation for WP Kernel.
 
 Define typed REST resources with automatic client generation, store integration, and cache management.
 
+### [Policies](/api/policy)
+
+Declarative capability rules with caching, denial events, and React helpers for UI gating.
+
 ### [Errors](/api/generated/error/README)
 
 Error types and handling primitives.

--- a/docs/api/policy.md
+++ b/docs/api/policy.md
@@ -1,0 +1,162 @@
+# Policy API
+
+Policies provide a declarative capability layer that Actions enforce and UI
+components consume through hooks. The client runtime handles caching, diagnostics,
+and cross-tab synchronisation.
+
+## `definePolicy`
+
+```ts
+import { definePolicy } from '@geekist/wp-kernel/policy';
+```
+
+### Signature
+
+```ts
+import type {
+	PolicyMap,
+	PolicyOptions,
+	PolicyHelpers,
+} from '@geekist/wp-kernel/policy';
+
+declare function definePolicy<K extends Record<string, unknown>>(
+	map: PolicyMap<K>,
+	options?: PolicyOptions
+): PolicyHelpers<K>;
+```
+
+`definePolicy()` accepts a typed map of rules keyed by capability name. Each rule
+receives a `PolicyContext` with adapters, cache helpers, and the resolved
+namespace. The return value contains helpers for evaluating and extending the
+map.
+
+### Options
+
+`PolicyOptions` customise runtime behaviour:
+
+- `namespace` – override the detected plugin namespace. Defaults to
+  `getNamespace()` (usually the package slug).
+- `adapters.wp.canUser` – inject a capability check compatible with
+  `@wordpress/data`’s `canUser` selector. The runtime auto-detects the core
+  selector when the adapter is omitted.
+- `adapters.restProbe` – async helper for pinging REST endpoints before a rule
+  resolves. Optional.
+- `cache.ttlMs` – default time-to-live per entry (60_000 ms by default).
+- `cache.storage` – `'memory'` (default) or `'session'` persistence.
+- `cache.crossTab` – enable/disable BroadcastChannel fan-out (defaults to `true`).
+- `debug` – when `true`, the runtime logs reporter messages to the console.
+
+### Usage
+
+```ts
+export type JobPolicies = {
+	'jobs.manage': void;
+	'jobs.delete': { id: number };
+};
+
+export const policy = definePolicy<JobPolicies>({
+	'jobs.manage': () => true,
+	'jobs.delete': async ({ adapters }, { id }) =>
+		(await adapters.wp?.canUser('delete', {
+			kind: 'postType',
+			name: 'job',
+			id,
+		})) ?? false,
+});
+```
+
+The returned helpers automatically register with the Action runtime so
+`ctx.policy.can()` and `ctx.policy.assert()` operate on the same instance used by
+`usePolicy()`.
+
+## `PolicyHelpers`
+
+`PolicyHelpers<K>` exposes the following methods:
+
+- `can(key, ...params)` → `boolean | Promise<boolean>` – Evaluate a rule without
+  throwing. Async rules return promises.
+- `assert(key, ...params)` → `void | Promise<void>` – Throws
+  `KernelError('PolicyDenied')` when the rule resolves to `false`. Also emits a
+  `{namespace}.policy.denied` WordPress hook and BroadcastChannel event.
+- `keys()` → `(keyof K)[]` – List registered capability keys.
+- `extend(map)` → `void` – Merge additional rules and invalidate the cache for
+  affected keys.
+- `cache` – Shared `PolicyCache` instance used by the runtime and UI hook.
+
+## `PolicyContext`
+
+Rules receive a `PolicyContext` argument with:
+
+- `namespace` – resolved namespace.
+- `adapters` – the adapters supplied through `PolicyOptions` plus any detected
+  defaults (`wp.canUser`, `restProbe`).
+- `cache` – low-level cache interface supporting `get`, `set`, `invalidate`, and
+  `subscribe`.
+- `reporter` – structured logging hooks (`info`, `warn`, `error`, `debug`).
+
+Use the context to compose decisions, log diagnostic events, or reuse cached
+results across rules.
+
+## `PolicyCacheOptions`
+
+```ts
+interface PolicyCacheOptions {
+	ttlMs?: number;
+	storage?: 'memory' | 'session';
+	crossTab?: boolean;
+}
+```
+
+- Entries expire after `ttlMs` unless overridden in `cache.set()`.
+- `storage: 'session'` persists results to `sessionStorage`; memory is
+  ephemeral.
+- `crossTab: false` disables BroadcastChannel replication across tabs.
+
+## `usePolicy`
+
+```ts
+import { usePolicy } from '@geekist/wp-kernel/policy';
+```
+
+### Signature
+
+```ts
+function usePolicy<K extends Record<string, unknown>>(): {
+	can: <Key extends keyof K>(
+		key: Key,
+		...params: K[Key] extends void ? [] : [K[Key]]
+	) => boolean;
+	keys: (keyof K)[];
+	isLoading: boolean;
+	error?: Error;
+};
+```
+
+### Behaviour
+
+- Before hydration, `can()` returns `false` and `isLoading` is `true` so UI
+  components can optimistically disable affordances.
+- After hydration, the hook reads from the shared cache and subscribes to
+  invalidation events for live updates.
+- Thrown errors from `policy.can()` propagate to the hook’s `error` state.
+
+### Usage
+
+```tsx
+import type { JobPolicies } from '@/policy';
+
+export function Toolbar({ id }: { id: number }) {
+	const { can, isLoading } = usePolicy<JobPolicies>();
+	const removeDisabled = isLoading || !can('jobs.delete', { id });
+
+	return <Button disabled={removeDisabled}>Delete</Button>;
+}
+```
+
+## Denial events
+
+Every failed `assert()` emits a `{namespace}.policy.denied` hook via
+`@wordpress/hooks` and a message on the `wpk.policy.events` BroadcastChannel. The
+payload includes the policy key, sanitized params, message key, request id (when
+available), and timestamp. Use these events to aggregate audit logs or fan out to
+native bridges.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -43,11 +43,15 @@ WP Kernel revolves around a handful of primitives that cooperate rather than com
 
 The diagram mirrors the way WordPress ships features today. Views render blocks backed by bindings and Interactivity controllers. Actions coordinate writes. Resources speak REST to WordPress, while events and jobs make the system observable and resilient.
 
-## The five primitives
+## The core primitives
 
 ### Resources
 
 A resource turns a REST contract into a typed client, data store, and cache keys from a single definition. Reach for one whenever the UI needs to read or write data. Because the schema drives both TypeScript and PHP validation, the documentation you write here stays true across the stack. [Read the full guide →](/guide/resources)
+
+### Policies
+
+Policies define capability gates that sit between resources and Actions. They provide synchronous hints to the UI while Actions enforce them at runtime, emit denial events, and keep cache state in sync across tabs. [Read the full guide →](/guide/policy)
 
 ### Actions
 

--- a/docs/guide/policy.md
+++ b/docs/guide/policy.md
@@ -1,0 +1,189 @@
+# Policies
+
+Policies answer the question **“should this feature be available to the current
+user?”** before any network request fires. They are declarative capability rules
+that Actions enforce and the UI consumes as hints. Phase 1 ships purely on the
+client-the server is still the source of truth-so treat policy denials as UX
+signals, not security boundaries.
+
+## When to reach for policies
+
+Policies sit between resources and everything that consumes them:
+
+```
+Resources → Policies → Actions → Views → Jobs
+```
+
+Reach for a policy when:
+
+- multiple Actions need to agree on permission checks,
+- the UI should disable or hide affordances when the user lacks access, and
+- you want a single place to log and audit denials.
+
+Policies work best when the canonical decision still happens on the server.
+Client enforcement keeps the interface responsive and predictable while you wait
+for the authoritative response.
+
+## Defining capability maps
+
+Use `definePolicy()` to declare a strongly typed map from capability keys to
+rule functions. Rules receive a `PolicyContext` that exposes reporters,
+adapters, and the shared cache.
+
+```ts
+import { definePolicy } from '@geekist/wp-kernel/policy';
+
+type JobPolicies = {
+	'jobs.manage': void;
+	'jobs.delete': { id: number };
+	'beta.enabled': void;
+};
+
+export const policy = definePolicy<JobPolicies>({
+	'jobs.manage': () => true,
+	'jobs.delete': ({ adapters }, { id }) =>
+		adapters.wp?.canUser('delete', {
+			kind: 'postType',
+			name: 'job',
+			id,
+		}) ?? false,
+	'beta.enabled': async ({ adapters }) =>
+		(await adapters.restProbe?.('beta')) ?? false,
+});
+```
+
+### Typed parameters
+
+Keys whose value type is `void` automatically become optional parameters when
+calling `policy.can()` and `policy.assert()`. Keys with an object payload stay
+required and propagate exact property types to callers.
+
+### WordPress adapter detection
+
+If you do not supply a `wp.canUser` adapter, the runtime attempts to reuse
+`wp.data.select('core').canUser`. Detection happens once during initialization
+and logs a warning if the call fails. Provide a custom adapter when you need to
+proxy the decision to a REST endpoint or enforce non-standard permissions.
+
+### Extending policy maps
+
+Call `policy.extend()` to register additional rules at runtime. Re-registering a
+key in development prints a console warning and clears any cached value for that
+key so React hooks re-evaluate the rule.
+
+```ts
+policy.extend({
+	'jobs.delete': ({ reporter }, { id }) => {
+		reporter?.info('Auditing delete attempt', { id });
+		return id % 2 === 0;
+	},
+});
+```
+
+## Enforcing rules inside Actions
+
+The policy helpers automatically attach to the Action runtime. Inside an
+Action’s implementation you can synchronously or asynchronously gate behaviour:
+
+```ts
+import { defineAction } from '@geekist/wp-kernel/actions';
+import { policy } from '@/policy';
+
+export const DeleteJob = defineAction('Job.Delete', async (ctx, { id }) => {
+	await ctx.policy.assert('jobs.delete', { id });
+
+	await jobsResource.delete({ id });
+	ctx.emit('wpk.jobs.deleted', { id });
+});
+```
+
+`assert()` throws a `KernelError('PolicyDenied')` when a rule returns false. The
+error includes a structured `context` field, a `messageKey` of the form
+`policy.denied.{namespace}.{key}`, and triggers a `{namespace}.policy.denied`
+WordPress hook plus a BroadcastChannel message so other tabs hear about the
+refusal.
+
+Use `ctx.policy.can()` when you only need a boolean without raising errors.
+Both helpers propagate async rules, making it safe to call REST probes or other
+asynchronous checks inside the rule body.
+
+## Surfacing state in the UI
+
+Policies double as UI hints through the `usePolicy()` hook. The hook subscribes
+to the shared cache so components stay in sync with Action checks.
+
+```tsx
+import { usePolicy } from '@geekist/wp-kernel/policy';
+
+type PolicyKeys = Parameters<typeof policy.can>[0];
+
+export function DeleteJobButton({ id }: { id: number }) {
+	const { can, isLoading, error } = usePolicy<PolicyKeys>();
+	const allowed = can('jobs.delete', { id });
+
+	if (error) {
+		return <Notice status="error">{error.message}</Notice>;
+	}
+
+	return (
+		<Button variant="primary" disabled={isLoading || !allowed}>
+			Delete job
+		</Button>
+	);
+}
+```
+
+### Hydration contract
+
+Before the policy runtime hydrates, `usePolicy()` returns:
+
+- `can()` → `false`
+- `isLoading` → `true`
+- `keys` → `[]`
+
+Once hydration completes the hook returns cached values when available and sets
+`isLoading` to `false`. Calling `policy.can()` directly in the browser updates
+the cache, which immediately flows into any mounted hooks.
+
+## Cache behaviour and tuning
+
+All policy evaluations run through an LRU cache with a default TTL of 60
+seconds. The cache keeps both Action assertions and UI hooks in sync. Configure
+it via the `cache` option when defining the policy:
+
+```ts
+const policy = definePolicy(map, {
+	cache: {
+		ttlMs: 5 * 60_000,
+		storage: 'session',
+		crossTab: true,
+	},
+});
+```
+
+- `ttlMs` sets the default freshness window per entry.
+- `storage: 'session'` persists results to `sessionStorage`. Memory storage is
+  the default and resets on reload.
+- `crossTab` toggles BroadcastChannel fan-out. Disable it when you need
+  completely tab-local decisions.
+
+Rules can manually evict cache entries through `ctx.cache.invalidate()` or by
+calling `policy.extend()`, which invalidates the affected key automatically.
+
+## Observability and diagnostics
+
+Policies emit denial events even when the caller only asked for a boolean. The
+payload includes the policy key, sanitized params, request id (when available),
+and a timestamp. Listen to `{namespace}.policy.denied` through `wp.hooks` or a
+BroadcastChannel named `wpk.policy.events` to aggregate audit logs.
+
+Enable debug logging by passing `{ debug: true }` when defining the policy. The
+runtime then prints structured `info`, `warn`, and `error` messages that mirror
+the Action reporter surface.
+
+## Phase 2 outlook
+
+Phase 1 policies are UX hints. Future sprints will extend the same definitions
+to server enforcement so that Actions and REST routes share a single capability
+map. Designing policies now keeps the migration path straightforward once the
+server contract arrives.

--- a/packages/kernel/src/__tests__/integration/action-flow.test.ts
+++ b/packages/kernel/src/__tests__/integration/action-flow.test.ts
@@ -164,7 +164,7 @@ describe('Action Flow Integration', () => {
 			{ id: number; updates: { title: string } },
 			{ id: number; title: string }
 		>('Thing.Update', async (ctx, { id, updates }) => {
-			ctx.policy.assert('edit_things');
+			ctx.policy.assert('edit_things', undefined);
 			const result = await resource.update!(id, updates);
 			ctx.invalidate([`thing:${id}`, 'list']);
 			return result;

--- a/packages/kernel/src/actions/__tests__/context.test.ts
+++ b/packages/kernel/src/actions/__tests__/context.test.ts
@@ -147,13 +147,17 @@ describe('Action Context', () => {
 					bridged: true,
 				});
 
-				ctx.policy.assert('test.capability');
+				ctx.policy.assert('test.capability', undefined);
 				expect(mockPolicy.assert).toHaveBeenCalledWith(
-					'test.capability'
+					'test.capability',
+					undefined
 				);
 
-				const result = ctx.policy.can('test.capability');
-				expect(mockPolicy.can).toHaveBeenCalledWith('test.capability');
+				const result = ctx.policy.can('test.capability', undefined);
+				expect(mockPolicy.can).toHaveBeenCalledWith(
+					'test.capability',
+					undefined
+				);
 				expect(result).toBe(true);
 			});
 
@@ -165,12 +169,12 @@ describe('Action Context', () => {
 					bridged: true,
 				});
 
-				expect(() => ctx.policy.assert('test.capability')).toThrow(
-					KernelError
-				);
-				expect(() => ctx.policy.assert('test.capability')).toThrow(
-					/attempted to assert capability/
-				);
+				expect(() =>
+					ctx.policy.assert('test.capability', undefined)
+				).toThrow(KernelError);
+				expect(() =>
+					ctx.policy.assert('test.capability', undefined)
+				).toThrow(/attempted to assert a policy/);
 			});
 
 			it('returns false and warns when can called without runtime policy', () => {
@@ -186,7 +190,7 @@ describe('Action Context', () => {
 					bridged: true,
 				});
 
-				const result1 = ctx.policy.can('test.capability');
+				const result1 = ctx.policy.can('test.capability', undefined);
 				expect(result1).toBe(false);
 				expect(consoleWarnSpy).toHaveBeenCalledWith(
 					expect.stringContaining('no policy runtime is configured')
@@ -194,7 +198,7 @@ describe('Action Context', () => {
 
 				// Second call should not warn again (warned = true)
 				consoleWarnSpy.mockClear();
-				const result2 = ctx.policy.can('test.capability');
+				const result2 = ctx.policy.can('test.capability', undefined);
 				expect(result2).toBe(false);
 				expect(consoleWarnSpy).not.toHaveBeenCalled();
 
@@ -215,7 +219,7 @@ describe('Action Context', () => {
 					bridged: true,
 				});
 
-				const result = ctx.policy.can('test.capability');
+				const result = ctx.policy.can('test.capability', undefined);
 				expect(result).toBe(false);
 				expect(consoleWarnSpy).not.toHaveBeenCalled();
 

--- a/packages/kernel/src/actions/__tests__/defineAction.test.ts
+++ b/packages/kernel/src/actions/__tests__/defineAction.test.ts
@@ -55,8 +55,8 @@ describe('defineAction', () => {
 				expect(args).toEqual({ title: 'Example' });
 				expect(ctx.requestId).toMatch(/^act_/);
 				expect(ctx.namespace).toBe('wpk');
-				expect(ctx.policy.can('things.manage')).toBe(true);
-				ctx.policy.assert('things.manage');
+				expect(ctx.policy.can('things.manage', undefined)).toBe(true);
+				ctx.policy.assert('things.manage', undefined);
 				await ctx.jobs.enqueue('IndexThing', { id: 1 });
 				await ctx.jobs.wait('IndexThing', { id: 1 });
 				ctx.reporter.info('creating thing');
@@ -93,7 +93,10 @@ describe('defineAction', () => {
 		expect(runtime.jobs?.wait).toHaveBeenCalledWith('IndexThing', {
 			id: 1,
 		});
-		expect(runtime.policy?.assert).toHaveBeenCalledWith('things.manage');
+		expect(runtime.policy?.assert).toHaveBeenCalledWith(
+			'things.manage',
+			undefined
+		);
 
 		invalidateSpy.mockRestore();
 	});

--- a/packages/kernel/src/actions/index.ts
+++ b/packages/kernel/src/actions/index.ts
@@ -21,6 +21,5 @@ export type {
 	ResolvedActionOptions,
 	Reporter,
 	ActionJobs,
-	ActionPolicy,
 	WaitOptions,
 } from './types';

--- a/packages/kernel/src/actions/types.ts
+++ b/packages/kernel/src/actions/types.ts
@@ -15,6 +15,7 @@
  */
 
 import type { CacheKeyPattern } from '../resource/cache';
+import type { PolicyHelpers } from '../policy/types';
 
 /**
  * Configuration options controlling action event propagation and bridging.
@@ -154,11 +155,6 @@ export interface ActionJobs {
  * }
  * ```
  */
-export interface ActionPolicy {
-	assert: (capability: string) => void;
-	can: (capability: string) => boolean;
-}
-
 /**
  * Base metadata shared across all action lifecycle events.
  *
@@ -296,7 +292,10 @@ export interface ActionContext {
 	/** Background job helpers. */
 	readonly jobs: ActionJobs;
 	/** Policy enforcement helpers. */
-	readonly policy: ActionPolicy;
+	readonly policy: Pick<
+		PolicyHelpers<Record<string, unknown>>,
+		'assert' | 'can'
+	>;
 	/** Structured logging surface. */
 	readonly reporter: Reporter;
 	/** Resolved namespace of the current action. */
@@ -407,7 +406,7 @@ export type ReduxMiddleware<TState = unknown> = (
 export interface ActionRuntime {
 	reporter?: Reporter;
 	jobs?: ActionJobs;
-	policy?: Partial<ActionPolicy>;
+	policy?: Partial<PolicyHelpers<Record<string, unknown>>>;
 	bridge?: {
 		emit: (
 			eventName: string,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -53,6 +53,7 @@ export * as resource from './resource/index.js';
 export * as error from './error/index.js';
 export * as namespace from './namespace/index.js';
 export * as actions from './actions/index.js';
+export * as policy from './policy/index.js';
 
 // ============================================================================
 // Flat Exports (Convenience aliases)
@@ -135,9 +136,24 @@ export type {
 	ResolvedActionOptions,
 	Reporter,
 	ActionJobs,
-	ActionPolicy,
 	WaitOptions,
 } from './actions/types';
+
+// Policy system
+export { definePolicy, createPolicyProxy, usePolicy } from './policy/index.js';
+export type {
+	PolicyRule,
+	PolicyMap,
+	PolicyHelpers,
+	PolicyOptions,
+	PolicyContext,
+	PolicyCache,
+	PolicyCacheOptions,
+	PolicyDeniedEvent,
+	PolicyReporter,
+	UsePolicyResult,
+	ParamsOf,
+} from './policy/index.js';
 
 // Namespace detection
 export {

--- a/packages/kernel/src/policy/__tests__/cache.test.ts
+++ b/packages/kernel/src/policy/__tests__/cache.test.ts
@@ -1,0 +1,304 @@
+import { createPolicyCache, createPolicyCacheKey } from '../cache';
+
+jest.mock('../../namespace/detect', () => ({
+	getNamespace: () => 'acme',
+}));
+
+type BroadcastMessage =
+	| {
+			type: 'set';
+			namespace: string;
+			key: string;
+			value: boolean;
+			expiresAt: number;
+	  }
+	| { type: 'invalidate'; namespace: string; policyKey?: string }
+	| { type: 'clear'; namespace: string };
+
+class MockBroadcastChannel {
+	public static instances: MockBroadcastChannel[] = [];
+
+	public messages: BroadcastMessage[] = [];
+
+	public onmessage: ((event: MessageEvent<BroadcastMessage>) => void) | null =
+		null;
+
+	public constructor(public readonly name: string) {
+		MockBroadcastChannel.instances.push(this);
+	}
+
+	public postMessage(message: BroadcastMessage) {
+		this.messages.push(message);
+	}
+
+	public close() {
+		// noop for tests
+	}
+}
+
+describe('createPolicyCache', () => {
+	const storageKey = 'wpk.policy.cache.acme';
+	const originalBroadcastChannel = global.window.BroadcastChannel;
+	const originalSessionStorage = global.window.sessionStorage;
+
+	beforeEach(() => {
+		jest.restoreAllMocks();
+		MockBroadcastChannel.instances = [];
+		window.sessionStorage.clear();
+		Object.defineProperty(window, 'BroadcastChannel', {
+			configurable: true,
+			value: MockBroadcastChannel,
+		});
+	});
+
+	afterEach(() => {
+		Object.defineProperty(window, 'BroadcastChannel', {
+			configurable: true,
+			value: originalBroadcastChannel,
+		});
+		Object.defineProperty(window, 'sessionStorage', {
+			configurable: true,
+			value: originalSessionStorage,
+		});
+	});
+
+	it('creates stable cache keys for complex params', () => {
+		const key = createPolicyCacheKey('policy', {
+			beta: 2,
+			alpha: [{ nested: true }, 3],
+			nullable: null,
+		});
+
+		expect(key).toBe(
+			'policy::{"alpha":[{"nested":true},3],"beta":2,"nullable":null}'
+		);
+	});
+
+	it('hydrates persisted session storage entries', () => {
+		const expiresAt = Date.now() + 1000;
+		window.sessionStorage.setItem(
+			storageKey,
+			JSON.stringify({
+				'policy::void': { value: true, expiresAt },
+			})
+		);
+
+		const cache = createPolicyCache({ storage: 'session' }, 'acme');
+		expect(cache.get('policy::void')).toBe(true);
+		expect(cache.keys()).toEqual(['policy::void']);
+	});
+
+	it('guards against invalid persisted data', () => {
+		const warn = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+		window.sessionStorage.setItem(storageKey, '{invalid json');
+
+		const cache = createPolicyCache({ storage: 'session' }, 'acme');
+		expect(cache.keys()).toEqual([]);
+		expect(warn).toHaveBeenCalledWith(
+			'[wp-kernel] Failed to parse persisted policy cache.',
+			expect.any(SyntaxError)
+		);
+	});
+
+	it('persists values and surfaces storage errors', () => {
+		const store = new Map<string, string>();
+		const setItem = jest.fn((key: string, value: string) => {
+			store.set(key, value);
+		});
+		const getItem = jest.fn(() => null);
+		const customStorage = { getItem, setItem } as unknown as Storage;
+		Object.defineProperty(window, 'sessionStorage', {
+			configurable: true,
+			value: customStorage,
+		});
+
+		const cache = createPolicyCache({ storage: 'session' }, 'acme');
+		cache.set('policy::void', true);
+		expect(setItem).toHaveBeenCalledTimes(1);
+		const persisted = JSON.parse(store.get(storageKey) ?? '{}');
+		expect(persisted['policy::void'].value).toBe(true);
+
+		const error = new Error('persist failed');
+		setItem.mockImplementationOnce(() => {
+			throw error;
+		});
+		const warn = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+		cache.set('policy::void', false);
+		expect(warn).toHaveBeenCalledWith(
+			'[wp-kernel] Failed to persist policy cache.',
+			error
+		);
+	});
+
+	it('handles session storage access failures gracefully', () => {
+		const warn = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+		Object.defineProperty(window, 'sessionStorage', {
+			configurable: true,
+			get() {
+				throw new Error('blocked');
+			},
+		});
+
+		const cache = createPolicyCache({ storage: 'session' }, 'acme');
+		expect(cache.keys()).toEqual([]);
+		expect(warn).toHaveBeenCalledWith(
+			'[wp-kernel] sessionStorage is not available for policy cache.',
+			expect.any(Error)
+		);
+	});
+
+	it('evicts expired entries based on ttl', () => {
+		jest.useFakeTimers();
+		jest.setSystemTime(0);
+		const cache = createPolicyCache({}, 'acme');
+		cache.set('policy::void', true, { ttlMs: 50 });
+		expect(cache.get('policy::void')).toBe(true);
+		jest.advanceTimersByTime(51);
+		expect(cache.get('policy::void')).toBeUndefined();
+		expect(cache.keys()).toEqual([]);
+		jest.useRealTimers();
+	});
+
+	it('broadcasts local mutations and handles remote updates', () => {
+		const cache = createPolicyCache({}, 'acme');
+		const channel = MockBroadcastChannel.instances[0]!;
+		const listener = jest.fn();
+		const unsubscribe = cache.subscribe(listener);
+
+		cache.set('policy::void', true);
+		expect(channel.messages[0]).toMatchObject({
+			type: 'set',
+			namespace: 'acme',
+			key: 'policy::void',
+			value: true,
+		});
+		expect(cache.getSnapshot()).toBe(1);
+
+		channel.onmessage?.({
+			data: {
+				type: 'set',
+				namespace: 'acme',
+				key: 'policy::user',
+				value: false,
+				expiresAt: Date.now() + 1000,
+			},
+		} as MessageEvent<BroadcastMessage>);
+		expect(cache.get('policy::user')).toBe(false);
+		expect(listener).toHaveBeenCalled();
+
+		channel.onmessage?.({
+			data: {
+				type: 'invalidate',
+				namespace: 'acme',
+				policyKey: 'policy',
+			},
+		} as MessageEvent<BroadcastMessage>);
+		expect(cache.keys()).toEqual([]);
+
+		cache.set('policy::void', true);
+		channel.onmessage?.({
+			data: { type: 'clear', namespace: 'acme' },
+		} as MessageEvent<BroadcastMessage>);
+		expect(cache.keys()).toEqual([]);
+
+		channel.onmessage?.({
+			data: {
+				type: 'invalidate',
+				namespace: 'other',
+				policyKey: 'policy',
+			},
+		} as MessageEvent<BroadcastMessage>);
+		expect(cache.keys()).toEqual([]);
+
+		unsubscribe();
+	});
+
+	it('supports remote writes without re-broadcasting', () => {
+		const cache = createPolicyCache({}, 'acme');
+		const channel = MockBroadcastChannel.instances[0]!;
+		cache.set('policy::void', true, {
+			source: 'remote',
+			expiresAt: Date.now() + 10,
+		});
+		expect(channel.messages).toHaveLength(0);
+	});
+
+	it('invalidates namespaces and specific policies', () => {
+		const cache = createPolicyCache({}, 'acme');
+		const channel = MockBroadcastChannel.instances[0]!;
+		cache.set('foo::void', true);
+		cache.set('bar::void', true);
+		cache.invalidate('foo');
+		expect(cache.keys()).toEqual(['bar::void']);
+		expect(channel.messages).toContainEqual({
+			type: 'invalidate',
+			namespace: 'acme',
+			policyKey: 'foo',
+		});
+
+		cache.invalidate();
+		expect(cache.keys()).toEqual([]);
+		expect(channel.messages).toContainEqual({
+			type: 'clear',
+			namespace: 'acme',
+		});
+		const previous = channel.messages.length;
+		cache.invalidate('missing');
+		expect(channel.messages).toHaveLength(previous);
+	});
+
+	it('skips broadcast channel creation when disabled and logs failures', () => {
+		Object.defineProperty(window, 'BroadcastChannel', {
+			configurable: true,
+			value: undefined,
+		});
+		const cacheWithoutChannel = createPolicyCache(
+			{ crossTab: false },
+			'acme'
+		);
+		cacheWithoutChannel.set('policy::void', true);
+
+		Object.defineProperty(window, 'BroadcastChannel', {
+			configurable: true,
+			value: jest.fn(() => {
+				throw new Error('channel fail');
+			}),
+		});
+		const warn = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+		const cache = createPolicyCache({}, 'acme');
+		expect(warn).toHaveBeenCalledWith(
+			'[wp-kernel] Failed to create BroadcastChannel for policy cache.',
+			expect.any(Error)
+		);
+		cache.set('policy::void', true);
+	});
+
+	it('clears cache without listeners and respects remote expiry overrides', () => {
+		const cache = createPolicyCache({}, 'acme');
+		const channel = MockBroadcastChannel.instances[0]!;
+		expect(cache.get('missing')).toBeUndefined();
+		cache.set('policy::void', true, {
+			expiresAt: Date.now() + 500,
+			source: 'remote',
+		});
+		cache.clear();
+		expect(channel.messages).toContainEqual({
+			type: 'clear',
+			namespace: 'acme',
+		});
+	});
+
+	it('ignores persisted structures that are not plain objects', () => {
+		window.sessionStorage.setItem(storageKey, '"text"');
+		const cache = createPolicyCache({ storage: 'session' }, 'acme');
+		expect(cache.keys()).toEqual([]);
+	});
+});

--- a/packages/kernel/src/policy/__tests__/context.test.ts
+++ b/packages/kernel/src/policy/__tests__/context.test.ts
@@ -1,0 +1,194 @@
+import {
+	createPolicyProxy,
+	getPolicyRequestContext,
+	getPolicyRuntime,
+	withPolicyRequestContext,
+} from '../context';
+import { KernelError } from '../../error/KernelError';
+import type { ActionRuntime } from '../../actions/types';
+
+describe('policy context', () => {
+	const baseOptions = {
+		actionName: 'Task.Update',
+		requestId: 'req-1',
+		namespace: 'acme',
+		scope: 'crossTab' as const,
+		bridged: false,
+	};
+
+	const createProxy = () =>
+		createPolicyProxy(baseOptions) as {
+			assert: (key: string, value?: unknown) => void | Promise<void>;
+			can: (key: string, value?: unknown) => boolean | Promise<boolean>;
+		};
+
+	afterEach(() => {
+		delete global.__WP_KERNEL_ACTION_RUNTIME__;
+		jest.restoreAllMocks();
+	});
+
+	it('tracks request context across synchronous execution', () => {
+		const result = withPolicyRequestContext(baseOptions, () => {
+			expect(getPolicyRequestContext()).toEqual(baseOptions);
+			return 'done';
+		});
+
+		expect(result).toBe('done');
+		expect(getPolicyRequestContext()).toBeUndefined();
+	});
+
+	it('restores request context when synchronous execution throws', () => {
+		expect(() =>
+			withPolicyRequestContext(baseOptions, () => {
+				expect(getPolicyRequestContext()).toEqual(baseOptions);
+				throw new Error('boom');
+			})
+		).toThrow('boom');
+		expect(getPolicyRequestContext()).toBeUndefined();
+	});
+
+	it('restores request context after async resolution and rejection', async () => {
+		await withPolicyRequestContext(baseOptions, async () => {
+			expect(getPolicyRequestContext()).toEqual(baseOptions);
+		});
+		expect(getPolicyRequestContext()).toBeUndefined();
+
+		await expect(
+			withPolicyRequestContext(baseOptions, async () => {
+				throw new Error('fail');
+			})
+		).rejects.toThrow('fail');
+		expect(getPolicyRequestContext()).toBeUndefined();
+	});
+
+	it('returns configured policy runtime', () => {
+		const runtime: ActionRuntime = { policy: { can: jest.fn() } };
+		global.__WP_KERNEL_ACTION_RUNTIME__ = runtime;
+		expect(getPolicyRuntime()).toBe(runtime);
+	});
+
+	it('throws when no runtime policy is configured for assert', () => {
+		delete global.__WP_KERNEL_ACTION_RUNTIME__;
+		const proxy = createProxy();
+		expect(() => proxy.assert('tasks.manage', undefined)).toThrow(
+			KernelError
+		);
+	});
+
+	it('forwards assertions to runtime and exposes request context', () => {
+		const assert = jest.fn(() => {
+			expect(getPolicyRequestContext()).toEqual(baseOptions);
+		});
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: { assert },
+		} as ActionRuntime;
+		const proxy = createProxy();
+		proxy.assert('tasks.manage', { id: 1 });
+		expect(assert).toHaveBeenCalledWith('tasks.manage', { id: 1 });
+	});
+
+	it('passes undefined to runtime assert when no params are supplied', () => {
+		const assert = jest.fn();
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: { assert },
+		} as ActionRuntime;
+		const proxy = createProxy();
+		proxy.assert('tasks.manage');
+		expect(assert).toHaveBeenCalledWith('tasks.manage', undefined);
+	});
+
+	it('falls back to can() when assert is unavailable', () => {
+		const can = jest.fn().mockReturnValue(false);
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: { can },
+		} as ActionRuntime;
+		const proxy = createProxy();
+
+		expect(() => proxy.assert('tasks.manage')).toThrow(KernelError);
+		expect(() => proxy.assert('tasks.manage', undefined)).toThrow(
+			KernelError
+		);
+		expect(can).toHaveBeenCalledTimes(2);
+	});
+
+	it('rejects when fallback can() resolves to false asynchronously', async () => {
+		const can = jest.fn().mockResolvedValue(false);
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: { can },
+		} as ActionRuntime;
+		const proxy = createProxy();
+
+		await expect(proxy.assert('tasks.manage')).rejects.toThrow(KernelError);
+		expect(can).toHaveBeenCalledWith('tasks.manage');
+	});
+
+	it('resolves when fallback can() returns true', () => {
+		const can = jest.fn().mockReturnValue(true);
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: { can },
+		} as ActionRuntime;
+		const proxy = createProxy();
+		expect(() => proxy.assert('tasks.manage')).not.toThrow();
+	});
+
+	it('resolves when fallback can() resolves to true asynchronously', async () => {
+		const can = jest.fn().mockResolvedValue(true);
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: { can },
+		} as ActionRuntime;
+		const proxy = createProxy();
+		await expect(proxy.assert('tasks.manage')).resolves.toBeUndefined();
+	});
+
+	it('throws developer error when runtime lacks assertion surface', () => {
+		global.__WP_KERNEL_ACTION_RUNTIME__ = { policy: {} } as ActionRuntime;
+		const proxy = createProxy();
+		expect(() => proxy.assert('tasks.manage', undefined)).toThrow(
+			'does not expose assert()'
+		);
+	});
+
+	it('warns once when calling can() without runtime', () => {
+		const warn = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+		delete global.__WP_KERNEL_ACTION_RUNTIME__;
+		const proxy = createProxy();
+		expect(proxy.can('tasks.manage')).toBe(false);
+		expect(proxy.can('tasks.manage')).toBe(false);
+		expect(warn).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips warnings in production when runtime is missing', () => {
+		const originalEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'production';
+		const warn = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+		delete global.__WP_KERNEL_ACTION_RUNTIME__;
+		const proxy = createProxy();
+		expect(proxy.can('tasks.manage')).toBe(false);
+		expect(warn).not.toHaveBeenCalled();
+		process.env.NODE_ENV = originalEnv;
+	});
+
+	it('delegates can() calls with parameters to the runtime', () => {
+		const can = jest.fn((_: string, value?: unknown) => value === true);
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: { can },
+		} as ActionRuntime;
+		const proxy = createProxy();
+		expect(proxy.can('tasks.manage', true)).toBe(true);
+		expect(can).toHaveBeenCalledWith('tasks.manage', true);
+	});
+
+	it('delegates can() calls without parameters to the runtime', () => {
+		const can = jest.fn(() => true);
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: { can },
+		} as ActionRuntime;
+		const proxy = createProxy();
+		expect(proxy.can('tasks.manage')).toBe(true);
+		expect(can).toHaveBeenCalledWith('tasks.manage');
+	});
+});

--- a/packages/kernel/src/policy/__tests__/define.behavior.test.ts
+++ b/packages/kernel/src/policy/__tests__/define.behavior.test.ts
@@ -1,0 +1,286 @@
+import { type KernelError } from '../../error/KernelError';
+import { withPolicyRequestContext } from '../context';
+import type { ActionRuntime } from '../../actions/types';
+import type { definePolicy as definePolicyFn } from '../define';
+
+type DefinePolicy = typeof definePolicyFn;
+
+async function loadDefinePolicy(): Promise<DefinePolicy> {
+	jest.resetModules();
+	const module = await import('../define');
+	return module.definePolicy;
+}
+
+describe('definePolicy behaviour', () => {
+	const originalBroadcastChannel = window.BroadcastChannel;
+
+	beforeEach(() => {
+		delete global.__WP_KERNEL_ACTION_RUNTIME__;
+		Object.defineProperty(window, 'BroadcastChannel', {
+			configurable: true,
+			value: originalBroadcastChannel,
+		});
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	afterAll(() => {
+		Object.defineProperty(window, 'BroadcastChannel', {
+			configurable: true,
+			value: originalBroadcastChannel,
+		});
+	});
+
+	it('uses WordPress canUser fallback when adapters are not provided', async () => {
+		const canUser = jest.fn(() => true);
+		const select = window.wp?.data?.select as jest.Mock | undefined;
+		expect(select).toBeDefined();
+		select!.mockImplementation(() => ({ canUser }));
+
+		const definePolicy = await loadDefinePolicy();
+		const policy = definePolicy<{ 'content.read': { path: string } }>({
+			'content.read': (context, resource) =>
+				context.adapters.wp?.canUser?.('read', resource) ?? false,
+		});
+
+		const outcome = policy.can('content.read', { path: '/api' });
+		if (outcome instanceof Promise) {
+			await expect(outcome).resolves.toBe(true);
+		} else {
+			expect(outcome).toBe(true);
+		}
+		expect(select).toHaveBeenCalledWith('core');
+		expect(canUser).toHaveBeenCalledWith('read', { path: '/api' });
+		select!.mockReset();
+	});
+
+	it('warns when WordPress canUser invocation fails', async () => {
+		const warn = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+		const select = window.wp?.data?.select as jest.Mock | undefined;
+		expect(select).toBeDefined();
+		select!.mockImplementation(() => {
+			throw new Error('select failed');
+		});
+
+		const definePolicy = await loadDefinePolicy();
+		const policy = definePolicy<{ 'content.read': { path: string } }>(
+			{
+				'content.read': (context, resource) =>
+					context.adapters.wp?.canUser?.('read', resource) ?? false,
+			},
+			{ debug: true }
+		);
+
+		const outcome = policy.can('content.read', { path: '/api' });
+		if (outcome instanceof Promise) {
+			await expect(outcome).resolves.toBe(false);
+		} else {
+			expect(outcome).toBe(false);
+		}
+		expect(warn).toHaveBeenCalledWith(
+			'[wp-kernel][policy] Failed to invoke wp.data.select("core").canUser',
+			expect.objectContaining({ error: expect.any(Error) })
+		);
+		select!.mockReset();
+	});
+
+	it('falls back to false when WordPress canUser is unavailable', async () => {
+		const select = window.wp?.data?.select as jest.Mock | undefined;
+		expect(select).toBeDefined();
+
+		select!.mockImplementation(() => ({}));
+		try {
+			const definePolicy = await loadDefinePolicy();
+			const policy = definePolicy<{ 'content.read': { path: string } }>({
+				'content.read': (context, resource) =>
+					context.adapters.wp?.canUser?.('read', resource) ?? false,
+			});
+
+			const outcome = policy.can('content.read', { path: '/api' });
+			if (outcome instanceof Promise) {
+				await expect(outcome).resolves.toBe(false);
+				return;
+			}
+			expect(outcome).toBe(false);
+		} finally {
+			select!.mockReset();
+		}
+	});
+
+	it('enforces boolean return values from rules', async () => {
+		const definePolicy = await loadDefinePolicy();
+		const policy = definePolicy<{ 'content.read': void }>({
+			'content.read': () => 'yes' as unknown as boolean,
+		});
+
+		expect(() => policy.can('content.read')).toThrow(
+			'Policy "content.read" must return a boolean. Received string.'
+		);
+	});
+
+	it('emits denial events for async assertions', async () => {
+		const doAction = window.wp?.hooks?.doAction as jest.Mock | undefined;
+		expect(doAction).toBeDefined();
+
+		class CapturingChannel {
+			public static instance: CapturingChannel | undefined;
+			public messages: unknown[] = [];
+			public onmessage: ((event: MessageEvent) => void) | null = null;
+
+			public constructor(public name: string) {
+				CapturingChannel.instance = this;
+			}
+
+			public postMessage(message: unknown) {
+				this.messages.push(message);
+			}
+
+			public close() {}
+		}
+
+		Object.defineProperty(window, 'BroadcastChannel', {
+			configurable: true,
+			value: CapturingChannel,
+		});
+
+		const definePolicy = await loadDefinePolicy();
+		const policy = definePolicy<{ 'content.delete': void }>({
+			'content.delete': async () => false,
+		});
+
+		await expect(policy.assert('content.delete')).rejects.toMatchObject({
+			code: 'PolicyDenied',
+		});
+		expect(doAction).toHaveBeenCalledWith(
+			'wpk.policy.denied',
+			expect.objectContaining({ policyKey: 'content.delete' })
+		);
+		expect(CapturingChannel.instance?.messages[0]).toEqual(
+			expect.objectContaining({
+				type: 'policy.denied',
+				namespace: 'wpk',
+			})
+		);
+	});
+
+	it('skips WordPress hook emission when hooks are unavailable', async () => {
+		const hooks = window.wp?.hooks as { doAction?: jest.Mock } | undefined;
+		const originalDoAction = hooks?.doAction;
+		if (hooks) {
+			delete hooks.doAction;
+		}
+
+		try {
+			const definePolicy = await loadDefinePolicy();
+			const policy = definePolicy<{ deny: void }>({ deny: () => false });
+
+			try {
+				policy.assert('deny');
+				throw new Error('expected policy assertion to throw');
+			} catch (error) {
+				expect((error as { code?: string }).code).toBe('PolicyDenied');
+			}
+		} finally {
+			if (hooks) {
+				hooks.doAction =
+					originalDoAction ?? (jest.fn() as unknown as jest.Mock);
+			}
+		}
+	});
+
+	it('registers helpers on existing action runtime', async () => {
+		const runtime: ActionRuntime = { policy: {} };
+		global.__WP_KERNEL_ACTION_RUNTIME__ = runtime;
+
+		const definePolicy = await loadDefinePolicy();
+		const policy = definePolicy<{ 'content.read': void }>({
+			'content.read': () => true,
+		});
+
+		expect(global.__WP_KERNEL_ACTION_RUNTIME__).toBe(runtime);
+		expect(global.__WP_KERNEL_ACTION_RUNTIME__?.policy?.can).toBeDefined();
+		const outcome = policy.can('content.read');
+		if (outcome instanceof Promise) {
+			await expect(outcome).resolves.toBe(true);
+		} else {
+			expect(outcome).toBe(true);
+		}
+	});
+
+	it('builds denial context with request data and params', async () => {
+		expect.assertions(2);
+		const definePolicy = await loadDefinePolicy();
+		const policy = definePolicy<{ 'content.update': { reason: string } }>(
+			{
+				'content.update': () => false,
+			},
+			{ namespace: 'acme' }
+		);
+
+		try {
+			withPolicyRequestContext(
+				{
+					actionName: 'Action.Update',
+					requestId: 'req-123',
+					namespace: 'acme',
+					scope: 'crossTab',
+					bridged: false,
+				},
+				() => policy.assert('content.update', { reason: 'missing' })
+			);
+		} catch (error) {
+			const err = error as KernelError & { messageKey?: string };
+			expect(err.messageKey).toBe('policy.denied.acme.content.update');
+			expect(err.context).toEqual(
+				expect.objectContaining({
+					policyKey: 'content.update',
+					reason: 'missing',
+				})
+			);
+		}
+	});
+
+	it('logs BroadcastChannel creation failures', async () => {
+		const warn = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+		Object.defineProperty(window, 'BroadcastChannel', {
+			configurable: true,
+			value: jest.fn(() => {
+				throw new Error('channel failed');
+			}),
+		});
+
+		const definePolicy = await loadDefinePolicy();
+		const policy = definePolicy<{ deny: void }>({ deny: () => false });
+
+		try {
+			policy.assert('deny');
+			throw new Error('expected policy assertion to throw');
+		} catch (error) {
+			expect((error as { code?: string }).code).toBe('PolicyDenied');
+		}
+		expect(warn).toHaveBeenCalledWith(
+			'[wp-kernel] Failed to create BroadcastChannel for policy events.',
+			expect.any(Error)
+		);
+	});
+
+	it('warns when extending an existing policy key', async () => {
+		const warn = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+
+		const definePolicy = await loadDefinePolicy();
+		const policy = definePolicy<{ allow: void }>({ allow: () => true });
+
+		policy.extend({ allow: () => false });
+		expect(warn).toHaveBeenCalledWith(
+			'Policy "allow" is being overridden via extend().'
+		);
+	});
+});

--- a/packages/kernel/src/policy/__tests__/define.environment.test.ts
+++ b/packages/kernel/src/policy/__tests__/define.environment.test.ts
@@ -1,0 +1,407 @@
+import '@wordpress/jest-console';
+import type * as PolicyModule from '../define';
+import type * as WPData from '@wordpress/data';
+import type * as WPHooks from '@wordpress/hooks';
+import type { KernelError } from '../../error/KernelError';
+import type { PolicyContext } from '../types';
+
+type PolicyModuleType = typeof PolicyModule;
+
+function loadPolicyModule(): PolicyModuleType {
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	return require('../define') as PolicyModuleType;
+}
+
+function setWindowProp(key: string, value: unknown): void {
+	Reflect.set(window as unknown as Record<string, unknown>, key, value);
+}
+
+function deleteWindowProp(key: string): void {
+	Reflect.deleteProperty(window as unknown as Record<string, unknown>, key);
+}
+
+describe('policy environment edge cases', () => {
+	const originalBroadcast = global.BroadcastChannel;
+	const originalWp = (window as typeof window & { wp?: unknown }).wp;
+
+	beforeEach(() => {
+		jest.resetModules();
+	});
+
+	afterEach(() => {
+		if (originalBroadcast) {
+			global.BroadcastChannel = originalBroadcast;
+		} else {
+			delete (
+				globalThis as { BroadcastChannel?: typeof BroadcastChannel }
+			).BroadcastChannel;
+		}
+
+		if (originalWp === undefined) {
+			deleteWindowProp('wp');
+		} else {
+			setWindowProp('wp', originalWp);
+		}
+
+		delete (globalThis as { __WP_KERNEL_ACTION_RUNTIME__?: unknown })
+			.__WP_KERNEL_ACTION_RUNTIME__;
+	});
+
+	it('falls back when BroadcastChannel construction fails', () => {
+		const broadcastError = new Error('channel-unavailable');
+		const broadcastSpy = jest.fn(() => {
+			throw broadcastError;
+		});
+		const warnSpy = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+
+		(
+			globalThis as { BroadcastChannel?: typeof BroadcastChannel }
+		).BroadcastChannel = broadcastSpy as unknown as typeof BroadcastChannel;
+
+		jest.isolateModules(() => {
+			deleteWindowProp('wp');
+			const { definePolicy } = loadPolicyModule();
+
+			const policy = definePolicy<{ 'tasks.manage': void }>({
+				'tasks.manage': () => false,
+			});
+
+			expect(() => policy.assert('tasks.manage')).toThrow(
+				'Policy "tasks.manage" denied.'
+			);
+		});
+
+		expect(broadcastSpy).toHaveBeenCalled();
+		expect(warnSpy).toHaveBeenCalledWith(
+			'[wp-kernel] Failed to create BroadcastChannel for policy cache.',
+			broadcastError
+		);
+		expect(warnSpy).toHaveBeenCalledWith(
+			'[wp-kernel] Failed to create BroadcastChannel for policy events.',
+			broadcastError
+		);
+		warnSpy.mockRestore();
+	});
+
+	it('logs WordPress adapter failures when canUser throws', () => {
+		const warnSpy = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+
+		jest.isolateModules(() => {
+			const failure = new Error('wp-failed');
+			const select = jest.fn(() => ({
+				canUser: jest.fn(() => {
+					throw failure;
+				}),
+			}));
+
+			setWindowProp('wp', {
+				data: {
+					select,
+				},
+			});
+
+			const { definePolicy } = loadPolicyModule();
+
+			const policy = definePolicy<{ 'tasks.wp': void }>(
+				{
+					'tasks.wp': ({ adapters }: PolicyContext) => {
+						const allowed = adapters.wp?.canUser?.('read', {
+							path: '/wp-json/acme',
+						});
+						expect(allowed).toBe(false);
+						return false;
+					},
+				},
+				{
+					namespace: 'acme',
+					debug: true,
+				}
+			);
+
+			expect(() => policy.assert('tasks.wp')).toThrow(
+				'Policy "tasks.wp" denied.'
+			);
+
+			const store = select.mock.results[0]?.value as
+				| { canUser?: jest.Mock }
+				| undefined;
+			expect(store?.canUser).toHaveBeenCalledWith('read', {
+				path: '/wp-json/acme',
+			});
+
+			expect(warnSpy).toHaveBeenCalledWith(
+				'[wp-kernel][policy] Failed to invoke wp.data.select("core").canUser',
+				{
+					error: failure,
+				}
+			);
+		});
+		warnSpy.mockRestore();
+	});
+
+	it('raises a developer error when policy rules return non-boolean values', () => {
+		jest.isolateModules(() => {
+			const { definePolicy } = loadPolicyModule();
+			const policy = definePolicy<{ 'tasks.invalid': void }>({
+				'tasks.invalid': () => 'nope' as unknown as boolean,
+			});
+
+			expect(() => policy.can('tasks.invalid')).toThrow(
+				'Policy "tasks.invalid" must return a boolean. Received string.'
+			);
+		});
+	});
+
+	it('ignores extended rules that are not functions', () => {
+		jest.isolateModules(() => {
+			const { definePolicy } = loadPolicyModule();
+			const policy = definePolicy<{ 'tasks.manage': void }>({
+				'tasks.manage': () => true,
+			});
+
+			policy.extend({
+				// @ts-expect-error - coverage: non-function entries should be ignored
+				'tasks.manage': null,
+			});
+
+			expect(policy.can('tasks.manage')).toBe(true);
+		});
+	});
+
+	it('includes scalar and object params in denial context', () => {
+		jest.isolateModules(() => {
+			const { definePolicy } = loadPolicyModule();
+
+			const policy = definePolicy<{
+				'tasks.scalar': string;
+				'tasks.object': { reason: string };
+			}>(
+				{
+					'tasks.scalar': () => false,
+					'tasks.object': () => false,
+				},
+				{ namespace: 'acme' }
+			);
+
+			try {
+				policy.assert('tasks.scalar', 'blocked');
+			} catch (error) {
+				const denied = error as KernelError & { messageKey?: string };
+				expect(denied.code).toBe('PolicyDenied');
+				expect(denied.messageKey).toBe(
+					'policy.denied.acme.tasks.scalar'
+				);
+				expect(denied.context).toEqual(
+					expect.objectContaining({
+						policyKey: 'tasks.scalar',
+						value: 'blocked',
+					})
+				);
+			}
+
+			try {
+				policy.assert('tasks.object', { reason: 'blocked' });
+			} catch (error) {
+				const denied = error as KernelError;
+				expect(denied.context).toEqual(
+					expect.objectContaining({
+						policyKey: 'tasks.object',
+						reason: 'blocked',
+					})
+				);
+			}
+		});
+	});
+
+	it('uses no-op reporter methods when debug is disabled', () => {
+		const infoSpy = jest
+			.spyOn(console, 'info')
+			.mockImplementation(() => undefined);
+		const warnSpy = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+		const errorSpy = jest
+			.spyOn(console, 'error')
+			.mockImplementation(() => undefined);
+		const debugSpy = jest
+			.spyOn(console, 'debug')
+			.mockImplementation(() => undefined);
+
+		jest.isolateModules(() => {
+			const { definePolicy } = loadPolicyModule();
+
+			const policy = definePolicy<{ 'tasks.reporter': void }>({
+				'tasks.reporter': ({ reporter }: PolicyContext) => {
+					reporter?.info('info');
+					reporter?.warn('warn');
+					reporter?.error('error');
+					reporter?.debug?.('debug');
+					return true;
+				},
+			});
+
+			expect(policy.can('tasks.reporter')).toBe(true);
+		});
+
+		expect(infoSpy).not.toHaveBeenCalled();
+		expect(warnSpy).not.toHaveBeenCalled();
+		expect(errorSpy).not.toHaveBeenCalled();
+		expect(debugSpy).not.toHaveBeenCalled();
+		infoSpy.mockRestore();
+		warnSpy.mockRestore();
+		errorSpy.mockRestore();
+		debugSpy.mockRestore();
+	});
+
+	it('emits reporter output when debug mode is enabled', () => {
+		const infoSpy = jest
+			.spyOn(console, 'info')
+			.mockImplementation(() => undefined);
+		const warnSpy = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+		const errorSpy = jest
+			.spyOn(console, 'error')
+			.mockImplementation(() => undefined);
+		const debugSpy = jest
+			.spyOn(console, 'debug')
+			.mockImplementation(() => undefined);
+
+		jest.isolateModules(() => {
+			const { definePolicy } = loadPolicyModule();
+
+			const policy = definePolicy<{ 'tasks.reporter': void }>(
+				{
+					'tasks.reporter': ({ reporter }: PolicyContext) => {
+						reporter?.info('inform', { id: 1 });
+						reporter?.warn('warn', { id: 2 });
+						reporter?.error('error', { id: 3 });
+						reporter?.debug?.('debug', { id: 4 });
+						return true;
+					},
+				},
+				{ debug: true }
+			);
+
+			expect(policy.can('tasks.reporter')).toBe(true);
+		});
+
+		expect(infoSpy).toHaveBeenCalledWith('[wp-kernel][policy] inform', {
+			id: 1,
+		});
+		expect(warnSpy).toHaveBeenCalledWith('[wp-kernel][policy] warn', {
+			id: 2,
+		});
+		expect(errorSpy).toHaveBeenCalledWith('[wp-kernel][policy] error', {
+			id: 3,
+		});
+		expect(debugSpy).toHaveBeenCalledWith('[wp-kernel][policy] debug', {
+			id: 4,
+		});
+		infoSpy.mockRestore();
+		warnSpy.mockRestore();
+		errorSpy.mockRestore();
+		debugSpy.mockRestore();
+	});
+
+	it('omits wp adapter when data.select is unavailable', () => {
+		jest.isolateModules(() => {
+			setWindowProp('wp', {
+				data: {} as unknown as typeof WPData,
+			});
+
+			const { definePolicy } = loadPolicyModule();
+
+			const policy = definePolicy<{ 'tasks.wp': void }>({
+				'tasks.wp': ({ adapters }: PolicyContext) => {
+					expect(adapters.wp).toBeUndefined();
+					return true;
+				},
+			});
+
+			expect(policy.can('tasks.wp')).toBe(true);
+		});
+	});
+
+	it('returns false when wp store lacks canUser', () => {
+		jest.isolateModules(() => {
+			const select = jest.fn(() => ({}));
+
+			setWindowProp('wp', {
+				data: {
+					select,
+				} as unknown as typeof WPData,
+			});
+
+			const { definePolicy } = loadPolicyModule();
+
+			const policy = definePolicy<{ 'tasks.wp': void }>({
+				'tasks.wp': ({ adapters }: PolicyContext) => {
+					const allowed = adapters.wp?.canUser?.('read', {
+						path: '/wp-json',
+					});
+					expect(allowed).toBe(false);
+					return true;
+				},
+			});
+
+			expect(policy.can('tasks.wp')).toBe(true);
+			expect(select).toHaveBeenCalledWith('core');
+		});
+	});
+
+	it('ignores WordPress hooks when doAction is unavailable', () => {
+		jest.isolateModules(() => {
+			setWindowProp('wp', {
+				hooks: {} as unknown as typeof WPHooks,
+			});
+
+			const { definePolicy } = loadPolicyModule();
+			const policy = definePolicy<{ 'tasks.deny': void }>({
+				'tasks.deny': () => false,
+			});
+
+			expect(() => policy.assert('tasks.deny')).toThrow(
+				'Policy "tasks.deny" denied.'
+			);
+		});
+	});
+
+	it('skips BroadcastChannel setup when unsupported', () => {
+		const warnSpy = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+
+		jest.isolateModules(() => {
+			const testWindow = window as typeof window & {
+				BroadcastChannel?: typeof BroadcastChannel;
+			};
+			const broadcastChannelBackup = testWindow.BroadcastChannel;
+			Reflect.deleteProperty(testWindow, 'BroadcastChannel');
+
+			try {
+				const { definePolicy } = loadPolicyModule();
+				const policy = definePolicy<{ 'tasks.deny': void }>({
+					'tasks.deny': () => false,
+				});
+
+				expect(() => policy.assert('tasks.deny')).toThrow(
+					'Policy "tasks.deny" denied.'
+				);
+			} finally {
+				if (broadcastChannelBackup) {
+					testWindow.BroadcastChannel = broadcastChannelBackup;
+				} else {
+					Reflect.deleteProperty(testWindow, 'BroadcastChannel');
+				}
+			}
+		});
+
+		expect(warnSpy).not.toHaveBeenCalled();
+		warnSpy.mockRestore();
+	});
+});

--- a/packages/kernel/src/policy/__tests__/define.test.ts
+++ b/packages/kernel/src/policy/__tests__/define.test.ts
@@ -1,0 +1,273 @@
+import { createRoot } from 'react-dom/client';
+import React, { act, useEffect, useRef } from 'react';
+import { definePolicy } from '../define';
+import { usePolicy } from '../hooks';
+import { createPolicyProxy } from '../context';
+import type { PolicyHelpers, PolicyRule, UsePolicyResult } from '../types';
+import { KernelError } from '../../error/KernelError';
+
+describe('policy module', () => {
+	beforeAll(() => {
+		(
+			globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+		).IS_REACT_ACT_ENVIRONMENT = true;
+	});
+
+	afterAll(() => {
+		delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+			.IS_REACT_ACT_ENVIRONMENT;
+	});
+
+	beforeEach(() => {
+		delete (globalThis as { __WP_KERNEL_ACTION_RUNTIME__?: unknown })
+			.__WP_KERNEL_ACTION_RUNTIME__;
+		(
+			global as { BroadcastChannel?: typeof BroadcastChannel }
+		).BroadcastChannel = class {
+			public messages: unknown[] = [];
+			public constructor(public name: string) {}
+			postMessage(message: unknown) {
+				this.messages.push(message);
+			}
+			close() {}
+		} as unknown as typeof BroadcastChannel;
+	});
+
+	afterEach(() => {
+		delete (globalThis as { __WP_KERNEL_ACTION_RUNTIME__?: unknown })
+			.__WP_KERNEL_ACTION_RUNTIME__;
+		delete (global as { BroadcastChannel?: typeof BroadcastChannel })
+			.BroadcastChannel;
+		delete (window as typeof window & { wp?: unknown }).wp;
+	});
+
+	it('evaluates synchronous policies', () => {
+		const policy = definePolicy<{
+			'tasks.manage': void;
+			'tasks.delete': void;
+		}>({
+			'tasks.manage': () => true,
+			'tasks.delete': () => false,
+		});
+
+		expect(policy.can('tasks.manage')).toBe(true);
+		expect(policy.can('tasks.delete')).toBe(false);
+	});
+
+	it('caches asynchronous evaluations', async () => {
+		let hits = 0;
+		const policy = definePolicy<{
+			'tasks.async': void;
+		}>({
+			'tasks.async': async () => {
+				hits += 1;
+				return hits < 2;
+			},
+		});
+
+		const first = await policy.can('tasks.async');
+		expect(first).toBe(true);
+		const second = await policy.can('tasks.async');
+		expect(second).toBe(true);
+		expect(hits).toBe(1);
+	});
+
+	it('throws KernelError with messageKey and emits events when denied', async () => {
+		const hooks = window.wp?.hooks as { doAction?: jest.Mock } | undefined;
+		expect(hooks?.doAction).toBeDefined();
+		const doAction = hooks!.doAction!;
+		doAction.mockImplementation(() => undefined);
+
+		const policy = definePolicy<{
+			'tasks.manage': void;
+		}>(
+			{
+				'tasks.manage': () => false,
+			},
+			{ namespace: 'acme' }
+		);
+
+		expect(() => policy.assert('tasks.manage')).toThrow(KernelError);
+		try {
+			policy.assert('tasks.manage');
+		} catch (error) {
+			const err = error as KernelError & { messageKey?: string };
+			expect(err.code).toBe('PolicyDenied');
+			expect(err.messageKey).toBe('policy.denied.acme.tasks.manage');
+		}
+
+		expect(doAction).toHaveBeenCalledWith(
+			'acme.policy.denied',
+			expect.objectContaining({
+				policyKey: 'tasks.manage',
+				messageKey: 'policy.denied.acme.tasks.manage',
+			})
+		);
+	});
+
+	it('extend overrides rules and invalidates cache', async () => {
+		const policy = definePolicy<{
+			'tasks.manage': void;
+		}>({
+			'tasks.manage': async () => true,
+		});
+
+		await expect(policy.can('tasks.manage')).resolves.toBe(true);
+		expect(policy.cache.get('tasks.manage::void')).toBe(true);
+
+		const warn = jest.spyOn(console, 'warn').mockImplementation();
+		policy.extend({
+			'tasks.manage': async () => false,
+		});
+		expect(warn).toHaveBeenCalled();
+		warn.mockRestore();
+
+		expect(policy.cache.get('tasks.manage::void')).toBeUndefined();
+		await expect(policy.can('tasks.manage')).resolves.toBe(false);
+	});
+
+	it('usePolicy exposes pre-hydration contract', async () => {
+		definePolicy<{
+			'tasks.manage': void;
+		}>({
+			'tasks.manage': () => true,
+		});
+
+		type TestPolicy = { 'tasks.manage': void };
+		const results: UsePolicyResult<TestPolicy>[] = [];
+
+		function TestComponent() {
+			const value = usePolicy<TestPolicy>();
+			const first = useRef(true);
+			useEffect(() => {
+				results.push(value);
+				if (first.current) {
+					first.current = false;
+				}
+			}, [value]);
+			return null;
+		}
+
+		const container = document.createElement('div');
+		let root: ReturnType<typeof createRoot> | undefined;
+		act(() => {
+			root = createRoot(container);
+			root.render(React.createElement(TestComponent));
+		});
+
+		await act(async () => {
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 0);
+			});
+		});
+
+		const initial = results[0]!;
+		expect(initial.isLoading).toBe(true);
+		expect(initial.can('tasks.manage')).toBe(false);
+
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		const latest = results[results.length - 1]!;
+		expect(latest.isLoading).toBe(false);
+		expect(latest.can('tasks.manage')).toBe(true);
+		act(() => {
+			root?.unmount();
+		});
+	});
+
+	it('proxy injects request context for action assertions', async () => {
+		const hooks = window.wp?.hooks as { doAction?: jest.Mock } | undefined;
+		expect(hooks?.doAction).toBeDefined();
+		const doAction = hooks!.doAction!;
+		doAction.mockImplementation(() => undefined);
+
+		const policy = definePolicy<{
+			'tasks.manage': void;
+		}>(
+			{
+				'tasks.manage': () => false,
+			},
+			{ namespace: 'acme' }
+		) as PolicyHelpers<Record<string, unknown>>;
+
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy,
+			bridge: {
+				emit: jest.fn(),
+			},
+		};
+		const bridgeEmit = (
+			global.__WP_KERNEL_ACTION_RUNTIME__ as {
+				bridge: { emit: jest.Mock };
+			}
+		).bridge.emit;
+
+		const proxy = createPolicyProxy({
+			actionName: 'Task.Update',
+			requestId: 'req-1',
+			namespace: 'acme',
+			scope: 'crossTab',
+			bridged: true,
+		});
+
+		expect(() => proxy.assert('tasks.manage', undefined)).toThrow(
+			KernelError
+		);
+		expect(doAction).toHaveBeenCalledWith(
+			'acme.policy.denied',
+			expect.objectContaining({
+				requestId: 'req-1',
+			})
+		);
+		expect(bridgeEmit).toHaveBeenCalledWith(
+			'acme.bridge.policy.denied',
+			expect.objectContaining({ policyKey: 'tasks.manage' }),
+			expect.objectContaining({ requestId: 'req-1' })
+		);
+	});
+
+	it('throws a developer error when accessing unknown policy keys', () => {
+		const policy = definePolicy<{ 'tasks.manage': void }>({
+			'tasks.manage': () => true,
+		});
+
+		expect(() => policy.can('tasks.delete' as never)).toThrow(KernelError);
+	});
+
+	it('reuses in-flight promises for async policy evaluations', async () => {
+		let resolveFn: ((value: boolean) => void) | undefined;
+		const asyncRule = jest.fn(
+			() =>
+				new Promise<boolean>((resolve) => {
+					resolveFn = resolve;
+				})
+		);
+		const policy = definePolicy<{ 'tasks.async': void }>({
+			'tasks.async': asyncRule,
+		});
+
+		const first = policy.can('tasks.async');
+		const second = policy.can('tasks.async');
+		expect(first).toBe(second);
+		resolveFn?.(true);
+		await expect(first).resolves.toBe(true);
+		expect(asyncRule).toHaveBeenCalledTimes(1);
+	});
+
+	it('clears in-flight cache when async rules reject', async () => {
+		const asyncRule = jest
+			.fn<Promise<boolean>, Parameters<PolicyRule<void>>>()
+			.mockRejectedValueOnce(new Error('fail'))
+			.mockResolvedValueOnce(true);
+
+		const policy = definePolicy<{ 'tasks.async': void }>({
+			'tasks.async': asyncRule,
+		});
+
+		await expect(policy.can('tasks.async')).rejects.toThrow('fail');
+		await expect(policy.can('tasks.async')).resolves.toBe(true);
+		expect(asyncRule).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/kernel/src/policy/__tests__/hooks.test.ts
+++ b/packages/kernel/src/policy/__tests__/hooks.test.ts
@@ -1,0 +1,211 @@
+import React, { act, useEffect, useRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import { usePolicy } from '../hooks';
+import { createPolicyCache, createPolicyCacheKey } from '../cache';
+import type { ActionRuntime } from '../../actions/types';
+import type { PolicyHelpers, UsePolicyResult } from '../types';
+import { KernelError } from '../../error/KernelError';
+
+jest.mock('../../namespace/detect', () => ({
+	getNamespace: () => 'acme',
+}));
+
+type RuntimePolicy =
+	| PolicyHelpers<Record<string, unknown>>
+	| (Partial<PolicyHelpers<Record<string, unknown>>> & {
+			cache?: PolicyHelpers<Record<string, unknown>>['cache'];
+	  });
+
+describe('usePolicy hook', () => {
+	beforeAll(() => {
+		(
+			globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+		).IS_REACT_ACT_ENVIRONMENT = true;
+	});
+
+	afterAll(() => {
+		delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+			.IS_REACT_ACT_ENVIRONMENT;
+	});
+
+	afterEach(() => {
+		delete global.__WP_KERNEL_ACTION_RUNTIME__;
+		jest.restoreAllMocks();
+	});
+
+	function renderTestComponent<Policy extends Record<string, unknown>>(
+		results: UsePolicyResult<Policy>[]
+	) {
+		const container = document.createElement('div');
+		const root = createRoot(container);
+
+		function TestComponent() {
+			const value = usePolicy<Policy>();
+			const initial = useRef(true);
+			if (initial.current) {
+				results.push(value);
+				initial.current = false;
+			}
+			useEffect(() => {
+				results.push(value);
+			}, [value]);
+			return null;
+		}
+
+		act(() => {
+			root.render(React.createElement(TestComponent));
+		});
+
+		return {
+			container,
+			cleanup() {
+				act(() => {
+					root.unmount();
+				});
+			},
+		};
+	}
+
+	it('reports a developer error when no runtime is configured', async () => {
+		const results: UsePolicyResult<Record<string, never>>[] = [];
+		const { cleanup } = renderTestComponent(results);
+
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		const latest = results[results.length - 1]!;
+		expect(latest.isLoading).toBe(false);
+		expect(latest.error).toBeInstanceOf(KernelError);
+		expect((latest.error as KernelError).code).toBe('DeveloperError');
+		cleanup();
+	});
+
+	it('returns cached values without calling runtime can()', async () => {
+		const cache = createPolicyCache({ crossTab: false }, 'acme');
+		const cacheKey = createPolicyCacheKey('tasks.manage', undefined);
+		cache.set(cacheKey, true, {
+			source: 'remote',
+			expiresAt: Date.now() + 1000,
+		});
+		const runtimeCan = jest.fn().mockReturnValue(false);
+		const runtime: RuntimePolicy = {
+			can: runtimeCan,
+			keys: () => ['tasks.manage'],
+			cache,
+		};
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: runtime,
+		} as ActionRuntime;
+
+		const results: UsePolicyResult<Record<string, unknown>>[] = [];
+		const { cleanup } = renderTestComponent(results);
+
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		const latest = results[results.length - 1]!;
+		expect(latest.isLoading).toBe(false);
+		expect(latest.can('tasks.manage', undefined)).toBe(true);
+		expect(runtimeCan).not.toHaveBeenCalled();
+		expect(latest.keys).toEqual(['tasks.manage']);
+		cleanup();
+	});
+
+	it('captures async denials from runtime can()', async () => {
+		const runtimeCan = jest.fn(() => Promise.reject('nope'));
+		const runtime: RuntimePolicy = {
+			can: runtimeCan,
+			keys: () => ['tasks.manage'],
+			cache: createPolicyCache({ crossTab: false }, 'acme'),
+		};
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: runtime,
+		} as ActionRuntime;
+
+		const results: UsePolicyResult<Record<string, unknown>>[] = [];
+		const { cleanup } = renderTestComponent(results);
+
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		const latest = results[results.length - 1]!;
+		await act(async () => {
+			latest.can('tasks.manage', undefined);
+			await Promise.resolve();
+		});
+
+		const final = results[results.length - 1]!;
+		expect(final.error).toBeInstanceOf(Error);
+		expect((final.error as Error).message).toBe('nope');
+		cleanup();
+	});
+
+	it('records thrown errors from runtime can()', async () => {
+		const runtimeCan = jest.fn(() => {
+			throw new KernelError('PolicyDenied', { message: 'denied' });
+		});
+		const runtime: RuntimePolicy = {
+			can: runtimeCan,
+			keys: () => ['tasks.manage'],
+			cache: createPolicyCache({ crossTab: false }, 'acme'),
+		};
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: runtime,
+		} as ActionRuntime;
+
+		const results: UsePolicyResult<Record<string, unknown>>[] = [];
+		const { cleanup } = renderTestComponent(results);
+
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		const latest = results[results.length - 1]!;
+		let allowed: boolean | undefined;
+		await act(async () => {
+			allowed = latest.can('tasks.manage', undefined);
+			await Promise.resolve();
+		});
+		expect(allowed).toBe(false);
+		const final = results[results.length - 1]!;
+		expect(final.error).toBeInstanceOf(KernelError);
+		expect((final.error as KernelError).code).toBe('PolicyDenied');
+		cleanup();
+	});
+
+	it('coerces non-error throws from runtime can()', async () => {
+		const runtimeCan = jest.fn(() => {
+			throw 'denied';
+		});
+		const runtime: RuntimePolicy = {
+			can: runtimeCan,
+			keys: () => ['tasks.manage'],
+			cache: createPolicyCache({ crossTab: false }, 'acme'),
+		};
+		global.__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: runtime,
+		} as ActionRuntime;
+
+		const results: UsePolicyResult<Record<string, unknown>>[] = [];
+		const { cleanup } = renderTestComponent(results);
+
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		const latest = results[results.length - 1]!;
+		let allowed: boolean | undefined;
+		await act(async () => {
+			allowed = latest.can('tasks.manage', undefined);
+			await Promise.resolve();
+		});
+		expect(allowed).toBe(false);
+		const final = results[results.length - 1]!;
+		expect(final.error).toBeInstanceOf(Error);
+		expect((final.error as Error).message).toBe('denied');
+		cleanup();
+	});
+});

--- a/packages/kernel/src/policy/cache.ts
+++ b/packages/kernel/src/policy/cache.ts
@@ -1,0 +1,311 @@
+import { getNamespace } from '../namespace/detect';
+import type { PolicyCache, PolicyCacheOptions } from './types';
+
+const DEFAULT_TTL_MS = 60_000;
+const STORAGE_KEY_PREFIX = 'wpk.policy.cache';
+const BROADCAST_CHANNEL_NAME = 'wpk.policy.cache';
+
+type Listener = () => void;
+
+type CacheEntryInternal = {
+	value: boolean;
+	expiresAt: number;
+};
+
+type BroadcastMessage =
+	| {
+			type: 'set';
+			namespace: string;
+			key: string;
+			value: boolean;
+			expiresAt: number;
+	  }
+	| { type: 'invalidate'; namespace: string; policyKey?: string }
+	| { type: 'clear'; namespace: string };
+
+const hasWindow = typeof window !== 'undefined';
+
+function stableSerialize(value: unknown): unknown {
+	if (value === null) {
+		return null;
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item) => stableSerialize(item));
+	}
+
+	if (typeof value === 'object') {
+		const entries = Object.entries(value as Record<string, unknown>)
+			.map(([key, val]) => [key, stableSerialize(val)] as const)
+			.sort(([a], [b]) => {
+				if (a > b) {
+					return 1;
+				}
+				if (a < b) {
+					return -1;
+				}
+				return 0;
+			});
+
+		return entries.reduce<Record<string, unknown>>((acc, [key, val]) => {
+			acc[key] = val;
+			return acc;
+		}, {});
+	}
+
+	return value;
+}
+
+export function createPolicyCacheKey(
+	policyKey: string,
+	params: unknown
+): string {
+	const serialized =
+		params === undefined ? 'void' : JSON.stringify(stableSerialize(params));
+	return `${policyKey}::${serialized}`;
+}
+
+function getStorage(options: PolicyCacheOptions | undefined): Storage | null {
+	if (!hasWindow) {
+		return null;
+	}
+
+	if (options?.storage === 'session') {
+		try {
+			return window.sessionStorage;
+		} catch (error) {
+			console.warn(
+				'[wp-kernel] sessionStorage is not available for policy cache.',
+				error
+			);
+			return null;
+		}
+	}
+
+	return null;
+}
+
+function readPersisted(
+	namespace: string,
+	options: PolicyCacheOptions | undefined
+): Record<string, CacheEntryInternal> {
+	const storage = getStorage(options);
+	if (!storage) {
+		return {};
+	}
+
+	try {
+		const raw = storage.getItem(`${STORAGE_KEY_PREFIX}.${namespace}`);
+		if (!raw) {
+			return {};
+		}
+		const parsed = JSON.parse(raw) as
+			| Record<string, CacheEntryInternal>
+			| undefined;
+		if (!parsed || typeof parsed !== 'object') {
+			return {};
+		}
+		return parsed;
+	} catch (error) {
+		console.warn(
+			'[wp-kernel] Failed to parse persisted policy cache.',
+			error
+		);
+		return {};
+	}
+}
+
+function persist(
+	namespace: string,
+	store: Map<string, CacheEntryInternal>,
+	options: PolicyCacheOptions | undefined
+): void {
+	const storage = getStorage(options);
+	if (!storage) {
+		return;
+	}
+
+	try {
+		const serialized = JSON.stringify(Object.fromEntries(store.entries()));
+		storage.setItem(`${STORAGE_KEY_PREFIX}.${namespace}`, serialized);
+	} catch (error) {
+		console.warn('[wp-kernel] Failed to persist policy cache.', error);
+	}
+}
+
+function createBroadcastChannel(
+	options: PolicyCacheOptions | undefined
+): BroadcastChannel | null {
+	if (!hasWindow) {
+		return null;
+	}
+
+	if (options?.crossTab === false) {
+		return null;
+	}
+
+	if (typeof window.BroadcastChannel !== 'function') {
+		return null;
+	}
+
+	try {
+		return new window.BroadcastChannel(BROADCAST_CHANNEL_NAME);
+	} catch (error) {
+		console.warn(
+			'[wp-kernel] Failed to create BroadcastChannel for policy cache.',
+			error
+		);
+		return null;
+	}
+}
+
+export function createPolicyCache(
+	options: PolicyCacheOptions | undefined,
+	namespace = getNamespace()
+): PolicyCache {
+	const ttl = options?.ttlMs ?? DEFAULT_TTL_MS;
+	const store = new Map<string, CacheEntryInternal>();
+	const listeners = new Set<Listener>();
+	let version = 0;
+	const persisted = readPersisted(namespace, options);
+	for (const [key, entry] of Object.entries(persisted)) {
+		store.set(key, entry);
+	}
+
+	const channel = createBroadcastChannel(options);
+	if (channel) {
+		channel.onmessage = (event: MessageEvent<BroadcastMessage>) => {
+			const message = event.data;
+			if (!message || message.namespace !== namespace) {
+				return;
+			}
+
+			if (message.type === 'set') {
+				store.set(message.key, {
+					value: message.value,
+					expiresAt: message.expiresAt,
+				});
+				version += 1;
+				listeners.forEach((listener) => listener());
+				persist(namespace, store, options);
+				return;
+			}
+
+			if (message.type === 'invalidate') {
+				if (message.policyKey) {
+					const prefix = `${message.policyKey}::`;
+					for (const key of Array.from(store.keys())) {
+						if (key.startsWith(prefix)) {
+							store.delete(key);
+						}
+					}
+				} else {
+					store.clear();
+				}
+				version += 1;
+				listeners.forEach((listener) => listener());
+				persist(namespace, store, options);
+				return;
+			}
+
+			if (message.type === 'clear') {
+				store.clear();
+				version += 1;
+				listeners.forEach((listener) => listener());
+				persist(namespace, store, options);
+			}
+		};
+	}
+
+	function notify(): void {
+		version += 1;
+		listeners.forEach((listener) => listener());
+		persist(namespace, store, options);
+	}
+
+	function broadcast(message: BroadcastMessage): void {
+		if (!channel) {
+			return;
+		}
+		channel.postMessage(message);
+	}
+
+	function evictExpired(
+		key: string,
+		entry: CacheEntryInternal | undefined
+	): boolean {
+		if (!entry) {
+			return true;
+		}
+		if (entry.expiresAt <= Date.now()) {
+			store.delete(key);
+			return true;
+		}
+		return false;
+	}
+
+	return {
+		get(key: string): boolean | undefined {
+			const entry = store.get(key);
+			if (evictExpired(key, entry)) {
+				return undefined;
+			}
+			return entry?.value;
+		},
+		set(
+			key: string,
+			value: boolean,
+			setOptions: {
+				ttlMs?: number;
+				source?: 'local' | 'remote';
+				expiresAt?: number;
+			} = {}
+		): void {
+			const expiresAt =
+				setOptions.expiresAt ?? Date.now() + (setOptions.ttlMs ?? ttl);
+			store.set(key, { value, expiresAt });
+			notify();
+			if (setOptions.source !== 'remote') {
+				broadcast({ type: 'set', namespace, key, value, expiresAt });
+			}
+		},
+		invalidate(policyKey?: string): void {
+			if (!policyKey) {
+				store.clear();
+				notify();
+				broadcast({ type: 'clear', namespace });
+				return;
+			}
+
+			const prefix = `${policyKey}::`;
+			let removed = false;
+			for (const key of Array.from(store.keys())) {
+				if (key.startsWith(prefix)) {
+					store.delete(key);
+					removed = true;
+				}
+			}
+			if (removed) {
+				notify();
+				broadcast({ type: 'invalidate', namespace, policyKey });
+			}
+		},
+		clear(): void {
+			store.clear();
+			notify();
+			broadcast({ type: 'clear', namespace });
+		},
+		keys(): string[] {
+			return Array.from(store.keys());
+		},
+		subscribe(listener: Listener): () => void {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+		getSnapshot(): number {
+			return version;
+		},
+	};
+}

--- a/packages/kernel/src/policy/context.ts
+++ b/packages/kernel/src/policy/context.ts
@@ -1,0 +1,147 @@
+import { KernelError } from '../error/KernelError';
+import type { ActionRuntime } from '../actions/types';
+import type { PolicyHelpers } from './types';
+
+export interface PolicyProxyOptions {
+	actionName: string;
+	requestId: string;
+	namespace: string;
+	scope: 'crossTab' | 'tabLocal';
+	bridged: boolean;
+}
+
+type PolicyRequestContext = PolicyProxyOptions;
+
+let currentContext: PolicyRequestContext | undefined;
+
+export function getPolicyRuntime(): ActionRuntime | undefined {
+	return globalThis.__WP_KERNEL_ACTION_RUNTIME__;
+}
+
+export function getPolicyRequestContext(): PolicyRequestContext | undefined {
+	return currentContext;
+}
+
+export function withPolicyRequestContext<T>(
+	context: PolicyRequestContext,
+	fn: () => T
+): T {
+	const previous = currentContext;
+	currentContext = context;
+	try {
+		const result = fn();
+		if (result instanceof Promise) {
+			return result.finally(() => {
+				currentContext = previous;
+			}) as unknown as T;
+		}
+		currentContext = previous;
+		return result;
+	} catch (error) {
+		currentContext = previous;
+		throw error;
+	}
+}
+
+export function createPolicyProxy(
+	options: PolicyProxyOptions
+): Pick<PolicyHelpers<Record<string, unknown>>, 'assert' | 'can'> {
+	let warned = false;
+
+	function resolvePolicy(): Partial<PolicyHelpers<Record<string, unknown>>> {
+		const runtime = getPolicyRuntime();
+		if (runtime?.policy) {
+			return runtime.policy;
+		}
+
+		throw new KernelError('DeveloperError', {
+			message: `Action "${options.actionName}" attempted to assert a policy without a policy runtime configured.`,
+		});
+	}
+
+	return {
+		assert(key: string, ...params: unknown[]): void | Promise<void> {
+			const runtimePolicy = resolvePolicy();
+			return withPolicyRequestContext(options, () => {
+				const normalizedParams =
+					params.length === 0
+						? ([] as never[])
+						: ([params[0]] as never[]);
+
+				if (runtimePolicy.assert) {
+					const assertFn = runtimePolicy.assert as (
+						policyKey: string,
+						param?: unknown
+					) => void | Promise<void>;
+					if (normalizedParams.length === 0) {
+						return assertFn(key, undefined);
+					}
+					return assertFn(key, normalizedParams[0]);
+				}
+
+				if (runtimePolicy.can) {
+					const canFn = runtimePolicy.can as (
+						policyKey: string,
+						param?: unknown
+					) => boolean | Promise<boolean>;
+					const result =
+						normalizedParams.length === 0
+							? canFn(key)
+							: canFn(key, normalizedParams[0]);
+					if (result instanceof Promise) {
+						return result.then((allowed) => {
+							if (!allowed) {
+								throw new KernelError('PolicyDenied', {
+									message: `Policy "${key}" denied by runtime can().`,
+									context: {
+										policyKey: key,
+										requestId: options.requestId,
+									},
+								});
+							}
+						});
+					}
+
+					if (!result) {
+						throw new KernelError('PolicyDenied', {
+							message: `Policy "${key}" denied by runtime can().`,
+							context: {
+								policyKey: key,
+								requestId: options.requestId,
+							},
+						});
+					}
+					return;
+				}
+
+				throw new KernelError('DeveloperError', {
+					message: `Action "${options.actionName}" attempted to assert policy "${key}" but runtime does not expose assert().`,
+				});
+			});
+		},
+		can(key: string, ...params: unknown[]): boolean | Promise<boolean> {
+			const runtimePolicy = getPolicyRuntime()?.policy;
+			if (!runtimePolicy?.can) {
+				if (!warned && process.env.NODE_ENV !== 'production') {
+					console.warn(
+						`Action "${options.actionName}" called policy.can('${key}') but no policy runtime is configured.`
+					);
+					warned = true;
+				}
+				return false;
+			}
+			const normalizedParams =
+				params.length === 0
+					? ([] as never[])
+					: ([params[0]] as never[]);
+			const canFn = runtimePolicy.can as (
+				policyKey: string,
+				param?: unknown
+			) => boolean | Promise<boolean>;
+			if (normalizedParams.length === 0) {
+				return canFn(key);
+			}
+			return canFn(key, normalizedParams[0]);
+		},
+	};
+}

--- a/packages/kernel/src/policy/define.ts
+++ b/packages/kernel/src/policy/define.ts
@@ -1,0 +1,400 @@
+import { KernelError } from '../error/KernelError';
+import { getNamespace } from '../namespace/detect';
+import { createPolicyCache, createPolicyCacheKey } from './cache';
+import { getPolicyRequestContext, getPolicyRuntime } from './context';
+import type {
+	ParamsOf,
+	PolicyAdapters,
+	PolicyContext,
+	PolicyHelpers,
+	PolicyMap,
+	PolicyOptions,
+	PolicyReporter,
+	PolicyRule,
+	PolicyDeniedEvent,
+} from './types';
+
+const POLICY_EVENT_CHANNEL = 'wpk.policy.events';
+
+interface WordPressHooks {
+	doAction: (eventName: string, payload: unknown) => void;
+}
+
+let eventChannel: BroadcastChannel | null | undefined;
+
+function getHooks(): WordPressHooks | null {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+
+	const wp = (window as Window & { wp?: { hooks?: WordPressHooks } }).wp;
+	if (!wp?.hooks || typeof wp.hooks.doAction !== 'function') {
+		return null;
+	}
+	return wp.hooks;
+}
+
+function getEventChannel(): BroadcastChannel | null {
+	if (eventChannel !== undefined) {
+		return eventChannel;
+	}
+
+	if (
+		typeof window === 'undefined' ||
+		typeof window.BroadcastChannel !== 'function'
+	) {
+		eventChannel = null;
+		return eventChannel;
+	}
+
+	try {
+		eventChannel = new window.BroadcastChannel(POLICY_EVENT_CHANNEL);
+	} catch (error) {
+		console.warn(
+			'[wp-kernel] Failed to create BroadcastChannel for policy events.',
+			error
+		);
+		eventChannel = null;
+	}
+
+	return eventChannel;
+}
+
+function createReporter(debug?: boolean): PolicyReporter {
+	if (!debug) {
+		return {
+			info: () => undefined,
+			warn: () => undefined,
+			error: () => undefined,
+			debug: () => undefined,
+		};
+	}
+
+	return {
+		info(message, context) {
+			console.info(`[wp-kernel][policy] ${message}`, context ?? '');
+		},
+		warn(message, context) {
+			console.warn(`[wp-kernel][policy] ${message}`, context ?? '');
+		},
+		error(message, context) {
+			console.error(`[wp-kernel][policy] ${message}`, context ?? '');
+		},
+		debug(message, context) {
+			console.debug(`[wp-kernel][policy] ${message}`, context ?? '');
+		},
+	};
+}
+
+function resolveAdapters(
+	options: PolicyOptions | undefined,
+	reporter: PolicyReporter
+): PolicyAdapters {
+	const adapters = options?.adapters ?? {};
+	const resolvedWp = adapters.wp ?? detectWpCanUser(reporter);
+	return {
+		wp: resolvedWp,
+		restProbe: adapters.restProbe,
+	};
+}
+
+function detectWpCanUser(reporter: PolicyReporter) {
+	if (typeof window === 'undefined') {
+		return undefined;
+	}
+
+	const wp = (
+		window as Window & {
+			wp?: {
+				data?: {
+					select?: (store: string) =>
+						| {
+								canUser?: (
+									action:
+										| 'create'
+										| 'read'
+										| 'update'
+										| 'delete',
+									resource:
+										| { path: string }
+										| {
+												kind: 'postType';
+												name: string;
+												id?: number;
+										  }
+								) => boolean | Promise<boolean>;
+						  }
+						| undefined;
+				};
+			};
+		}
+	).wp;
+
+	if (!wp?.data?.select) {
+		return undefined;
+	}
+
+	return {
+		canUser(
+			action: 'create' | 'read' | 'update' | 'delete',
+			resource:
+				| { path: string }
+				| { kind: 'postType'; name: string; id?: number }
+		) {
+			try {
+				const store = wp.data?.select?.('core');
+				const canUser = store?.canUser;
+				if (typeof canUser === 'function') {
+					return canUser(action, resource);
+				}
+				return false;
+			} catch (error) {
+				reporter.warn(
+					'Failed to invoke wp.data.select("core").canUser',
+					{
+						error,
+					}
+				);
+				return false;
+			}
+		},
+	};
+}
+function ensureBoolean(value: unknown, key: string): asserts value is boolean {
+	if (typeof value !== 'boolean') {
+		throw new KernelError('DeveloperError', {
+			message: `Policy "${key}" must return a boolean. Received ${typeof value}.`,
+		});
+	}
+}
+
+function buildContext(
+	policyKey: string,
+	params: unknown
+): Record<string, unknown> {
+	const context = getPolicyRequestContext();
+	const base: Record<string, unknown> = {
+		policyKey,
+	};
+
+	if (context?.requestId) {
+		base.requestId = context.requestId;
+	}
+
+	if (params && typeof params === 'object') {
+		Object.assign(base, params as Record<string, unknown>);
+	} else if (params !== undefined) {
+		base.value = params;
+	}
+
+	return base;
+}
+
+function emitPolicyDenied(
+	namespace: string,
+	payload: Omit<PolicyDeniedEvent, 'timestamp'>
+) {
+	const requestContext = getPolicyRequestContext();
+	const resolvedNamespace = requestContext?.namespace ?? namespace;
+	const hooks = getHooks();
+	const channel = getEventChannel();
+	const timestamp = Date.now();
+	const eventPayload: PolicyDeniedEvent = {
+		...payload,
+		timestamp,
+		requestId: payload.requestId ?? requestContext?.requestId,
+	};
+
+	const eventName = `${resolvedNamespace}.policy.denied`;
+	hooks?.doAction(eventName, eventPayload);
+	channel?.postMessage({
+		type: 'policy.denied',
+		namespace: resolvedNamespace,
+		payload: eventPayload,
+	});
+
+	if (requestContext?.bridged) {
+		const runtime = getPolicyRuntime();
+		runtime?.bridge?.emit?.(
+			`${resolvedNamespace}.bridge.policy.denied`,
+			eventPayload,
+			{
+				...requestContext,
+				timestamp,
+			}
+		);
+	}
+}
+
+function createDeniedError(
+	namespace: string,
+	policyKey: string,
+	params: unknown
+) {
+	const messageKey = `policy.denied.${namespace}.${policyKey}`;
+	const context = buildContext(policyKey, params);
+	const error = new KernelError('PolicyDenied', {
+		message: `Policy "${policyKey}" denied.`,
+		context,
+	});
+
+	(error as KernelError & { messageKey?: string }).messageKey = messageKey;
+	return { error, messageKey, context };
+}
+
+export function definePolicy<K extends Record<string, unknown>>(
+	map: PolicyMap<K>,
+	options?: PolicyOptions
+): PolicyHelpers<K> {
+	const namespace = options?.namespace ?? getNamespace();
+	const reporter = createReporter(options?.debug);
+	const cache = createPolicyCache(options?.cache, namespace);
+	const adapters = resolveAdapters(options, reporter);
+
+	const policyContext: PolicyContext = {
+		namespace,
+		adapters,
+		cache,
+		reporter,
+	};
+
+	const rules = new Map<keyof K, PolicyRule<K[keyof K]>>();
+	(Object.keys(map) as Array<keyof K>).forEach((key) => {
+		rules.set(key, map[key]);
+	});
+
+	const asyncKeys = new Set<keyof K>();
+	const inFlight = new Map<string, Promise<boolean>>();
+
+	function getRule<Key extends keyof K>(key: Key): PolicyRule<K[Key]> {
+		const rule = rules.get(key);
+		if (!rule) {
+			throw new KernelError('DeveloperError', {
+				message: `Policy "${String(key)}" is not registered.`,
+			});
+		}
+		return rule as PolicyRule<K[Key]>;
+	}
+
+	function evaluate<Key extends keyof K>(
+		key: Key,
+		params: ParamsOf<K, Key>[0] | undefined
+	): boolean | Promise<boolean> {
+		const cacheKey = createPolicyCacheKey(String(key), params);
+
+		if (asyncKeys.has(key)) {
+			const cached = cache.get(cacheKey);
+			if (typeof cached === 'boolean') {
+				return cached;
+			}
+
+			const inflight = inFlight.get(cacheKey);
+			if (inflight) {
+				return inflight;
+			}
+		}
+
+		const rule = getRule(key);
+		const result = rule(policyContext, params as K[Key]);
+
+		if (result instanceof Promise) {
+			asyncKeys.add(key);
+			const promise = result
+				.then((value) => {
+					ensureBoolean(value, String(key));
+					cache.set(cacheKey, value);
+					inFlight.delete(cacheKey);
+					return value;
+				})
+				.catch((error) => {
+					inFlight.delete(cacheKey);
+					throw error;
+				});
+			inFlight.set(cacheKey, promise);
+			return promise;
+		}
+
+		ensureBoolean(result, String(key));
+		return result;
+	}
+
+	const helpers: PolicyHelpers<K> = {
+		can<Key extends keyof K>(
+			key: Key,
+			...params: ParamsOf<K, Key>
+		): boolean | Promise<boolean> {
+			const param = params[0] as ParamsOf<K, Key>[0] | undefined;
+			return evaluate(key, param);
+		},
+		assert<Key extends keyof K>(
+			key: Key,
+			...params: ParamsOf<K, Key>
+		): void | Promise<void> {
+			const param = params[0] as ParamsOf<K, Key>[0] | undefined;
+			const outcome = evaluate(key, param);
+			if (outcome instanceof Promise) {
+				return outcome.then((allowed) => {
+					if (!allowed) {
+						const { error, messageKey, context } =
+							createDeniedError(namespace, String(key), param);
+						emitPolicyDenied(namespace, {
+							policyKey: String(key),
+							context,
+							messageKey,
+						});
+						throw error;
+					}
+				});
+			}
+
+			if (!outcome) {
+				const { error, messageKey, context } = createDeniedError(
+					namespace,
+					String(key),
+					param
+				);
+				emitPolicyDenied(namespace, {
+					policyKey: String(key),
+					context,
+					messageKey,
+				});
+				throw error;
+			}
+		},
+		keys(): (keyof K)[] {
+			return Array.from(rules.keys());
+		},
+		extend(additionalMap: Partial<PolicyMap<K>>): void {
+			(Object.keys(additionalMap) as Array<keyof K>).forEach((key) => {
+				const rule = additionalMap[key];
+				if (typeof rule !== 'function') {
+					return;
+				}
+
+				if (rules.has(key) && process.env.NODE_ENV !== 'production') {
+					console.warn(
+						`Policy "${String(key)}" is being overridden via extend().`
+					);
+				}
+
+				rules.set(key, rule);
+				asyncKeys.delete(key);
+				cache.invalidate(String(key));
+			});
+		},
+		cache,
+	};
+
+	const runtime = getPolicyRuntime();
+	if (runtime) {
+		runtime.policy = helpers as PolicyHelpers<Record<string, unknown>>;
+	} else {
+		(
+			globalThis as { __WP_KERNEL_ACTION_RUNTIME__?: unknown }
+		).__WP_KERNEL_ACTION_RUNTIME__ = {
+			policy: helpers as PolicyHelpers<Record<string, unknown>>,
+		};
+	}
+
+	return helpers;
+}

--- a/packages/kernel/src/policy/hooks.ts
+++ b/packages/kernel/src/policy/hooks.ts
@@ -1,0 +1,107 @@
+import {
+	useCallback,
+	useEffect,
+	useState,
+	useSyncExternalStore,
+} from '@wordpress/element';
+import { KernelError } from '../error/KernelError';
+import { createPolicyCacheKey } from './cache';
+import { getPolicyRuntime } from './context';
+import type { ParamsOf, PolicyHelpers, UsePolicyResult } from './types';
+
+type PolicyLike<K extends Record<string, unknown>> =
+	| PolicyHelpers<K>
+	| (Partial<PolicyHelpers<K>> & { cache?: PolicyHelpers<K>['cache'] });
+
+function isPromise(value: unknown): value is Promise<unknown> {
+	return typeof value === 'object' && value !== null && 'then' in value;
+}
+
+function resolvePolicy<K extends Record<string, unknown>>():
+	| PolicyLike<K>
+	| undefined {
+	const runtime = getPolicyRuntime();
+	return runtime?.policy as PolicyLike<K> | undefined;
+}
+
+export function usePolicy<
+	K extends Record<string, unknown>,
+>(): UsePolicyResult<K> {
+	const policy = resolvePolicy<K>();
+	const cache = policy?.cache;
+
+	const subscribe = useCallback(
+		(listener: () => void) =>
+			cache?.subscribe(listener) ?? (() => undefined),
+		[cache]
+	);
+	const getSnapshot = useCallback(() => cache?.getSnapshot() ?? 0, [cache]);
+	useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+	const [hydrated, setHydrated] = useState(false);
+	const [error, setError] = useState<Error | undefined>(undefined);
+
+	useEffect(() => {
+		if (!policy?.can) {
+			setError(
+				new KernelError('DeveloperError', {
+					message:
+						'No policy runtime configured. Call definePolicy() and wire it into the action runtime.',
+				})
+			);
+		} else {
+			setError(undefined);
+		}
+		setHydrated(true);
+	}, [policy]);
+
+	const can = useCallback(
+		<Key extends keyof K>(
+			key: Key,
+			...params: ParamsOf<K, Key>
+		): boolean => {
+			if (!hydrated || !policy?.can) {
+				return false;
+			}
+
+			const param = params[0] as ParamsOf<K, Key>[0] | undefined;
+			const cacheKey = createPolicyCacheKey(String(key), param);
+			const cached = cache?.get(cacheKey);
+			if (typeof cached === 'boolean') {
+				return cached;
+			}
+
+			try {
+				const result = policy.can(key, ...(params as ParamsOf<K, Key>));
+				if (isPromise(result)) {
+					result.catch((err) => {
+						if (err instanceof Error) {
+							setError(err);
+						} else {
+							setError(new Error(String(err)));
+						}
+					});
+					return false;
+				}
+				return result;
+			} catch (err) {
+				if (err instanceof Error) {
+					setError(err);
+				} else {
+					setError(new Error(String(err)));
+				}
+				return false;
+			}
+		},
+		[hydrated, policy, cache]
+	);
+
+	const keys = policy?.keys ? policy.keys() : [];
+
+	return {
+		can,
+		keys,
+		isLoading: !hydrated,
+		error,
+	};
+}

--- a/packages/kernel/src/policy/index.ts
+++ b/packages/kernel/src/policy/index.ts
@@ -1,0 +1,17 @@
+export { definePolicy } from './define';
+export { createPolicyProxy } from './context';
+export { usePolicy } from './hooks';
+export { createPolicyCache, createPolicyCacheKey } from './cache';
+export type {
+	PolicyRule,
+	PolicyMap,
+	PolicyHelpers,
+	PolicyOptions,
+	PolicyContext,
+	PolicyCache,
+	PolicyCacheOptions,
+	PolicyDeniedEvent,
+	PolicyReporter,
+	UsePolicyResult,
+	ParamsOf,
+} from './types';

--- a/packages/kernel/src/policy/types.ts
+++ b/packages/kernel/src/policy/types.ts
@@ -1,0 +1,160 @@
+/**
+ * Policy module type definitions.
+ *
+ * These types describe the runtime contract for declarative capability policies.
+ * Policies are evaluated both within actions (for enforcement) and within UI hooks
+ * (for conditional rendering). All enforcement flows through strongly typed helpers
+ * produced by `definePolicy()`.
+ */
+
+/**
+ * Reporter interface used for structured diagnostics from the policy runtime.
+ * Mirrors the reporter surface used by actions but is defined locally to avoid
+ * circular type dependencies.
+ */
+export interface PolicyReporter {
+	info: (message: string, context?: Record<string, unknown>) => void;
+	warn: (message: string, context?: Record<string, unknown>) => void;
+	error: (message: string, context?: Record<string, unknown>) => void;
+	debug?: (message: string, context?: Record<string, unknown>) => void;
+}
+
+/**
+ * Policy rule signature.
+ *
+ * @template P - Parameters required by the rule. `void` indicates no params.
+ */
+export type PolicyRule<P = void> = (
+	ctx: PolicyContext,
+	params: P
+) => boolean | Promise<boolean>;
+
+/**
+ * Mapping from policy key to rule implementation.
+ */
+export type PolicyMap<Keys extends Record<string, unknown>> = {
+	[K in keyof Keys]: PolicyRule<Keys[K]>;
+};
+
+/**
+ * Extract the tuple type used for params in `can`/`assert` helpers.
+ * Ensures that void params are optional while others remain required.
+ */
+export type ParamsOf<K, Key extends keyof K> = K[Key] extends void
+	? []
+	: [K[Key]];
+
+/**
+ * Cache storage options for policy evaluations.
+ */
+export interface PolicyCacheOptions {
+	ttlMs?: number;
+	storage?: 'memory' | 'session';
+	crossTab?: boolean;
+}
+
+/**
+ * Entry stored in the policy cache.
+ */
+export interface PolicyCacheEntry {
+	value: boolean;
+	expiresAt: number;
+}
+
+/**
+ * Minimal cache contract used by the policy runtime and React hook.
+ */
+export interface PolicyCache {
+	get: (key: string) => boolean | undefined;
+	set: (
+		key: string,
+		value: boolean,
+		options?: {
+			ttlMs?: number;
+			source?: 'local' | 'remote';
+			expiresAt?: number;
+		}
+	) => void;
+	invalidate: (policyKey?: string) => void;
+	clear: () => void;
+	keys: () => string[];
+	subscribe: (listener: () => void) => () => void;
+	getSnapshot: () => number;
+}
+
+/**
+ * Adapters that policy rules can leverage when evaluating capabilities.
+ */
+export interface PolicyAdapters {
+	wp?: {
+		canUser: (
+			action: 'create' | 'read' | 'update' | 'delete',
+			resource:
+				| { path: string }
+				| { kind: 'postType'; name: string; id?: number }
+		) => boolean | Promise<boolean>;
+	};
+	restProbe?: (key: string) => Promise<boolean>;
+}
+
+/**
+ * Policy evaluation context passed to every rule.
+ */
+export interface PolicyContext {
+	namespace: string;
+	adapters: PolicyAdapters;
+	cache: PolicyCache;
+	reporter?: PolicyReporter;
+}
+
+/**
+ * Additional options accepted by `definePolicy()`.
+ */
+export interface PolicyOptions {
+	namespace?: string;
+	adapters?: PolicyAdapters;
+	cache?: PolicyCacheOptions;
+	debug?: boolean;
+}
+
+/**
+ * Runtime helpers exposed by `definePolicy()`.
+ */
+export interface PolicyHelpers<K extends Record<string, unknown>> {
+	can: <Key extends keyof K>(
+		key: Key,
+		...params: ParamsOf<K, Key>
+	) => boolean | Promise<boolean>;
+	assert: <Key extends keyof K>(
+		key: Key,
+		...params: ParamsOf<K, Key>
+	) => void | Promise<void>;
+	keys: () => (keyof K)[];
+	extend: (additionalMap: Partial<PolicyMap<K>>) => void;
+	readonly cache: PolicyCache;
+}
+
+/**
+ * Payload emitted with `{namespace}.policy.denied` events.
+ */
+export interface PolicyDeniedEvent {
+	policyKey: string;
+	context?: Record<string, unknown>;
+	requestId?: string;
+	timestamp: number;
+	reason?: string;
+	messageKey?: string;
+}
+
+/**
+ * Result returned by the `usePolicy()` hook.
+ */
+export interface UsePolicyResult<K extends Record<string, unknown>> {
+	can: <Key extends keyof K>(
+		key: Key,
+		...params: ParamsOf<K, Key>
+	) => boolean;
+	keys: (keyof K)[];
+	isLoading: boolean;
+	error?: Error;
+}


### PR DESCRIPTION
## Summary
- add a typed helper in the policy context tests to exercise runtime fallbacks without tripping the stricter helper generics
- introduce a policy environment regression suite covering BroadcastChannel failures, WordPress adapters, reporter logging, and cache fallbacks

## Testing
- pnpm typecheck
- pnpm typecheck:tests
- pnpm test:coverage
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e1e77cba9c832595c62ec3f07859bf