### PR TITLE
Refactor action and policy definitions to use config objects

### DIFF
--- a/Architecture Implementation Phases.md
+++ b/Architecture Implementation Phases.md
@@ -277,7 +277,10 @@ removing positional overloads entirely.
 - Complete the "Summary of work done below"
 
 **Summary of work done**
-`<placeholder to be replaced when complete>`
+Replaced the positional `defineAction()` and `definePolicy()` signatures with
+configuration objects, updated runtime validation + error messaging, refactored
+tests and documentation to the new call shape, and noted the breaking change in
+the kernel changelog.
 
 ---
 

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -63,12 +63,12 @@ Let's build up an action step by step to see how it all fits together:
 ```typescript
 import { defineAction } from '@geekist/wp-kernel/actions';
 
-export const CreatePost = defineAction(
-	'Post.Create',
-	async (ctx, { title, content }) => {
+export const CreatePost = defineAction({
+	name: 'Post.Create',
+	handler: async (ctx, { title, content }) => {
 		// Action logic goes here
-	}
-);
+	},
+});
 ```
 
 ### 2. Add Resource Integration
@@ -77,15 +77,15 @@ export const CreatePost = defineAction(
 import { defineAction } from '@geekist/wp-kernel/actions';
 import { post } from '@/resources/post';
 
-export const CreatePost = defineAction(
-	'Post.Create',
-	async (ctx, { title, content }) => {
+export const CreatePost = defineAction({
+	name: 'Post.Create',
+	handler: async (ctx, { title, content }) => {
 		// Call the resource (this does the actual API work)
 		const created = await post.create({ title, content });
 
 		return created;
-	}
-);
+	},
+});
 ```
 
 ### 3. Add Event Emission
@@ -94,9 +94,9 @@ export const CreatePost = defineAction(
 import { defineAction } from '@geekist/wp-kernel/actions';
 import { post } from '@/resources/post';
 
-export const CreatePost = defineAction(
-	'Post.Create',
-	async (ctx, { title, content }) => {
+export const CreatePost = defineAction({
+	name: 'Post.Create',
+	handler: async (ctx, { title, content }) => {
 		const created = await post.create({ title, content });
 
 		// Emit canonical domain events
@@ -106,8 +106,8 @@ export const CreatePost = defineAction(
 		});
 
 		return created;
-	}
-);
+	},
+});
 ```
 
 ### 4. Add Cache Invalidation
@@ -116,9 +116,9 @@ export const CreatePost = defineAction(
 import { defineAction } from '@geekist/wp-kernel/actions';
 import { post } from '@/resources/post';
 
-export const CreatePost = defineAction(
-	'Post.Create',
-	async (ctx, { title, content }) => {
+export const CreatePost = defineAction({
+	name: 'Post.Create',
+	handler: async (ctx, { title, content }) => {
 		const created = await post.create({ title, content });
 
 		ctx.emit('post.created', {
@@ -130,8 +130,8 @@ export const CreatePost = defineAction(
 		ctx.invalidate(['post', 'post:list']);
 
 		return created;
-	}
-);
+	},
+});
 ```
 
 ### 5. Add Background Jobs
@@ -140,9 +140,9 @@ export const CreatePost = defineAction(
 import { defineAction } from '@geekist/wp-kernel/actions';
 import { post } from '@/resources/post';
 
-export const CreatePost = defineAction(
-	'Post.Create',
-	async (ctx, { title, content, notifySubscribers = false }) => {
+export const CreatePost = defineAction({
+	name: 'Post.Create',
+	handler: async (ctx, { title, content, notifySubscribers = false }) => {
 		const created = await post.create({ title, content });
 
 		ctx.emit('post.created', {
@@ -160,8 +160,8 @@ export const CreatePost = defineAction(
 		}
 
 		return created;
-	}
-);
+	},
+});
 ```
 
 ### 6. Add Error Handling & Validation
@@ -171,9 +171,9 @@ import { defineAction } from '@geekist/wp-kernel/actions';
 import { post } from '@/resources/post';
 import { KernelError } from '@geekist/wp-kernel/error';
 
-export const CreatePost = defineAction(
-	'Post.Create',
-	async (ctx, { title, content, notifySubscribers = false }) => {
+export const CreatePost = defineAction({
+	name: 'Post.Create',
+	handler: async (ctx, { title, content, notifySubscribers = false }) => {
 		// Validation
 		if (!title?.trim()) {
 			throw new KernelError('ValidationError', {
@@ -207,8 +207,8 @@ export const CreatePost = defineAction(
 			ctx.reporter.error('Post creation failed', { title, error });
 			throw error;
 		}
-	}
-);
+	},
+});
 ```
 
 ### Reporting and notices
@@ -334,9 +334,9 @@ store('my-plugin', {
 ### Optimistic Updates
 
 ```typescript
-export const UpdatePost = defineAction(
-	'Post.Update',
-	async (ctx, { id, updates }) => {
+export const UpdatePost = defineAction({
+	name: 'Post.Update',
+	handler: async (ctx, { id, updates }) => {
 		// Note: Optimistic updates would require additional store integration
 		// beyond the action itself. This is a conceptual example.
 
@@ -345,16 +345,16 @@ export const UpdatePost = defineAction(
 		ctx.emit('post.updated', { postId: id, data: updated });
 
 		return updated;
-	}
-);
+	},
+});
 ```
 
 ### Batch Operations
 
 ```typescript
-export const BulkDeletePosts = defineAction(
-	'Post.BulkDelete',
-	async (ctx, { ids }) => {
+export const BulkDeletePosts = defineAction({
+	name: 'Post.BulkDelete',
+	handler: async (ctx, { ids }) => {
 		const results = [];
 
 		for (const id of ids) {
@@ -375,16 +375,16 @@ export const BulkDeletePosts = defineAction(
 		});
 
 		return results;
-	}
-);
+	},
+});
 ```
 
 ### Conditional Side Effects
 
 ```typescript
-export const PublishPost = defineAction(
-	'Post.Publish',
-	async (ctx, { id, scheduleNotifications = true }) => {
+export const PublishPost = defineAction({
+	name: 'Post.Publish',
+	handler: async (ctx, { id, scheduleNotifications = true }) => {
 		const updated = await post.update(id, { status: 'publish' });
 
 		ctx.emit('post.published', {
@@ -406,8 +406,8 @@ export const PublishPost = defineAction(
 		}
 
 		return updated;
-	}
-);
+	},
+});
 ```
 
 ### Redux Middleware Integration

--- a/docs/guide/jobs.md
+++ b/docs/guide/jobs.md
@@ -11,12 +11,15 @@ Queue long-running tasks from Actions. Client can poll for status updates.
 ```typescript
 import { defineJob } from '@geekist/wp-kernel/jobs';
 
-export const IndexTestimonial = defineJob('IndexTestimonial', {
-	enqueue: (params: { id: number }) => {
-		// POST /wpk/v1/jobs/index-testimonial
-	},
-	status: (params) => {
-		// GET /wpk/v1/jobs/index-testimonial/status?id=...
+export const IndexTestimonial = defineJob({
+	name: 'IndexTestimonial',
+	handler: {
+		enqueue: (params: { id: number }) => {
+			// POST /wpk/v1/jobs/index-testimonial
+		},
+		status: (params) => {
+			// GET /wpk/v1/jobs/index-testimonial/status?id=...
+		},
 	},
 });
 

--- a/docs/guide/policy.md
+++ b/docs/guide/policy.md
@@ -40,15 +40,17 @@ type JobPolicies = {
 };
 
 export const policy = definePolicy<JobPolicies>({
-	'jobs.manage': () => true,
-	'jobs.delete': ({ adapters }, { id }) =>
-		adapters.wp?.canUser('delete', {
-			kind: 'postType',
-			name: 'job',
-			id,
-		}) ?? false,
-	'beta.enabled': async ({ adapters }) =>
-		(await adapters.restProbe?.('beta')) ?? false,
+	map: {
+		'jobs.manage': () => true,
+		'jobs.delete': ({ adapters }, { id }) =>
+			adapters.wp?.canUser('delete', {
+				kind: 'postType',
+				name: 'job',
+				id,
+			}) ?? false,
+		'beta.enabled': async ({ adapters }) =>
+			(await adapters.restProbe?.('beta')) ?? false,
+	},
 });
 ```
 
@@ -152,11 +154,14 @@ seconds. The cache keeps both Action assertions and UI hooks in sync. Configure
 it via the `cache` option when defining the policy:
 
 ```ts
-const policy = definePolicy(map, {
-	cache: {
-		ttlMs: 5 * 60_000,
-		storage: 'session',
-		crossTab: true,
+const policy = definePolicy({
+	map,
+	options: {
+		cache: {
+			ttlMs: 5 * 60_000,
+			storage: 'session',
+			crossTab: true,
+		},
 	},
 });
 ```

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Removed the `withKernel()` export. Registry middleware is now wired directly
   through `configureKernel()`, and teardown happens via the returned instance.
+- `defineAction()` and `definePolicy()` now accept configuration objects
+  (`{ name, handler, options }` / `{ map, options }`) rather than positional
+  parameters. Update call sites to pass the new shape.
 
 ### Minor Changes
 

--- a/packages/kernel/src/__tests__/integration/action-flow.test.ts
+++ b/packages/kernel/src/__tests__/integration/action-flow.test.ts
@@ -11,8 +11,17 @@
  */
 
 import { defineAction } from '../../actions/define';
+import type { ActionConfig, ActionOptions } from '../../actions/types';
 import { defineResource } from '../../resource/define';
 import * as cache from '../../resource/cache';
+
+function createAction<TArgs = void, TResult = void>(
+	name: string,
+	handler: ActionConfig<TArgs, TResult>['handler'],
+	options?: ActionOptions
+) {
+	return defineAction<TArgs, TResult>({ name, handler, options });
+}
 
 describe('Action Flow Integration', () => {
 	let mockApiFetch: jest.Mock;
@@ -57,7 +66,7 @@ describe('Action Flow Integration', () => {
 			},
 		});
 
-		const CreateThing = defineAction<
+		const CreateThing = createAction<
 			{ data: { title: string } },
 			{ id: number; title: string }
 		>('Thing.Create', async (ctx, { data }) => {
@@ -112,7 +121,7 @@ describe('Action Flow Integration', () => {
 			},
 		});
 
-		const UpdateThing = defineAction<
+		const UpdateThing = createAction<
 			{ id: number; updates: { title: string } },
 			{ id: number; title: string }
 		>('Thing.Update', async (ctx, { id, updates }) => {
@@ -160,7 +169,7 @@ describe('Action Flow Integration', () => {
 
 		mockApiFetch.mockResolvedValue({ id: 1, title: 'Updated' });
 
-		const UpdateThing = defineAction<
+		const UpdateThing = createAction<
 			{ id: number; updates: { title: string } },
 			{ id: number; title: string }
 		>('Thing.Update', async (ctx, { id, updates }) => {
@@ -204,7 +213,7 @@ describe('Action Flow Integration', () => {
 		const createdThing = { id: 42, title: 'Created' };
 		mockApiFetch.mockResolvedValue(createdThing);
 
-		const CreateThing = defineAction<
+		const CreateThing = createAction<
 			{ data: { title: string } },
 			{ id: number; title: string }
 		>('Thing.Create', async (ctx, { data }) => {
@@ -232,7 +241,7 @@ describe('Action Flow Integration', () => {
 		const createdThing = { id: 42, title: 'Created' };
 		mockApiFetch.mockResolvedValue(createdThing);
 
-		const CreateThing = defineAction<
+		const CreateThing = createAction<
 			{ data: { title: string } },
 			{ id: number; title: string }
 		>(

--- a/packages/kernel/src/__tests__/integration/middleware-flow.test.ts
+++ b/packages/kernel/src/__tests__/integration/middleware-flow.test.ts
@@ -9,8 +9,17 @@
  */
 
 import { defineAction } from '../../actions/define';
+import type { ActionConfig, ActionOptions } from '../../actions/types';
 import { createActionMiddleware, invokeAction } from '../../actions/middleware';
 import { defineResource } from '../../resource/define';
+
+function createAction<TArgs = void, TResult = void>(
+	name: string,
+	handler: ActionConfig<TArgs, TResult>['handler'],
+	options?: ActionOptions
+) {
+	return defineAction<TArgs, TResult>({ name, handler, options });
+}
 
 type TestItem = {
 	id: number;
@@ -70,7 +79,7 @@ describe('Redux Middleware Integration', () => {
 			},
 		});
 
-		const CreateItem = defineAction<{ data: { title: string } }, TestItem>(
+		const CreateItem = createAction<{ data: { title: string } }, TestItem>(
 			'Item.Create',
 			async (ctx, { data }) => {
 				const created = await resource.create!(data);
@@ -140,7 +149,7 @@ describe('Redux Middleware Integration', () => {
 			},
 		});
 
-		const CreateItem = defineAction<{ data: { title: string } }, TestItem>(
+		const CreateItem = createAction<{ data: { title: string } }, TestItem>(
 			'Item.Create',
 			async (_ctx, { data }) => {
 				return await resource.create!(data);
@@ -175,7 +184,7 @@ describe('Redux Middleware Integration', () => {
 			},
 		});
 
-		const CreateItem = defineAction<{ data: { title: string } }, TestItem>(
+		const CreateItem = createAction<{ data: { title: string } }, TestItem>(
 			'Item.Create',
 			async (_ctx, { data }) => {
 				return await resource.create!(data);

--- a/packages/kernel/src/actions/__tests__/defineAction.test.ts
+++ b/packages/kernel/src/actions/__tests__/defineAction.test.ts
@@ -1,6 +1,15 @@
 import { defineAction } from '../define';
+import type { ActionConfig, ActionOptions } from '../types';
 import * as cache from '../../resource/cache';
 import { KernelError } from '../../error/KernelError';
+
+function createAction<TArgs = void, TResult = void>(
+	name: string,
+	handler: ActionConfig<TArgs, TResult>['handler'],
+	options?: ActionOptions
+) {
+	return defineAction<TArgs, TResult>({ name, handler, options });
+}
 
 describe('defineAction', () => {
 	let originalRuntime: typeof global.__WP_KERNEL_ACTION_RUNTIME__;
@@ -50,7 +59,7 @@ describe('defineAction', () => {
 			.spyOn(cache, 'invalidate')
 			.mockImplementation(() => undefined);
 
-		const action = defineAction<{ title: string }, { id: number }>(
+		const action = createAction<{ title: string }, { id: number }>(
 			'Thing.Create',
 			async (ctx, args) => {
 				expect(args).toEqual({ title: 'Example' });
@@ -103,7 +112,7 @@ describe('defineAction', () => {
 	});
 
 	it('wraps thrown errors and emits error lifecycle event', async () => {
-		const action = defineAction('Thing.Fail', async () => {
+		const action = createAction('Thing.Fail', async () => {
 			throw new Error('boom');
 		});
 
@@ -121,7 +130,7 @@ describe('defineAction', () => {
 	});
 
 	it('marks tabLocal actions as non-bridged', async () => {
-		const action = defineAction('Thing.Local', async () => ({ ok: true }), {
+		const action = createAction('Thing.Local', async () => ({ ok: true }), {
 			scope: 'tabLocal',
 			bridged: true,
 		});
@@ -137,7 +146,7 @@ describe('defineAction', () => {
 			bridge: { emit: bridgeEmit },
 		};
 
-		const action = defineAction(
+		const action = createAction(
 			'Thing.NoBridge',
 			async () => ({ ok: true }),
 			{

--- a/packages/kernel/src/actions/__tests__/middleware.test.ts
+++ b/packages/kernel/src/actions/__tests__/middleware.test.ts
@@ -1,5 +1,14 @@
 import { createActionMiddleware, invokeAction } from '../middleware';
 import { defineAction } from '../define';
+import type { ActionConfig, ActionOptions } from '../types';
+
+function createAction<TArgs = void, TResult = void>(
+	name: string,
+	handler: ActionConfig<TArgs, TResult>['handler'],
+	options?: ActionOptions
+) {
+	return defineAction<TArgs, TResult>({ name, handler, options });
+}
 
 describe('createActionMiddleware', () => {
 	it('executes defined actions and returns their promise', async () => {
@@ -8,7 +17,7 @@ describe('createActionMiddleware', () => {
 		const next = jest.fn();
 		const invoke = middleware(api)(next);
 
-		const action = defineAction<{ value: number }, number>(
+		const action = createAction<{ value: number }, number>(
 			'Thing.Double',
 			async (_ctx, args) => {
 				return args.value * 2;

--- a/packages/kernel/src/actions/index.ts
+++ b/packages/kernel/src/actions/index.ts
@@ -10,6 +10,7 @@ export {
 	type ActionEnvelope,
 } from './middleware';
 export type {
+	ActionConfig,
 	ActionContext,
 	ActionFn,
 	ActionOptions,

--- a/packages/kernel/src/actions/types.ts
+++ b/packages/kernel/src/actions/types.ts
@@ -38,10 +38,18 @@ export type { Reporter } from '../reporter';
  * @example
  * ```typescript
  * // Cross-tab action with PHP bridge (default for mutations)
- * defineAction('CreatePost', impl, { scope: 'crossTab', bridged: true });
+ * defineAction({
+ *   name: 'CreatePost',
+ *   handler: impl,
+ *   options: { scope: 'crossTab', bridged: true }
+ * });
  *
  * // Tab-local UI action (no PHP bridge)
- * defineAction('ToggleSidebar', impl, { scope: 'tabLocal' }); // bridged=false automatically
+ * defineAction({
+ *   name: 'ToggleSidebar',
+ *   handler: impl,
+ *   options: { scope: 'tabLocal' } // bridged=false automatically
+ * });
  * ```
  */
 export type ActionOptions = {
@@ -311,6 +319,18 @@ export type ActionFn<TArgs, TResult> = (
 ) => Promise<TResult>;
 
 /**
+ * Configuration object accepted by `defineAction()`.
+ */
+export type ActionConfig<TArgs, TResult> = {
+	/** Unique action identifier. */
+	name: string;
+	/** Implementation invoked when the action is executed. */
+	handler: ActionFn<TArgs, TResult>;
+	/** Optional runtime configuration. */
+	options?: ActionOptions;
+};
+
+/**
  * Callable action returned by `defineAction()`.
  *
  * After wrapping with `defineAction()`, actions become callable functions that:
@@ -324,8 +344,11 @@ export type ActionFn<TArgs, TResult> = (
  *
  * @example
  * ```typescript
- * const CreatePost = defineAction('CreatePost', async (ctx, input) => {
- *   // implementation
+ * const CreatePost = defineAction({
+ *   name: 'CreatePost',
+ *   handler: async (ctx, input) => {
+ *     // implementation
+ *   }
  * });
  *
  * // Usage

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -126,6 +126,7 @@ export {
 	EXECUTE_ACTION_TYPE,
 } from './actions/middleware.js';
 export type {
+	ActionConfig,
 	ActionContext,
 	ActionFn,
 	ActionOptions,
@@ -146,6 +147,7 @@ export type {
 	PolicyMap,
 	PolicyHelpers,
 	PolicyOptions,
+	PolicyDefinitionConfig,
 	PolicyContext,
 	PolicyCache,
 	PolicyCacheOptions,

--- a/packages/kernel/src/policy/__tests__/define.behavior.test.ts
+++ b/packages/kernel/src/policy/__tests__/define.behavior.test.ts
@@ -1,15 +1,21 @@
 import { type PolicyDeniedError } from '../../error/PolicyDeniedError';
 import { withPolicyRequestContext } from '../context';
 import type { ActionRuntime } from '../../actions/types';
-import type { definePolicy as definePolicyFn } from '../define';
+import type { PolicyHelpers, PolicyMap, PolicyOptions } from '../types';
 import { WPK_SUBSYSTEM_NAMESPACES } from '../../namespace/constants';
 
-type DefinePolicy = typeof definePolicyFn;
+type DefinePolicy = <K extends Record<string, unknown>>(
+	map: PolicyMap<K>,
+	options?: PolicyOptions
+) => PolicyHelpers<K>;
 
 async function loadDefinePolicy(): Promise<DefinePolicy> {
 	jest.resetModules();
 	const module = await import('../define');
-	return module.definePolicy;
+	return <K extends Record<string, unknown>>(
+		map: PolicyMap<K>,
+		options?: PolicyOptions
+	) => module.definePolicy<K>({ map, options });
 }
 
 describe('definePolicy behaviour', () => {

--- a/packages/kernel/src/policy/__tests__/define.environment.test.ts
+++ b/packages/kernel/src/policy/__tests__/define.environment.test.ts
@@ -66,7 +66,9 @@ describe('policy environment edge cases', () => {
 			const { definePolicy } = loadPolicyModule();
 
 			const policy = definePolicy<{ 'tasks.manage': void }>({
-				'tasks.manage': () => false,
+				map: {
+					'tasks.manage': () => false,
+				},
 			});
 
 			expect(() => policy.assert('tasks.manage')).toThrow(
@@ -111,8 +113,8 @@ describe('policy environment edge cases', () => {
 
 			const { definePolicy } = loadPolicyModule();
 
-			const policy = definePolicy<{ 'tasks.wp': void }>(
-				{
+			const policy = definePolicy<{ 'tasks.wp': void }>({
+				map: {
 					'tasks.wp': ({ adapters }: PolicyContext) => {
 						const allowed = adapters.wp?.canUser?.('read', {
 							path: '/wp-json/acme',
@@ -121,11 +123,11 @@ describe('policy environment edge cases', () => {
 						return false;
 					},
 				},
-				{
+				options: {
 					namespace: 'acme',
 					debug: true,
-				}
-			);
+				},
+			});
 
 			expect(() => policy.assert('tasks.wp')).toThrow(
 				'Policy "tasks.wp" denied.'
@@ -154,7 +156,9 @@ describe('policy environment edge cases', () => {
 		jest.isolateModules(() => {
 			const { definePolicy } = loadPolicyModule();
 			const policy = definePolicy<{ 'tasks.invalid': void }>({
-				'tasks.invalid': () => 'nope' as unknown as boolean,
+				map: {
+					'tasks.invalid': () => 'nope' as unknown as boolean,
+				},
 			});
 
 			expect(() => policy.can('tasks.invalid')).toThrow(
@@ -167,7 +171,9 @@ describe('policy environment edge cases', () => {
 		jest.isolateModules(() => {
 			const { definePolicy } = loadPolicyModule();
 			const policy = definePolicy<{ 'tasks.manage': void }>({
-				'tasks.manage': () => true,
+				map: {
+					'tasks.manage': () => true,
+				},
 			});
 
 			policy.extend({
@@ -186,13 +192,13 @@ describe('policy environment edge cases', () => {
 			const policy = definePolicy<{
 				'tasks.scalar': string;
 				'tasks.object': { reason: string };
-			}>(
-				{
+			}>({
+				map: {
 					'tasks.scalar': () => false,
 					'tasks.object': () => false,
 				},
-				{ namespace: 'acme' }
-			);
+				options: { namespace: 'acme' },
+			});
 
 			try {
 				policy.assert('tasks.scalar', 'blocked');
@@ -242,12 +248,14 @@ describe('policy environment edge cases', () => {
 			const { definePolicy } = loadPolicyModule();
 
 			const policy = definePolicy<{ 'tasks.reporter': void }>({
-				'tasks.reporter': ({ reporter }: PolicyContext) => {
-					reporter?.info('info');
-					reporter?.warn('warn');
-					reporter?.error('error');
-					reporter?.debug?.('debug');
-					return true;
+				map: {
+					'tasks.reporter': ({ reporter }: PolicyContext) => {
+						reporter?.info('info');
+						reporter?.warn('warn');
+						reporter?.error('error');
+						reporter?.debug?.('debug');
+						return true;
+					},
 				},
 			});
 
@@ -281,8 +289,8 @@ describe('policy environment edge cases', () => {
 		jest.isolateModules(() => {
 			const { definePolicy } = loadPolicyModule();
 
-			const policy = definePolicy<{ 'tasks.reporter': void }>(
-				{
+			const policy = definePolicy<{ 'tasks.reporter': void }>({
+				map: {
 					'tasks.reporter': ({ reporter }: PolicyContext) => {
 						reporter?.info('inform', { id: 1 });
 						reporter?.warn('warn', { id: 2 });
@@ -291,8 +299,8 @@ describe('policy environment edge cases', () => {
 						return true;
 					},
 				},
-				{ debug: true }
-			);
+				options: { debug: true },
+			});
 
 			expect(policy.can('tasks.reporter')).toBe(true);
 		});
@@ -324,9 +332,11 @@ describe('policy environment edge cases', () => {
 			const { definePolicy } = loadPolicyModule();
 
 			const policy = definePolicy<{ 'tasks.wp': void }>({
-				'tasks.wp': ({ adapters }: PolicyContext) => {
-					expect(adapters.wp).toBeUndefined();
-					return true;
+				map: {
+					'tasks.wp': ({ adapters }: PolicyContext) => {
+						expect(adapters.wp).toBeUndefined();
+						return true;
+					},
 				},
 			});
 
@@ -347,12 +357,14 @@ describe('policy environment edge cases', () => {
 			const { definePolicy } = loadPolicyModule();
 
 			const policy = definePolicy<{ 'tasks.wp': void }>({
-				'tasks.wp': ({ adapters }: PolicyContext) => {
-					const allowed = adapters.wp?.canUser?.('read', {
-						path: '/wp-json',
-					});
-					expect(allowed).toBe(false);
-					return true;
+				map: {
+					'tasks.wp': ({ adapters }: PolicyContext) => {
+						const allowed = adapters.wp?.canUser?.('read', {
+							path: '/wp-json',
+						});
+						expect(allowed).toBe(false);
+						return true;
+					},
 				},
 			});
 
@@ -369,7 +381,9 @@ describe('policy environment edge cases', () => {
 
 			const { definePolicy } = loadPolicyModule();
 			const policy = definePolicy<{ 'tasks.deny': void }>({
-				'tasks.deny': () => false,
+				map: {
+					'tasks.deny': () => false,
+				},
 			});
 
 			expect(() => policy.assert('tasks.deny')).toThrow(
@@ -393,7 +407,9 @@ describe('policy environment edge cases', () => {
 			try {
 				const { definePolicy } = loadPolicyModule();
 				const policy = definePolicy<{ 'tasks.deny': void }>({
-					'tasks.deny': () => false,
+					map: {
+						'tasks.deny': () => false,
+					},
 				});
 
 				expect(() => policy.assert('tasks.deny')).toThrow(

--- a/packages/kernel/src/policy/index.ts
+++ b/packages/kernel/src/policy/index.ts
@@ -6,6 +6,7 @@ export type {
 	PolicyMap,
 	PolicyHelpers,
 	PolicyOptions,
+	PolicyDefinitionConfig,
 	PolicyContext,
 	PolicyCache,
 	PolicyCacheOptions,

--- a/packages/kernel/src/policy/types.ts
+++ b/packages/kernel/src/policy/types.ts
@@ -134,7 +134,8 @@ export type PolicyCache = {
  * ```typescript
  * // Using WordPress adapter in policy rule
  * const policy = definePolicy({
- *   'posts.edit': async (ctx, postId: number) => {
+ *   map: {
+ *     'posts.edit': async (ctx, postId: number) => {
  *     // ctx.adapters.wp is auto-injected
  *     const result = await ctx.adapters.wp?.canUser('update', {
  *       kind: 'postType',
@@ -148,11 +149,14 @@ export type PolicyCache = {
  * @example
  * ```typescript
  * // Custom adapter for REST endpoint probing
- * const policy = definePolicy(rules, {
- *   adapters: {
- *     restProbe: async (key) => {
- *       const res = await fetch(`/wp-json/acme/v1/capabilities/${key}`);
- *       return res.ok;
+ * const policy = definePolicy({
+ *   map: rules,
+ *   options: {
+ *     adapters: {
+ *       restProbe: async (key) => {
+ *         const res = await fetch(`/wp-json/acme/v1/capabilities/${key}`);
+ *         return res.ok;
+ *       }
  *     }
  *   }
  * });
@@ -223,6 +227,14 @@ export type PolicyOptions = {
 	adapters?: PolicyAdapters;
 	cache?: PolicyCacheOptions;
 	debug?: boolean;
+};
+
+/**
+ * Configuration object accepted by `definePolicy()`.
+ */
+export type PolicyDefinitionConfig<K extends Record<string, unknown>> = {
+	map: PolicyMap<K>;
+	options?: PolicyOptions;
 };
 
 /**


### PR DESCRIPTION
## Summary
- migrate defineAction() to accept configuration objects and adjust runtime validation
- update definePolicy() to use config-based signatures and refresh associated helpers/tests
- refresh documentation and changelog entries to highlight the new API shape

## Testing
- pnpm build
- pnpm typecheck
- pnpm typecheck:tests
- pnpm test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68e68ebb1ef08325bcf74a799f06e08b