### PR TITLE
Fix auto-registered DataView policy accessors

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -39,6 +39,10 @@
   observed (e.g., lazy-loaded plugins). Components won't auto-rerender on late
   registration but will observe new policies on their next render triggered by
   other state changes.
+- Auto-registered `ResourceDataView` controllers now re-resolve policy runtime
+  accessors so that actions gated by policies unlock once `definePolicy()`
+  registers the runtime, avoiding the need for a full refresh when the UI
+  attached before policies were available.
 
 ### Migration Guide
 

--- a/packages/ui/src/dataviews/ResourceDataView.tsx
+++ b/packages/ui/src/dataviews/ResourceDataView.tsx
@@ -635,7 +635,7 @@ function useResolvedController<TItem, TQuery>(
 			runtime: context.dataviews,
 			namespace: context.namespace,
 			invalidate: context.invalidate,
-			policies: context.policies,
+			policies: () => context.policies,
 			fetchList,
 			prefetchList: resource.prefetchList,
 		});

--- a/packages/ui/src/dataviews/__tests__/resource-controller.test.ts
+++ b/packages/ui/src/dataviews/__tests__/resource-controller.test.ts
@@ -1,4 +1,5 @@
 import type { View } from '@wordpress/dataviews';
+import type { KernelUIPolicyRuntime } from '@geekist/wp-kernel/data';
 import type { Reporter } from '@geekist/wp-kernel/reporter';
 import { createResourceDataViewController } from '../resource-controller';
 import { DataViewsControllerError } from '../../runtime/dataviews/errors';
@@ -143,5 +144,27 @@ describe('createResourceDataViewController', () => {
 				sort: { field: 'title', direction: 'desc' },
 			},
 		});
+	});
+
+	it('resolves policies using accessor function', () => {
+		const runtime = createRuntime();
+		const policyRuntime: { current?: KernelUIPolicyRuntime } = {};
+
+		const controller = createResourceDataViewController({
+			resourceName: 'jobs',
+			config,
+			runtime,
+			namespace: 'tests',
+			policies: () => policyRuntime.current,
+		});
+
+		expect(controller.policies).toBeUndefined();
+
+		const policies = {
+			policy: { can: jest.fn() },
+		} as unknown as KernelUIPolicyRuntime;
+		policyRuntime.current = policies;
+
+		expect(controller.policies).toBe(policies);
 	});
 });

--- a/packages/ui/src/dataviews/resource-controller.ts
+++ b/packages/ui/src/dataviews/resource-controller.ts
@@ -216,7 +216,13 @@ export function createResourceDataViewController<TItem, TQuery>(
 		namespace: options.namespace,
 		preferencesKey,
 		invalidate: options.invalidate,
-		policies: options.policies,
+		get policies() {
+			const source = options.policies;
+			if (typeof source === 'function') {
+				return source() ?? undefined;
+			}
+			return source;
+		},
 		fetchList: options.fetchList,
 		prefetchList: options.prefetchList,
 		mapViewToQuery,

--- a/packages/ui/src/dataviews/types.ts
+++ b/packages/ui/src/dataviews/types.ts
@@ -124,6 +124,10 @@ export interface ResourceDataViewConfig<TItem, TQuery> {
 	defaultLayouts?: Record<string, unknown>;
 }
 
+export type KernelUIPolicyRuntimeSource =
+	| KernelUIPolicyRuntime
+	| (() => KernelUIPolicyRuntime | undefined);
+
 export interface ResourceDataViewControllerOptions<TItem, TQuery> {
 	resource?: ResourceObject<TItem, TQuery>;
 	resourceName?: string;
@@ -132,7 +136,7 @@ export interface ResourceDataViewControllerOptions<TItem, TQuery> {
 	runtime: DataViewsControllerRuntime;
 	namespace: string;
 	invalidate?: (patterns: CacheKeyPattern | CacheKeyPattern[]) => void;
-	policies?: KernelUIPolicyRuntime;
+	policies?: KernelUIPolicyRuntimeSource;
 	preferencesKey?: string;
 	fetchList?: (query: TQuery) => Promise<ListResponse<TItem>>;
 	prefetchList?: (query: TQuery) => Promise<void>;

--- a/packages/ui/src/runtime/__tests__/attachUIBindings.test.ts
+++ b/packages/ui/src/runtime/__tests__/attachUIBindings.test.ts
@@ -440,6 +440,35 @@ describe('attachUIBindings', () => {
 		);
 	});
 
+	it('updates auto-registered controllers when policy runtime becomes available', () => {
+		const events = new KernelEventBus();
+		const registry = createPreferencesRegistry();
+		const kernel = createKernel(events, undefined, registry);
+		const resource = createResourceWithDataView();
+
+		mockGetRegisteredResources.mockReturnValueOnce([
+			{ resource, namespace: 'tests' } as ResourceDefinedEvent,
+		]);
+
+		const runtime = attachUIBindings(kernel);
+		const dataviews = runtime.dataviews!;
+		const controller = dataviews.controllers.get('jobs') as {
+			policies?: KernelUIRuntime['policies'];
+		};
+
+		expect(controller).toBeDefined();
+		expect(controller?.policies).toBeUndefined();
+
+		const policy = { can: jest.fn() };
+		(
+			globalThis as {
+				__WP_KERNEL_ACTION_RUNTIME__?: { policy?: unknown };
+			}
+		).__WP_KERNEL_ACTION_RUNTIME__ = { policy };
+
+		expect(controller?.policies).toEqual({ policy });
+	});
+
 	it('auto-registers DataViews controllers for future resources', () => {
 		const events = new KernelEventBus();
 		const registry = createPreferencesRegistry();

--- a/packages/ui/src/runtime/attachUIBindings.ts
+++ b/packages/ui/src/runtime/attachUIBindings.ts
@@ -98,7 +98,7 @@ function registerResourceDataView<TItem, TQuery>(
 			runtime: dataviews,
 			namespace: runtime.namespace,
 			invalidate: runtime.invalidate,
-			policies: runtime.policies,
+			policies: () => runtime.policies,
 			preferencesKey: metadata.preferencesKey,
 			fetchList: resource.fetchList,
 			prefetchList: resource.prefetchList,


### PR DESCRIPTION
## Summary
- resolve policy runtime lazily for auto-registered ResourceDataView controllers to pick up late policy registrations
- allow DataView controller options to accept policy runtime accessors and update runtime/controller integrations accordingly
- document the fix in the UI changelog and add regression coverage for controller/runtime policy resolution

## Testing
- pnpm --filter @geekist/wp-kernel-ui test -- attachUIBindings
- pnpm --filter @geekist/wp-kernel-ui test -- resource-controller