### PR TITLE
Sprint 5: Reporter Telemetry Integration

### DIFF
--- a/app/showcase/__tests__/build-verification/imports.test.ts
+++ b/app/showcase/__tests__/build-verification/imports.test.ts
@@ -37,7 +37,7 @@ describe('Build: Monorepo package imports', () => {
 		// (vs 100KB+ when bundling WordPress packages)
 		expect(bundle.length).toBeGreaterThan(15000); // Should contain kernel code
 		// Reporter instrumentation increases bundle size slightly but should stay well below 60KB
-		expect(bundle.length).toBeLessThan(58000); // But not bundle WordPress
+		expect(bundle.length).toBeLessThan(60000); // But not bundle WordPress
 	});
 
 	it('should NOT bundle WordPress packages', () => {

--- a/docs/api/generated/http/type-aliases/TransportMeta.md
+++ b/docs/api/generated/http/type-aliases/TransportMeta.md
@@ -1,0 +1,35 @@
+[**WP Kernel API v0.3.0**](../../README.md)
+
+---
+
+[WP Kernel API](../../README.md) / [http](../README.md) / TransportMeta
+
+# Type Alias: TransportMeta
+
+```ts
+type TransportMeta = object;
+```
+
+## Properties
+
+### reporter?
+
+```ts
+optional reporter: Reporter;
+```
+
+---
+
+### namespace?
+
+```ts
+optional namespace: string;
+```
+
+---
+
+### resourceName?
+
+```ts
+optional resourceName: string;
+```

--- a/docs/guide/reporting.md
+++ b/docs/guide/reporting.md
@@ -82,6 +82,18 @@ const kernel = configureKernel({
 
 Call `kernel.teardown()` when hot reloading or tearing down tests to remove middleware and hook listeners.
 
+## Resource telemetry
+
+Resources now emit cache and transport logs through the same reporter tree. When you
+call `resource.invalidate()` the framework records `cache.invalidate.request` and
+`cache.invalidate.summary` events (along with match/miss debug entries) using a
+kernel-scoped reporter child. Transport operations inherit the reporter metadata as
+well, so `fetchList`, `fetch`, `create`, `update`, and `remove` generate
+`transport.request`, `transport.response`, or `transport.error` messages with
+correlated request IDs. Forward the reporter to your logging pipeline (Sentry,
+Datadog, etc.) to correlate cache invalidations and REST requests with upstream
+actions and policies.
+
 ## Linting: no console in kernel
 
 `console.*` calls are forbidden in `packages/kernel/src` outside the reporter module. Use the reporter everywhere else. The ESLint

--- a/docs/guide/resources.md
+++ b/docs/guide/resources.md
@@ -84,6 +84,14 @@ resources fall back to a deterministic console reporter so local development sti
 surfaces debug output. You can access the reporter via `resource.reporter` or supply
 your own implementation through the `reporter` option.
 
+Cache utilities participate in the same hierarchy. Calling `resource.invalidate()` or
+the grouped `cache.invalidate.*` helpers emits `cache.invalidate.request` and
+`cache.invalidate.summary` messages (plus match/miss debug logs) using the resource's
+reporter, giving you visibility into which cache keys were touched. Transport requests
+inherit the reporter too, so every `fetchList`, `fetch`, `create`, and `remove` call
+produces `transport.request`, `transport.response`, or `transport.error` entries with
+correlation IDs that downstream observability tooling can consume.
+
 ## Configuration
 
 ### Required Properties

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -23,6 +23,9 @@
 - Resource reporters inherit from the kernel instance. Client methods and store
   resolvers emit structured `debug`/`info`/`error` logs and every resource now
   exposes a `reporter` property for custom instrumentation.
+- Cache invalidation helpers and the transport layer accept reporter metadata,
+  emitting `cache.invalidate.*` and `transport.*` events with kernel-scoped
+  defaults so cache/REST lifecycles share correlation IDs.
 
 ### Technical Details
 

--- a/packages/kernel/src/data/__tests__/configure-kernel.test.ts
+++ b/packages/kernel/src/data/__tests__/configure-kernel.test.ts
@@ -20,6 +20,9 @@ jest.mock('../../actions/middleware', () => ({
 
 jest.mock('../../reporter', () => ({
 	createReporter: jest.fn(),
+	setKernelReporter: jest.fn(),
+	getKernelReporter: jest.fn(() => undefined),
+	clearKernelReporter: jest.fn(),
 }));
 
 jest.mock('../plugins/events', () => ({
@@ -152,15 +155,29 @@ describe('configureKernel', () => {
 		const patterns = ['post', 'list'];
 
 		kernel.invalidate(patterns);
-		expect(invalidateCache).toHaveBeenCalledWith(patterns, {
-			registry,
-		});
+		expect(invalidateCache).toHaveBeenCalledWith(
+			patterns,
+			expect.objectContaining({
+				registry,
+				namespace: 'acme',
+				reporter: expect.objectContaining({
+					child: expect.any(Function),
+				}),
+			})
+		);
 
 		kernel.invalidate(patterns, { emitEvent: false });
-		expect(invalidateCache).toHaveBeenCalledWith(patterns, {
-			emitEvent: false,
-			registry,
-		});
+		expect(invalidateCache).toHaveBeenCalledWith(
+			patterns,
+			expect.objectContaining({
+				emitEvent: false,
+				registry,
+				namespace: 'acme',
+				reporter: expect.objectContaining({
+					child: expect.any(Function),
+				}),
+			})
+		);
 	});
 
 	it('emits custom events through the event bus', () => {

--- a/packages/kernel/src/http/index.ts
+++ b/packages/kernel/src/http/index.ts
@@ -15,6 +15,7 @@ export type {
 	HttpMethod,
 	TransportRequest,
 	TransportResponse,
+	TransportMeta,
 	ResourceRequestEvent,
 	ResourceResponseEvent,
 	ResourceErrorEvent,

--- a/packages/kernel/src/http/types.ts
+++ b/packages/kernel/src/http/types.ts
@@ -5,10 +5,18 @@
  * used by the resource client.
  */
 
+import type { Reporter } from '../reporter';
+
 /**
  * HTTP methods supported by the transport layer
  */
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export type TransportMeta = {
+	reporter?: Reporter;
+	namespace?: string;
+	resourceName?: string;
+};
 
 /**
  * Request options for transport.fetch()
@@ -44,6 +52,11 @@ export type TransportRequest = {
 	 * Custom request ID for correlation (generated if not provided)
 	 */
 	requestId?: string;
+
+	/**
+	 * Metadata used for reporter instrumentation.
+	 */
+	meta?: TransportMeta;
 };
 
 /**

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -75,6 +75,7 @@ export type {
 	HttpMethod,
 	TransportRequest,
 	TransportResponse,
+	TransportMeta,
 	ResourceRequestEvent,
 	ResourceResponseEvent,
 	ResourceErrorEvent,
@@ -191,7 +192,13 @@ export type {
 } from './events/bus';
 
 // Reporter
-export { createReporter, createNoopReporter } from './reporter/index.js';
+export {
+	createReporter,
+	createNoopReporter,
+	getKernelReporter,
+	setKernelReporter,
+	clearKernelReporter,
+} from './reporter/index.js';
 export type {
 	Reporter,
 	ReporterOptions,

--- a/packages/kernel/src/reporter/__tests__/context.test.ts
+++ b/packages/kernel/src/reporter/__tests__/context.test.ts
@@ -1,0 +1,49 @@
+import {
+	getKernelReporter,
+	setKernelReporter,
+	clearKernelReporter,
+} from '../index';
+import type { Reporter } from '../types';
+
+describe('reporter context', () => {
+	afterEach(() => {
+		clearKernelReporter();
+	});
+
+	it('returns undefined when no reporter set', () => {
+		expect(getKernelReporter()).toBeUndefined();
+	});
+
+	it('stores and retrieves reporter instances', () => {
+		const reporter: Reporter = {
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn(),
+			child: jest.fn().mockReturnValue({
+				info: jest.fn(),
+				warn: jest.fn(),
+				error: jest.fn(),
+				debug: jest.fn(),
+				child: jest.fn(),
+			} as unknown as Reporter),
+		};
+
+		setKernelReporter(reporter);
+		expect(getKernelReporter()).toBe(reporter);
+	});
+
+	it('clears reporter when requested', () => {
+		const reporter: Reporter = {
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn(),
+			child: jest.fn(),
+		};
+
+		setKernelReporter(reporter);
+		clearKernelReporter();
+		expect(getKernelReporter()).toBeUndefined();
+	});
+});

--- a/packages/kernel/src/reporter/context.ts
+++ b/packages/kernel/src/reporter/context.ts
@@ -1,0 +1,15 @@
+import type { Reporter } from './types';
+
+let kernelReporter: Reporter | undefined;
+
+export function setKernelReporter(reporter: Reporter | undefined): void {
+	kernelReporter = reporter;
+}
+
+export function getKernelReporter(): Reporter | undefined {
+	return kernelReporter;
+}
+
+export function clearKernelReporter(): void {
+	kernelReporter = undefined;
+}

--- a/packages/kernel/src/reporter/index.ts
+++ b/packages/kernel/src/reporter/index.ts
@@ -115,3 +115,8 @@ export function createNoopReporter(): Reporter {
 }
 
 export type { Reporter, ReporterOptions, ReporterLevel } from './types';
+export {
+	getKernelReporter,
+	setKernelReporter,
+	clearKernelReporter,
+} from './context';

--- a/packages/kernel/src/resource/__tests__/reporter-instrumentation.test.ts
+++ b/packages/kernel/src/resource/__tests__/reporter-instrumentation.test.ts
@@ -65,6 +65,14 @@ describe('resource reporters', () => {
 
 		await resource.fetchList!({ search: 'test' });
 
+		expect(transportFetch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				meta: expect.objectContaining({
+					reporter,
+					resourceName: 'thing',
+				}),
+			})
+		);
 		expect(logs).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
@@ -169,6 +177,14 @@ describe('resource reporters', () => {
 		const item = await resource.fetch!(7);
 
 		expect(item).toEqual({ id: 7 });
+		expect(transportFetch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				meta: expect.objectContaining({
+					reporter,
+					resourceName: 'thing',
+				}),
+			})
+		);
 		expect(logs).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({

--- a/packages/kernel/src/resource/define.ts
+++ b/packages/kernel/src/resource/define.ts
@@ -191,7 +191,10 @@ export function defineResource<T = unknown, TQuery = unknown>(
 	});
 
 	// Create client methods using original config (for routes)
-	const client = createClient<T, TQuery>(config, reporter);
+	const client = createClient<T, TQuery>(config, reporter, {
+		namespace,
+		resourceName,
+	});
 
 	// Create or use provided cache keys
 	const cacheKeys: Required<CacheKeys> = {
@@ -205,6 +208,7 @@ export function defineResource<T = unknown, TQuery = unknown>(
 
 	// Build resource object
 	const storeReporter = reporter.child('store');
+	const cacheReporter = reporter.child('cache');
 
 	const resource: ResourceObject<T, TQuery> = {
 		...client,
@@ -343,8 +347,12 @@ export function defineResource<T = unknown, TQuery = unknown>(
 
 		// Thin-flat API: Cache management
 		invalidate: (patterns: CacheKeyPattern | CacheKeyPattern[]) => {
-			// Call global invalidate with resource context
-			globalInvalidate(patterns, { storeKey: resource.storeKey });
+			globalInvalidate(patterns, {
+				storeKey: resource.storeKey,
+				reporter: cacheReporter,
+				namespace,
+				resourceName,
+			});
 		},
 
 		key: (

--- a/packages/kernel/src/resource/grouped-api.ts
+++ b/packages/kernel/src/resource/grouped-api.ts
@@ -187,6 +187,9 @@ export function createCacheGetter<T, TQuery>(
 					// Invalidate all cache keys for this resource
 					globalInvalidate([[config.name]], {
 						storeKey: this.storeKey,
+						reporter: this.reporter.child('cache'),
+						namespace: this.storeKey.split('/')[0],
+						resourceName: this.name,
 					});
 				},
 			},


### PR DESCRIPTION
## Summary

Sprint 5: Reporter Telemetry Integration — resource cache and transport reporters.

**Sprint:** Norms (Phase 9 Reporter Integration)
**Scope:** data · resource · reporter · http · docs · app

## Links

- Roadmap section: <!-- TODO -->
- Sprint doc / spec: [Resource Reporter Integration](./Resource%20Reporter%20Integration.md)
- Related issues: <!-- #123, #456 -->
- Demo/preview (if any): <!-- URL -->

## Why

Phase 9 requires kernel resources, cache helpers, and transport requests to emit structured telemetry so cache invalidations and REST calls can be correlated through shared reporters.

## What

- Store the kernel reporter during `configureKernel()` and scope resource reporters and cache invalidation logs from it.
- Thread reporter metadata from `defineResource()` into clients, cache helpers, and grouped APIs so cache + transport operations emit `cache.invalidate.*` and `transport.*` events.
- Extend the HTTP transport with metadata-aware reporters and document the new telemetry flow alongside changelog updates and showcase bundle guard adjustments.

## How

- Added a reporter context module to persist the kernel reporter for transport/cache fallbacks and wrapped cleanup in kernel teardown.
- Updated resource/client/cache layers to derive child reporters per operation and pass metadata into transport requests.
- Enhanced docs/spec and bundle-size guard to reflect the broader reporter footprint and prevent regression noise.

## Testing

How reviewers test locally:

1. `pnpm --filter @geekist/wp-kernel test`
   **Expected:** Jest suite passes with coverage ≥ required thresholds.
2. `pnpm build`
   **Expected:** Workspace packages and docs build without errors.

### Test Matrix (tick what’s covered)

- [x] Unit (pnpm test)
- [ ] E2E (pnpm e2e)
- [x] Types (pnpm typecheck)
- [x] Docs examples (build/run)
- [ ] WordPress playground / wp-env sanity

## Screenshots / Recordings (if applicable)

n/a

## Breaking Changes

- [x] None

## Affected Packages

Tick any public packages this PR changes functionally.

- [x] `@geekist/wp-kernel`
- [ ] `@geekist/wp-kernel-ui`
- [ ] `@geekist/wp-kernel-cli`
- [ ] `@geekist/wp-kernel-e2e-utils`

## Release

Choose one and document in CHANGELOG.md files.

- [ ] **patch** — bugfixes / alignment (0.x.1)
- [x] **minor** — feature sprint (default) (0.x.0)
- [ ] **major** — breaking API (x.0.0)

## Checklist

- [x] Tests pass (`pnpm test`, where relevant: `pnpm e2e`)
- [ ] Lint passes (`pnpm lint`)
- [x] Types pass (`pnpm typecheck`, `pnpm typecheck:tests`)
- [x] CHANGELOG.md updated in affected packages (or PR labelled `no-release`)
- [x] Docs updated (site/README)
- [ ] Examples updated (if API changed)