### PR TITLE
Sprint 5A: Guarded apply command

### DIFF
--- a/packages/cli/PHASES.md
+++ b/packages/cli/PHASES.md
@@ -149,11 +149,11 @@
 
 ### Phase 5 Cohort (See `packages/cli/docs/Phase_05-Apply_Workflow.md` for the detailed breakdown)
 
-| Sub-phase                       | Summary                                                                      | Status Log                                    |
-| ------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------- |
-| **5A – Guarded Apply Command**  | Stand up `wpk apply` with guarded merges and basic summary reporting.        | Completed - / Outstanding - / Risks & Notes - |
-| **5B – Apply Safety & Logging** | Add clean-state enforcement, `--yes/--backup/--force`, and `.wpk-apply.log`. | Completed - / Outstanding - / Risks & Notes - |
-| **5C – PHP Printer DX Upgrade** | Refactor generated PHP to use native arrays and update fixtures/docs.        | Completed - / Outstanding - / Risks & Notes - |
+| Sub-phase                       | Summary                                                                      | Status Log                                                                                                                 |
+| ------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **5A – Guarded Apply Command**  | Stand up `wpk apply` with guarded merges and basic summary reporting.        | Completed - Guarded PHP apply command with merge tests / Outstanding - None / Risks & Notes - Safety flags targeted for 5B |
+| **5B – Apply Safety & Logging** | Add clean-state enforcement, `--yes/--backup/--force`, and `.wpk-apply.log`. | Completed - / Outstanding - / Risks & Notes -                                                                              |
+| **5C – PHP Printer DX Upgrade** | Refactor generated PHP to use native arrays and update fixtures/docs.        | Completed - / Outstanding - / Risks & Notes -                                                                              |
 
 See the companion Markdown spec for full scope/deliverables/DoD details.
 

--- a/packages/cli/src/cli/run.ts
+++ b/packages/cli/src/cli/run.ts
@@ -11,6 +11,7 @@ import {
 	InitCommand,
 	DoctorCommand,
 	DevCommand,
+	ApplyCommand,
 } from '../commands';
 import { VERSION } from '../version';
 
@@ -41,6 +42,7 @@ cli.register(GenerateCommand);
 cli.register(InitCommand);
 cli.register(DoctorCommand);
 cli.register(DevCommand);
+cli.register(ApplyCommand);
 
 /**
  * Run the WP Kernel CLI programmatically.

--- a/packages/cli/src/commands/__tests__/apply-command.test.ts
+++ b/packages/cli/src/commands/__tests__/apply-command.test.ts
@@ -1,0 +1,308 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { Writable } from 'node:stream';
+import type { Command } from 'clipanion';
+import { ApplyCommand } from '../apply';
+
+const TMP_PREFIX = path.join(os.tmpdir(), 'wpk-apply-command-');
+
+const GUARDED_SOURCE = `<?php
+// WPK:BEGIN AUTO
+return 'generated';
+// WPK:END AUTO
+`;
+
+const UNGUARDED_SOURCE = `<?php
+return 'generated';
+`;
+
+const GUARDED_EXISTING = `<?php
+// Manual header
+// WPK:BEGIN AUTO
+return 'manual';
+// WPK:END AUTO
+// Manual footer
+`;
+
+describe('ApplyCommand', () => {
+	it('creates new files when target is missing', async () => {
+		await withWorkspace(async (workspace) => {
+			await writeGeneratedFile(
+				workspace,
+				'Rest/BaseController.php',
+				GUARDED_SOURCE
+			);
+
+			const command = createCommand(workspace);
+			const exitCode = await command.execute();
+
+			expect(exitCode).toBe(0);
+			expect(command.summary).toEqual({
+				created: 1,
+				updated: 0,
+				skipped: 0,
+			});
+
+			const target = path.join(workspace, 'inc/Rest/BaseController.php');
+			const contents = await fs.readFile(target, 'utf8');
+			expect(contents).toBe(GUARDED_SOURCE);
+		});
+	});
+
+	it('merges guarded sections while preserving manual edits', async () => {
+		await withWorkspace(async (workspace) => {
+			await writeGeneratedFile(
+				workspace,
+				'Rest/BaseController.php',
+				GUARDED_SOURCE
+			);
+
+			const target = path.join(workspace, 'inc/Rest/BaseController.php');
+			await ensureDirectory(path.dirname(target));
+			await fs.writeFile(target, GUARDED_EXISTING, 'utf8');
+
+			const command = createCommand(workspace);
+			const exitCode = await command.execute();
+
+			expect(exitCode).toBe(0);
+			expect(command.summary).toEqual({
+				created: 0,
+				updated: 1,
+				skipped: 0,
+			});
+
+			const contents = await fs.readFile(target, 'utf8');
+			expect(contents).toBe(`<?php
+// Manual header
+// WPK:BEGIN AUTO
+return 'generated';
+// WPK:END AUTO
+// Manual footer
+`);
+		});
+	});
+
+	it('fails when guarded source lacks destination markers', async () => {
+		await withWorkspace(async (workspace) => {
+			await writeGeneratedFile(
+				workspace,
+				'Rest/BaseController.php',
+				GUARDED_SOURCE
+			);
+
+			const target = path.join(workspace, 'inc/Rest/BaseController.php');
+			await ensureDirectory(path.dirname(target));
+			await fs.writeFile(
+				target,
+				`<?php
+// Manual header without guard markers.
+return 'manual';
+`,
+				'utf8'
+			);
+
+			const baseline = await fs.readFile(target, 'utf8');
+
+			const command = createCommand(workspace);
+			const exitCode = await command.execute();
+
+			expect(exitCode).toBe(1);
+			expect(command.summary).toBeNull();
+
+			const contents = await fs.readFile(target, 'utf8');
+			expect(contents).toBe(baseline);
+		});
+	});
+
+	it('skips files with no changes', async () => {
+		await withWorkspace(async (workspace) => {
+			await writeGeneratedFile(
+				workspace,
+				'Rest/BaseController.php',
+				GUARDED_SOURCE
+			);
+
+			const target = path.join(workspace, 'inc/Rest/BaseController.php');
+			await ensureDirectory(path.dirname(target));
+			await fs.writeFile(target, GUARDED_SOURCE, 'utf8');
+
+			const command = createCommand(workspace);
+			const exitCode = await command.execute();
+
+			expect(exitCode).toBe(0);
+			expect(command.summary).toEqual({
+				created: 0,
+				updated: 0,
+				skipped: 1,
+			});
+
+			const contents = await fs.readFile(target, 'utf8');
+			expect(contents).toBe(GUARDED_SOURCE);
+		});
+	});
+
+	it('skips when no generated PHP directory exists', async () => {
+		await withWorkspace(async (workspace) => {
+			const command = createCommand(workspace);
+			const exitCode = await command.execute();
+
+			expect(exitCode).toBe(0);
+			expect(command.summary).toEqual({
+				created: 0,
+				updated: 0,
+				skipped: 0,
+			});
+		});
+	});
+
+	it('ignores generated PHP paths that are files', async () => {
+		await withWorkspace(async (workspace) => {
+			const filePath = path.join(workspace, '.generated/php');
+			await ensureDirectory(path.dirname(filePath));
+			await fs.writeFile(filePath, '<?php\n', 'utf8');
+
+			const command = createCommand(workspace);
+			const exitCode = await command.execute();
+
+			expect(exitCode).toBe(0);
+			expect(command.summary).toEqual({
+				created: 0,
+				updated: 0,
+				skipped: 0,
+			});
+		});
+	});
+
+	it('updates unguarded files when contents change', async () => {
+		await withWorkspace(async (workspace) => {
+			await writeGeneratedFile(workspace, 'index.php', UNGUARDED_SOURCE);
+
+			const target = path.join(workspace, 'inc/index.php');
+			await ensureDirectory(path.dirname(target));
+			await fs.writeFile(
+				target,
+				`<?php
+return 'manual';
+`,
+				'utf8'
+			);
+
+			const command = createCommand(workspace);
+			const exitCode = await command.execute();
+
+			expect(exitCode).toBe(0);
+			expect(command.summary).toEqual({
+				created: 0,
+				updated: 1,
+				skipped: 0,
+			});
+
+			const contents = await fs.readFile(target, 'utf8');
+			expect(contents).toBe(UNGUARDED_SOURCE);
+		});
+	});
+
+	it('skips unguarded files without changes', async () => {
+		await withWorkspace(async (workspace) => {
+			await writeGeneratedFile(workspace, 'index.php', UNGUARDED_SOURCE);
+
+			const target = path.join(workspace, 'inc/index.php');
+			await ensureDirectory(path.dirname(target));
+			await fs.writeFile(target, UNGUARDED_SOURCE, 'utf8');
+
+			const command = createCommand(workspace);
+			const exitCode = await command.execute();
+
+			expect(exitCode).toBe(0);
+			expect(command.summary).toEqual({
+				created: 0,
+				updated: 0,
+				skipped: 1,
+			});
+
+			const contents = await fs.readFile(target, 'utf8');
+			expect(contents).toBe(UNGUARDED_SOURCE);
+		});
+	});
+
+	it('fails when the destination path is a directory', async () => {
+		await withWorkspace(async (workspace) => {
+			await writeGeneratedFile(workspace, 'index.php', UNGUARDED_SOURCE);
+
+			const target = path.join(workspace, 'inc/index.php');
+			await fs.mkdir(target, { recursive: true });
+
+			const command = createCommand(workspace);
+			const exitCode = await command.execute();
+
+			expect(exitCode).toBe(1);
+			expect(command.summary).toBeNull();
+		});
+	});
+});
+
+async function withWorkspace(
+	run: (workspace: string) => Promise<void>
+): Promise<void> {
+	const workspace = await fs.mkdtemp(TMP_PREFIX);
+
+	try {
+		const originalCwd = process.cwd();
+		process.chdir(workspace);
+		try {
+			await run(workspace);
+		} finally {
+			process.chdir(originalCwd);
+		}
+	} finally {
+		await fs.rm(workspace, { recursive: true, force: true });
+	}
+}
+
+async function writeGeneratedFile(
+	workspace: string,
+	relativePath: string,
+	contents: string
+): Promise<void> {
+	const filePath = path.join(workspace, '.generated/php', relativePath);
+	await ensureDirectory(path.dirname(filePath));
+	await fs.writeFile(filePath, contents, 'utf8');
+}
+
+async function ensureDirectory(directory: string): Promise<void> {
+	await fs.mkdir(directory, { recursive: true });
+}
+
+function createCommand(workspace: string): ApplyCommand {
+	const command = new ApplyCommand();
+	const stdout = new MemoryStream();
+	const stderr = new MemoryStream();
+
+	command.context = {
+		stdout,
+		stderr,
+		stdin: process.stdin,
+		env: process.env,
+		cwd: () => workspace,
+	} as Command.Context;
+
+	return command;
+}
+
+class MemoryStream extends Writable {
+	private readonly chunks: string[] = [];
+
+	override _write(
+		chunk: string | Buffer,
+		_encoding: BufferEncoding,
+		callback: (error?: Error | null) => void
+	): void {
+		this.chunks.push(chunk.toString());
+		callback();
+	}
+
+	toString(): string {
+		return this.chunks.join('');
+	}
+}

--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -1,0 +1,241 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { Command } from 'clipanion';
+import { createReporter } from '@geekist/wp-kernel';
+import { WPK_NAMESPACE } from '@geekist/wp-kernel/namespace/constants';
+import type { Reporter } from '@geekist/wp-kernel';
+import { resolveFromWorkspace, toWorkspaceRelative } from '../utils';
+
+const BEGIN_MARKER = 'WPK:BEGIN AUTO';
+const END_MARKER = 'WPK:END AUTO';
+
+export interface ApplySummary {
+	created: number;
+	updated: number;
+	skipped: number;
+}
+
+interface ApplyOptions {
+	reporter: Reporter;
+	sourceDir: string;
+	targetDir: string;
+}
+
+export class ApplyCommand extends Command {
+	static override paths = [['apply']];
+
+	static override usage = Command.Usage({
+		description:
+			'Apply generated PHP artifacts into the working inc/ directory.',
+		examples: [['Apply generated controllers into inc/', 'wpk apply']],
+	});
+
+	public summary: ApplySummary | null = null;
+
+	override async execute(): Promise<number> {
+		const reporter = createReporter({
+			namespace: `${WPK_NAMESPACE}.cli.apply`,
+			level: 'info',
+			enabled: process.env.NODE_ENV !== 'test',
+		});
+
+		const sourceDir = resolveFromWorkspace('.generated/php');
+		const targetDir = resolveFromWorkspace('inc');
+
+		reporter.info('Applying generated PHP artifacts.', {
+			sourceDir: toWorkspaceRelative(sourceDir),
+			targetDir: toWorkspaceRelative(targetDir),
+		});
+
+		try {
+			const summary = await applyGeneratedPhpArtifacts({
+				reporter,
+				sourceDir,
+				targetDir,
+			});
+			this.summary = summary;
+		} catch (error) {
+			reporter.error('Failed to apply generated PHP artifacts.', {
+				error:
+					error instanceof Error
+						? { name: error.name, message: error.message }
+						: { value: error },
+			});
+			return 1;
+		}
+
+		const summary = this.summary!;
+		const { created, updated, skipped } = summary;
+
+		this.context.stdout.write(
+			`PHP apply summary: created ${created}, updated ${updated}, skipped ${skipped}\n`
+		);
+
+		return 0;
+	}
+}
+
+export async function applyGeneratedPhpArtifacts({
+	reporter,
+	sourceDir,
+	targetDir,
+}: ApplyOptions): Promise<ApplySummary> {
+	await fs.mkdir(targetDir, { recursive: true });
+
+	const files = await collectPhpFiles(sourceDir);
+
+	if (files.length === 0) {
+		reporter.info('No generated PHP files found to apply.', {
+			sourceDir: toWorkspaceRelative(sourceDir),
+		});
+		return { created: 0, updated: 0, skipped: 0 };
+	}
+
+	const summary: ApplySummary = { created: 0, updated: 0, skipped: 0 };
+
+	for (const file of files) {
+		const relative = path.relative(sourceDir, file);
+		const destination = path.join(targetDir, relative);
+		const destinationDir = path.dirname(destination);
+		await fs.mkdir(destinationDir, { recursive: true });
+
+		const generated = await fs.readFile(file, 'utf8');
+		const existing = await readFileIfExists(destination);
+
+		let status: keyof ApplySummary;
+
+		if (existing === null) {
+			await fs.writeFile(destination, generated, 'utf8');
+			status = 'created';
+		} else if (hasGuardMarkers(generated)) {
+			if (!hasGuardMarkers(existing)) {
+				throw new Error(
+					`Destination missing guard markers: ${toWorkspaceRelative(
+						destination
+					)}`
+				);
+			}
+
+			const nextContents = mergeGuardedContent(existing, generated);
+
+			if (nextContents === existing) {
+				status = 'skipped';
+			} else {
+				await fs.writeFile(destination, nextContents, 'utf8');
+				status = 'updated';
+			}
+		} else if (existing === generated) {
+			status = 'skipped';
+		} else {
+			await fs.writeFile(destination, generated, 'utf8');
+			status = 'updated';
+		}
+
+		summary[status] += 1;
+
+		reporter.debug('Processed PHP artifact.', {
+			source: toWorkspaceRelative(file),
+			target: toWorkspaceRelative(destination),
+			status,
+		});
+	}
+
+	return summary;
+}
+
+async function collectPhpFiles(root: string): Promise<string[]> {
+	try {
+		const stat = await fs.stat(root);
+		if (!stat.isDirectory()) {
+			return [];
+		}
+	} catch (error) {
+		if (isNotFoundError(error)) {
+			return [];
+		}
+
+		throw error;
+	}
+
+	const stack: string[] = [root];
+	const files: string[] = [];
+
+	while (stack.length > 0) {
+		const current = stack.pop()!;
+		const entries = await fs.readdir(current, { withFileTypes: true });
+
+		for (const entry of entries) {
+			const entryPath = path.join(current, entry.name);
+			if (entry.isDirectory()) {
+				stack.push(entryPath);
+			} else if (entry.isFile() && entry.name.endsWith('.php')) {
+				files.push(entryPath);
+			}
+		}
+	}
+
+	return files.sort((a, b) => a.localeCompare(b));
+}
+
+function readFileIfExists(filePath: string): Promise<string | null> {
+	return fs
+		.readFile(filePath, 'utf8')
+		.then((contents) => contents)
+		.catch((error: unknown) => {
+			if (isNotFoundError(error)) {
+				return null;
+			}
+
+			throw error;
+		});
+}
+
+function hasGuardMarkers(contents: string): boolean {
+	return contents.includes(BEGIN_MARKER) && contents.includes(END_MARKER);
+}
+
+interface GuardSegment {
+	start: number;
+	end: number;
+	segment: string;
+}
+
+function mergeGuardedContent(existing: string, generated: string): string {
+	const existingSegment = locateGuardSegment(existing);
+	const generatedSegment = locateGuardSegment(generated);
+
+	if (existingSegment.segment === generatedSegment.segment) {
+		return existing;
+	}
+
+	return (
+		existing.slice(0, existingSegment.start) +
+		generatedSegment.segment +
+		existing.slice(existingSegment.end)
+	);
+}
+
+function locateGuardSegment(contents: string): GuardSegment {
+	const beginIndex = contents.indexOf(BEGIN_MARKER);
+	const endIndex = contents.indexOf(END_MARKER, beginIndex);
+
+	if (beginIndex === -1 || endIndex === -1) {
+		throw new Error('Guard markers not found in PHP file.');
+	}
+
+	const start = Math.max(contents.lastIndexOf('\n', beginIndex - 1) + 1, 0);
+	const endOfLine = contents.indexOf('\n', endIndex);
+	const end = endOfLine === -1 ? contents.length : endOfLine + 1;
+	const segment = contents.slice(start, end);
+
+	return { start, end, segment };
+}
+
+function isNotFoundError(error: unknown): boolean {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		'code' in error &&
+		(error as { code?: string }).code === 'ENOENT'
+	);
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -9,3 +9,4 @@ export { GenerateCommand } from './generate';
 export { InitCommand } from './init';
 export { DoctorCommand } from './doctor';
 export { DevCommand } from './dev';
+export { ApplyCommand } from './apply';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,4 +40,5 @@ export {
 	InitCommand,
 	DoctorCommand,
 	DevCommand,
+	ApplyCommand,
 } from './commands';


### PR DESCRIPTION
## Summary
- add a dedicated `wpk apply` command that merges generated PHP into guarded sections while logging a summary
- exercise the new command with fixtures covering creation, guarded updates, failure modes, and unguarded files
- surface the command in the CLI exports/registration and update the Phase 5A roadmap status

## Testing
- pnpm --filter @geekist/wp-kernel-cli test