### PR TITLE
Sprint 2: Kernel UI runtime integration

### DIFF
--- a/Architecture Implementation Phases.md
+++ b/Architecture Implementation Phases.md
@@ -97,11 +97,10 @@ Legacy globals and side-effect modules are removed outright.
 - Complete the "Summary of work done below"
 
 **Summary of work done**
-Introduced the adapter-driven integration (`attachUIBindings`, `KernelUIProvider`),
-updated UI tests and documentation, and recorded the breaking-change guidance in
-the package changelog. Legacy globals (`__WP_KERNEL_UI_ATTACH_RESOURCE_HOOKS__`
-and the cached dispatch bridge) remain in place pending the deeper rewire slated
-for Phase 3, so they are intentionally documented as follow-up work.
+Implemented the adapter-driven integration (`attachUIBindings`, `KernelUIProvider`,
+`useKernelUI`), removed the legacy globals and side-effect module, refactored UI
+hooks/tests to require the runtime, updated showcase bootstrap to pass the
+adapter, and refreshed documentation/changelogs to describe the breaking change.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,12 @@ pnpm add @geekist/wp-kernel
 
 ```ts
 import { configureKernel } from '@geekist/wp-kernel';
+import { attachUIBindings } from '@geekist/wp-kernel-ui';
 
 const kernel = configureKernel({
 	registry: window.wp.data,
 	namespace: 'my-plugin',
+	ui: { attach: attachUIBindings },
 });
 
 kernel.emit('my-plugin.ready', { timestamp: Date.now() });

--- a/app/showcase/src/admin/index.tsx
+++ b/app/showcase/src/admin/index.tsx
@@ -9,6 +9,8 @@
  */
 
 import { createRoot } from '@wordpress/element';
+import { KernelUIProvider } from '@geekist/wp-kernel-ui';
+import type { KernelUIRuntime } from '@geekist/wp-kernel/data';
 import { JobsList } from './pages/JobsList';
 
 /**
@@ -22,8 +24,9 @@ function App(): JSX.Element {
  * Mount the admin application
  *
  * Called by main index.ts when #wpk-admin-root is detected.
+ * @param runtime
  */
-export function mountAdmin() {
+export function mountAdmin(runtime: KernelUIRuntime) {
 	const rootElement = document.getElementById('wpk-admin-root');
 
 	if (!rootElement) {
@@ -35,5 +38,9 @@ export function mountAdmin() {
 
 	// Create React root and render the application
 	const root = createRoot(rootElement);
-	root.render(<App />);
+	root.render(
+		<KernelUIProvider runtime={runtime}>
+			<App />
+		</KernelUIProvider>
+	);
 }

--- a/app/showcase/src/index.ts
+++ b/app/showcase/src/index.ts
@@ -4,9 +4,9 @@
  * Initializes the Kernel runtime and mounts admin UI.
  */
 
-import '@geekist/wp-kernel-ui';
 import { configureKernel } from '@geekist/wp-kernel';
 import type { KernelRegistry } from '@geekist/wp-kernel';
+import { attachUIBindings } from '@geekist/wp-kernel-ui';
 import { mountAdmin } from './admin';
 import { job } from './resources';
 import { ShowcaseActionError } from './errors/ShowcaseActionError';
@@ -30,7 +30,12 @@ export function init(): void {
 	}
 
 	// Initialize WP Kernel runtime (middleware + events plugin)
-	configureKernel({ registry: globalWindow.wp.data as KernelRegistry });
+	const kernel = configureKernel({
+		registry: globalWindow.wp.data as KernelRegistry,
+		ui: { attach: attachUIBindings },
+	});
+
+	const runtime = kernel.getUIRuntime();
 
 	try {
 		// Trigger lazy store registration and warm initial data.
@@ -48,7 +53,13 @@ export function init(): void {
 
 	const adminRoot = document.getElementById('wpk-admin-root');
 	if (adminRoot) {
-		mountAdmin();
+		if (!runtime) {
+			console.warn(
+				'[WP Kernel Showcase] UI runtime unavailable. Ensure attachUIBindings is configured.'
+			);
+			return;
+		}
+		mountAdmin(runtime);
 	}
 }
 

--- a/packages/kernel/src/data/index.ts
+++ b/packages/kernel/src/data/index.ts
@@ -7,4 +7,8 @@ export type {
 	ConfigureKernelOptions,
 	KernelInstance,
 	KernelUIConfig,
+	KernelUIRuntime,
+	KernelUIAttach,
+	UIIntegrationOptions,
+	KernelUIPolicyRuntime,
 } from './types';

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -164,6 +164,10 @@ export type {
 	ConfigureKernelOptions,
 	KernelInstance,
 	KernelUIConfig,
+	KernelUIRuntime,
+	KernelUIAttach,
+	UIIntegrationOptions,
+	KernelUIPolicyRuntime,
 	NoticeStatus,
 } from './data/index.js';
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -11,6 +11,9 @@
  */
 export const VERSION = '0.3.0';
 
+export { attachUIBindings, KernelUIProvider, useKernelUI } from './runtime';
+export type { KernelUIProviderProps } from './runtime';
+
 // Hooks migrated from kernel
 export { usePolicy } from './hooks/usePolicy';
 export {

--- a/packages/ui/src/runtime/attachUIBindings.ts
+++ b/packages/ui/src/runtime/attachUIBindings.ts
@@ -1,0 +1,68 @@
+import type {
+	KernelInstance,
+	KernelUIRuntime,
+	KernelUIAttach,
+	UIIntegrationOptions,
+} from '@geekist/wp-kernel/data';
+import {
+	getRegisteredResources,
+	type ResourceDefinedEvent,
+} from '@geekist/wp-kernel';
+import type { ResourceObject } from '@geekist/wp-kernel/resource';
+import { attachResourceHooks } from '../hooks/resource-hooks';
+
+type RuntimePolicy = NonNullable<KernelUIRuntime['policies']>['policy'];
+
+function resolvePolicyRuntime(): KernelUIRuntime['policies'] {
+	const runtime = (
+		globalThis as {
+			__WP_KERNEL_ACTION_RUNTIME__?: { policy?: RuntimePolicy };
+		}
+	).__WP_KERNEL_ACTION_RUNTIME__;
+
+	if (!runtime?.policy) {
+		return undefined;
+	}
+
+	return { policy: runtime.policy };
+}
+
+function attachExistingResources(
+	runtime: KernelUIRuntime,
+	resources: ResourceDefinedEvent[]
+): void {
+	resources.forEach((event) => {
+		attachResourceHooks(
+			event.resource as ResourceObject<unknown, unknown>,
+			runtime
+		);
+	});
+}
+
+export const attachUIBindings: KernelUIAttach = (
+	kernel: KernelInstance,
+	options?: UIIntegrationOptions
+): KernelUIRuntime => {
+	const runtime: KernelUIRuntime = {
+		kernel,
+		namespace: kernel.getNamespace(),
+		reporter: kernel.getReporter(),
+		registry: kernel.getRegistry(),
+		events: kernel.events,
+		policies: resolvePolicyRuntime(),
+		invalidate: (patterns, invalidateOptions) =>
+			kernel.invalidate(patterns, invalidateOptions),
+		options,
+	};
+
+	attachExistingResources(runtime, getRegisteredResources());
+
+	runtime.events.on('resource:defined', ({ resource }) => {
+		attachResourceHooks(
+			resource as ResourceObject<unknown, unknown>,
+			runtime
+		);
+	});
+
+	return runtime;
+};

--- a/packages/ui/src/runtime/context.tsx
+++ b/packages/ui/src/runtime/context.tsx
@@ -1,0 +1,30 @@
+/* @jsxImportSource react */
+import { createContext, useContext, type ReactNode } from 'react';
+import { KernelError } from '@geekist/wp-kernel/error';
+import type { KernelUIRuntime } from '@geekist/wp-kernel/data';
+
+const KernelUIContext = createContext<KernelUIRuntime | null>(null);
+
+export interface KernelUIProviderProps {
+	runtime: KernelUIRuntime;
+	children: ReactNode;
+}
+
+export function KernelUIProvider({ runtime, children }: KernelUIProviderProps) {
+	return (
+		<KernelUIContext.Provider value={runtime}>
+			{children}
+		</KernelUIContext.Provider>
+	);
+}
+
+export function useKernelUI(): KernelUIRuntime {
+	const runtime = useContext(KernelUIContext);
+	if (!runtime) {
+		throw new KernelError('DeveloperError', {
+			message:
+				'Kernel UI runtime unavailable. Attach UI bindings via configureKernel({ ui: { attach } }) and wrap your React tree with <KernelUIProvider />.',
+		});
+	}
+	return runtime;
+}

--- a/packages/ui/src/runtime/index.ts
+++ b/packages/ui/src/runtime/index.ts
@@ -1,0 +1,3 @@
+export { attachUIBindings } from './attachUIBindings';
+export { KernelUIProvider, useKernelUI } from './context';
+export type { KernelUIProviderProps } from './context';


### PR DESCRIPTION
## Summary
- add kernel runtime tracking APIs so configureKernel can report and attach UI adapters
- introduce the KernelUIProvider/attachUIBindings runtime and update UI hooks plus tests to consume it
- update showcase bootstrap, README, and implementation notes for the adapter-driven UI wiring

## Testing
- `pnpm lint --fix`
- `pnpm typecheck`
- `pnpm typecheck:tests`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68e6b3af73dc8325be9875ec60747170