### PR TITLE
fix(cli): harden structuredClone fallback handling

### DIFF
--- a/packages/cli/src/adapters/extensions.ts
+++ b/packages/cli/src/adapters/extensions.ts
@@ -159,14 +159,19 @@ export async function runAdapterExtensions(
 
 function cloneIr(ir: IRv1): IRv1 {
 	if (typeof globalThis.structuredClone === 'function') {
-		return globalThis.structuredClone(ir) as IRv1;
+		try {
+			return globalThis.structuredClone(ir) as IRv1;
+		} catch (_error) {
+			// When structuredClone throws (e.g. because a polyfill is
+			// unavailable), fall back to the JSON-based approach below.
+		}
 	}
 
-	// Fallback to JSON cloning when structuredClone is unavailable. Our IR
-	// graphs contain only plain objects/arrays/primitives, so JSON
-	// serialisation preserves the required data while keeping the fallback
-	// dependency-free. If richer types are introduced in the future, this
-	// should be revisited.
+	// Fallback to JSON cloning when structuredClone is unavailable or
+	// throws. Our IR graphs contain only plain objects/arrays/primitives, so
+	// JSON serialisation preserves the required data while keeping the
+	// fallback dependency-free. If richer types are introduced in the
+	// future, this should be revisited.
 	return JSON.parse(JSON.stringify(ir)) as IRv1;
 }
 


### PR DESCRIPTION
## Summary
- guard adapter IR cloning against structuredClone failures by falling back to JSON cloning
- update adapter extension fallback test to use a jest spy instead of mutating the global structuredClone

## Testing
- pnpm --filter @geekist/wp-kernel-cli test

------
https://chatgpt.com/codex/tasks/task_e_68e88c305cc083258c57d6801372d422