### PR TITLE
Sprint 8: CLI coverage enhancements

### DIFF
--- a/packages/cli/src/config/__tests__/load-kernel-config.test.ts
+++ b/packages/cli/src/config/__tests__/load-kernel-config.test.ts
@@ -7,6 +7,12 @@ import {
 	getConfigOrigin,
 	resolveConfigValue,
 	formatError,
+	createTsLoader,
+	createJsLoader,
+	findUp,
+	fileExists,
+	getTsImport,
+	setCachedTsImport,
 } from '../load-kernel-config';
 import { WPK_CONFIG_SOURCES } from '@geekist/wp-kernel/namespace/constants';
 import { KernelError } from '@geekist/wp-kernel';
@@ -484,6 +490,91 @@ describe('loadKernelConfig helpers', () => {
 
 	it('stringifies unknown errors in formatError', () => {
 		expect(formatError(42)).toBe('42');
+	});
+
+	it('falls back to tsImport when default loader fails', async () => {
+		const defaultLoader = jest
+			.fn()
+			.mockRejectedValue(new Error('default failed'));
+		const tsImport = jest.fn().mockResolvedValue({
+			default: {
+				kernelConfig: {
+					config: { version: 1 },
+				},
+			},
+		});
+
+		const loader = createTsLoader({
+			defaultLoader,
+			tsImportLoader: async () => tsImport,
+		});
+
+		const result = await loader('/tmp/kernel.config.ts', '');
+
+		expect(defaultLoader).toHaveBeenCalled();
+		expect(tsImport).toHaveBeenCalled();
+		expect(result).toEqual({ version: 1 });
+	});
+
+	it('wraps dynamic import failures in createJsLoader', async () => {
+		const loader = createJsLoader(async () => {
+			throw new Error('dynamic import boom');
+		});
+
+		await expect(loader('/tmp/kernel.config.js')).rejects.toMatchObject({
+			code: 'DeveloperError',
+		});
+	});
+
+	it('searches upwards for files until the filesystem root', async () => {
+		const workspaceRoot = await fs.mkdtemp(
+			path.join(os.tmpdir(), TMP_PREFIX)
+		);
+		try {
+			await fs.writeFile(
+				path.join(workspaceRoot, 'composer.json'),
+				createComposerJson('inc/'),
+				'utf8'
+			);
+			const nested = path.join(workspaceRoot, 'nested', 'dir');
+			await fs.mkdir(nested, { recursive: true });
+
+			const found = await findUp(nested, 'composer.json');
+			expect(found && path.basename(found)).toBe('composer.json');
+
+			const missing = await findUp(nested, 'nonexistent.json');
+			expect(missing).toBeNull();
+		} finally {
+			await fs.rm(workspaceRoot, { recursive: true, force: true });
+		}
+	});
+
+	it('checks for file existence using fs access semantics', async () => {
+		const workspaceRoot = await fs.mkdtemp(
+			path.join(os.tmpdir(), TMP_PREFIX)
+		);
+		try {
+			const filePath = path.join(workspaceRoot, 'test.txt');
+			await fs.writeFile(filePath, 'hello', 'utf8');
+
+			await expect(fileExists(filePath)).resolves.toBe(true);
+			await expect(
+				fileExists(path.join(workspaceRoot, 'missing.txt'))
+			).resolves.toBe(false);
+		} finally {
+			await fs.rm(workspaceRoot, { recursive: true, force: true });
+		}
+	});
+
+	it('reuses cached tsImport loaders when preset', async () => {
+		const cached = Promise.resolve(jest.fn());
+		setCachedTsImport(cached);
+
+		const loader = await getTsImport();
+		const resolved = await cached;
+		expect(loader).toBe(resolved);
+
+		setCachedTsImport(null);
 	});
 });
 

--- a/packages/cli/src/config/validate-kernel-config.ts
+++ b/packages/cli/src/config/validate-kernel-config.ts
@@ -45,7 +45,7 @@ const resourceRouteValidator = t.isObject(
 	{ extra: t.isRecord(t.isUnknown()) }
 );
 
-const resourceRoutesValidator = t.cascade(
+export const resourceRoutesValidator = t.cascade(
 	t.isObject(
 		{
 			list: t.isOptional(resourceRouteValidator),
@@ -366,7 +366,7 @@ export function validateKernelConfig(
 	};
 }
 
-function normalizeVersion(
+export function normalizeVersion(
 	version: KernelConfigVersion | undefined,
 	reporter: Reporter,
 	sourcePath: string
@@ -394,7 +394,7 @@ function normalizeVersion(
 	return version;
 }
 
-function runResourceChecks(
+export function runResourceChecks(
 	resourceName: string,
 	resource: ResourceConfig,
 	reporter: Reporter
@@ -442,7 +442,7 @@ function runResourceChecks(
 	}
 }
 
-function formatValidationErrors(
+export function formatValidationErrors(
 	errors: string[] | undefined,
 	sourcePath: string,
 	origin: string

--- a/packages/cli/src/ir/__tests__/block-discovery.helpers.test.ts
+++ b/packages/cli/src/ir/__tests__/block-discovery.helpers.test.ts
@@ -1,0 +1,155 @@
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import { KernelError } from '@geekist/wp-kernel';
+import {
+	discoverBlocks,
+	isOutsideWorkspace,
+	shouldSkipEntry,
+	loadBlockEntry,
+	fileExists,
+} from '../block-discovery';
+
+describe('block discovery helpers', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('skips directories outside the workspace during traversal', async () => {
+		const workspaceRoot = await fs.mkdtemp(
+			path.join(os.tmpdir(), 'wpk-blocks-')
+		);
+		try {
+			const readdir = jest
+				.spyOn(fs, 'readdir')
+				.mockImplementation(async (dir: string, _options?: unknown) => {
+					if (dir === workspaceRoot) {
+						return [
+							createDirent({
+								name: '..',
+								type: 'dir',
+							}),
+						] as unknown as Dirent[];
+					}
+
+					if (dir === path.join(workspaceRoot, '..')) {
+						return [] as unknown as Dirent[];
+					}
+
+					return [] as unknown as Dirent[];
+				});
+
+			const blocks = await discoverBlocks(workspaceRoot);
+
+			expect(blocks).toEqual([]);
+			expect(readdir).toHaveBeenCalledTimes(1);
+		} finally {
+			await fs.rm(workspaceRoot, { recursive: true, force: true });
+		}
+	});
+
+	it('identifies entries that should be skipped', () => {
+		const symlink = createDirent({ name: 'link', type: 'symlink' });
+		const file = createDirent({ name: 'file', type: 'file' });
+		const ignored = createDirent({ name: 'node_modules', type: 'dir' });
+		const directory = createDirent({ name: 'blocks', type: 'dir' });
+
+		expect(shouldSkipEntry(symlink as unknown as Dirent)).toBe(true);
+		expect(shouldSkipEntry(file as unknown as Dirent)).toBe(true);
+		expect(shouldSkipEntry(ignored as unknown as Dirent)).toBe(true);
+		expect(shouldSkipEntry(directory as unknown as Dirent)).toBe(false);
+	});
+
+	it('loads block entries and detects render files', async () => {
+		const tmp = await fs.mkdtemp(
+			path.join(os.tmpdir(), 'wpk-block-entry-')
+		);
+		try {
+			const blockDir = path.join(tmp, 'blocks', 'example');
+			await fs.mkdir(blockDir, { recursive: true });
+			const manifestPath = path.join(blockDir, 'block.json');
+			await fs.writeFile(
+				manifestPath,
+				JSON.stringify({
+					name: 'plugin/example',
+					title: 'Example',
+				}),
+				'utf8'
+			);
+			await fs.writeFile(
+				path.join(blockDir, 'render.php'),
+				'<?php echo 1;'
+			);
+
+			const block = await loadBlockEntry(manifestPath, blockDir, tmp);
+
+			expect(block).toMatchObject({
+				key: 'plugin/example',
+				hasRender: true,
+			});
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it('rethrows unexpected fs errors when checking file existence', async () => {
+		const error = Object.assign(new Error('boom'), { code: 'EACCES' });
+		const statSpy = jest
+			.spyOn(fs, 'stat')
+			.mockRejectedValue(error as NodeJS.ErrnoException);
+
+		await expect(fileExists('/tmp/forbidden')).rejects.toThrow(error);
+		expect(statSpy).toHaveBeenCalled();
+	});
+
+	it('throws kernel errors when manifests cannot be read or are invalid', async () => {
+		const tmp = await fs.mkdtemp(
+			path.join(os.tmpdir(), 'wpk-block-error-')
+		);
+		try {
+			const blockDir = path.join(tmp, 'broken');
+			await fs.mkdir(blockDir, { recursive: true });
+			const manifestPath = path.join(blockDir, 'block.json');
+			await fs.writeFile(manifestPath, 'not json', 'utf8');
+
+			await expect(
+				loadBlockEntry(manifestPath, blockDir, tmp)
+			).rejects.toBeInstanceOf(KernelError);
+
+			await fs.writeFile(
+				manifestPath,
+				JSON.stringify('not-an-object'),
+				'utf8'
+			);
+
+			await expect(
+				loadBlockEntry(manifestPath, blockDir, tmp)
+			).rejects.toBeInstanceOf(KernelError);
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it('detects paths outside the workspace root', () => {
+		const workspaceRoot = '/workspace/project';
+		const outside = path.join(workspaceRoot, '..', 'other');
+
+		expect(isOutsideWorkspace(workspaceRoot, outside)).toBe(true);
+		expect(
+			isOutsideWorkspace(workspaceRoot, path.join(workspaceRoot, 'src'))
+		).toBe(false);
+	});
+});
+
+function createDirent(options: {
+	name: string;
+	type: 'file' | 'dir' | 'symlink';
+}) {
+	return {
+		name: options.name,
+		isFile: () => options.type === 'file',
+		isDirectory: () => options.type === 'dir',
+		isSymbolicLink: () => options.type === 'symlink',
+	};
+}

--- a/packages/cli/src/ir/__tests__/resource-builder.helpers.test.ts
+++ b/packages/cli/src/ir/__tests__/resource-builder.helpers.test.ts
@@ -1,0 +1,244 @@
+import {
+	normaliseQueryParams,
+	recordPostTypeCollision,
+	inferIdentity,
+	pickRoutePlaceholder,
+	createIdentityFromPlaceholder,
+	prepareStorage,
+	inferPostType,
+	sortWarnings,
+} from '../resource-builder';
+import type { IRResource } from '../types';
+
+describe('resource builder helpers', () => {
+	it('normalises query params by sorting keys', () => {
+		expect(normaliseQueryParams(undefined)).toBeUndefined();
+
+		const result = normaliseQueryParams({
+			b: ['two'],
+			a: ['one'],
+		});
+
+		expect(result).toEqual({
+			a: ['one'],
+			b: ['two'],
+		});
+	});
+
+	it('detects post type collisions across resources', () => {
+		const registry = new Map<string, string>();
+		const noWarning = recordPostTypeCollision({
+			resourceKey: 'alpha',
+			registry,
+			storageResult: { warnings: [], storage: undefined },
+		});
+		expect(noWarning).toEqual([]);
+
+		const withPostType = recordPostTypeCollision({
+			resourceKey: 'alpha',
+			registry,
+			storageResult: {
+				warnings: [],
+				storage: undefined,
+				postType: 'foo',
+			},
+		});
+		expect(withPostType).toEqual([]);
+
+		const collision = recordPostTypeCollision({
+			resourceKey: 'beta',
+			registry,
+			storageResult: {
+				warnings: [],
+				storage: undefined,
+				postType: 'foo',
+			},
+		});
+		expect(collision).toHaveLength(1);
+
+		const secondRegistry = new Map<string, string>([['foo', 'alpha']]);
+		const explicitCollision = recordPostTypeCollision({
+			resourceKey: 'gamma',
+			registry: secondRegistry,
+			storageResult: {
+				warnings: [],
+				storage: undefined,
+				explicitPostType: 'foo',
+			},
+		});
+		expect(explicitCollision[0]?.message).toContain('Post type "foo"');
+	});
+
+	it('infers identity metadata from route placeholders', () => {
+		const routes = [
+			{
+				path: '/things/:id',
+				method: 'GET',
+				policy: undefined,
+				transport: 'local',
+			},
+		] as unknown as IRResource['routes'];
+		const inferred = inferIdentity({
+			resourceKey: 'thing',
+			provided: undefined,
+			routes,
+		});
+		expect(inferred.identity).toEqual({ type: 'number', param: 'id' });
+		expect(inferred.warning?.code).toBe('identity.inference.applied');
+
+		const unsupported = inferIdentity({
+			resourceKey: 'thing',
+			provided: undefined,
+			routes: [
+				{
+					path: '/things/:custom',
+					method: 'GET',
+					policy: undefined,
+					transport: 'local',
+				},
+			] as unknown as IRResource['routes'],
+		});
+		expect(unsupported.identity).toBeUndefined();
+		expect(unsupported.warning?.code).toBe(
+			'identity.inference.unsupported'
+		);
+
+		const missing = inferIdentity({
+			resourceKey: 'thing',
+			provided: undefined,
+			routes: [] as unknown as IRResource['routes'],
+		});
+		expect(missing.identity).toBeUndefined();
+		expect(missing.warning?.code).toBe('identity.inference.missing');
+
+		const provided = inferIdentity({
+			resourceKey: 'thing',
+			provided: { type: 'string', param: 'slug' },
+			routes,
+		});
+		expect(provided.identity).toEqual({ type: 'string', param: 'slug' });
+	});
+
+	it('chooses placeholders based on priority and frequency', () => {
+		const routes = [
+			{
+				path: '/one/:slug',
+				method: 'GET',
+				policy: undefined,
+				transport: 'local',
+			},
+			{
+				path: '/two/:uuid',
+				method: 'GET',
+				policy: undefined,
+				transport: 'local',
+			},
+		] as unknown as IRResource['routes'];
+		expect(pickRoutePlaceholder(routes)).toBe('slug');
+
+		const fallback = pickRoutePlaceholder([
+			{
+				path: '/fallback/:custom',
+				method: 'GET',
+				policy: undefined,
+				transport: 'local',
+			},
+		] as unknown as IRResource['routes']);
+		expect(fallback).toBe('custom');
+
+		const uuidOnly = pickRoutePlaceholder([
+			{
+				path: '/items/:uuid',
+				method: 'GET',
+				policy: undefined,
+				transport: 'local',
+			},
+		] as unknown as IRResource['routes']);
+		expect(uuidOnly).toBe('uuid');
+	});
+
+	it('creates identity metadata from placeholders', () => {
+		expect(createIdentityFromPlaceholder('id')).toEqual({
+			type: 'number',
+			param: 'id',
+		});
+		expect(createIdentityFromPlaceholder('slug')).toEqual({
+			type: 'string',
+			param: 'slug',
+		});
+		expect(createIdentityFromPlaceholder('uuid')).toEqual({
+			type: 'string',
+			param: 'uuid',
+		});
+		expect(createIdentityFromPlaceholder('unknown')).toBeUndefined();
+	});
+
+	it('prepares storage metadata for different modes', () => {
+		const noStorage = prepareStorage({
+			resourceKey: 'thing',
+			storage: undefined,
+			sanitizedNamespace: 'ns',
+		});
+		expect(noStorage.storage).toBeUndefined();
+
+		const optionStorage = prepareStorage({
+			resourceKey: 'thing',
+			storage: { mode: 'wp-option', option: 'foo' } as never,
+			sanitizedNamespace: 'ns',
+		});
+		expect(optionStorage.storage).toEqual({
+			mode: 'wp-option',
+			option: 'foo',
+		});
+
+		const explicitPost = prepareStorage({
+			resourceKey: 'thing',
+			storage: { mode: 'wp-post', postType: 'custom' } as never,
+			sanitizedNamespace: 'ns',
+		});
+		expect(explicitPost.storage).toMatchObject({ postType: 'custom' });
+		expect(explicitPost.explicitPostType).toBe('custom');
+
+		const inferredPost = prepareStorage({
+			resourceKey: 'thing',
+			storage: { mode: 'wp-post' } as never,
+			sanitizedNamespace: 'Namespace Value',
+		});
+		expect(inferredPost.storage?.postType).toBe(
+			'namespace_value_thing'.slice(0, 20)
+		);
+	});
+
+	it('infers post types and truncates long identifiers', () => {
+		const result = inferPostType({
+			resourceKey: 'VeryLongResourceNameExceedingLimits',
+			sanitizedNamespace: 'ExampleNamespace',
+		});
+		expect(result.postType).toHaveLength(20);
+		expect(result.warnings[0]?.code).toBe(
+			'storage.wpPost.postType.truncated'
+		);
+
+		const fallback = inferPostType({
+			resourceKey: '   ',
+			sanitizedNamespace: '   ',
+		});
+		expect(fallback.postType).toBe('wpk_resource');
+	});
+
+	it('sorts warnings deterministically', () => {
+		const warnings = sortWarnings([
+			{ code: 'b', message: 'two' },
+			{ code: 'a', message: 'three' },
+			{ code: 'a', message: undefined },
+			{ code: 'a', message: 'one' },
+		] as never);
+
+		expect(warnings.map((w) => `${w.code}:${w.message ?? ''}`)).toEqual([
+			'a:',
+			'a:one',
+			'a:three',
+			'b:two',
+		]);
+	});
+});

--- a/packages/cli/src/ir/__tests__/schema.helpers.test.ts
+++ b/packages/cli/src/ir/__tests__/schema.helpers.test.ts
@@ -1,0 +1,191 @@
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs/promises';
+import { KernelError } from '@geekist/wp-kernel';
+import type { ResourceConfig } from '@geekist/wp-kernel/resource';
+import {
+	inferSchemaSetting,
+	resolveSchemaPath,
+	ensureFileExists,
+	fileExists,
+	loadJsonSchema,
+	synthesiseSchema,
+	createSchemaFromPostMeta,
+	toTitleCase,
+	resolveResourceSchema,
+	createSchemaAccumulator,
+} from '../schema';
+
+describe('schema helpers', () => {
+	it('infers schema setting from resource configuration', () => {
+		const baseResource = {
+			routes: {},
+			name: 'thing',
+		} as unknown as ResourceConfig;
+		expect(inferSchemaSetting({ ...baseResource, schema: 'manual' })).toBe(
+			'manual'
+		);
+		expect(
+			inferSchemaSetting({
+				...baseResource,
+				storage: { mode: 'wp-post' } as never,
+			})
+		).toBe('auto');
+		expect(inferSchemaSetting(baseResource)).toBeUndefined();
+	});
+
+	it('resolves schema paths using absolute, relative and workspace fallbacks', async () => {
+		const workspaceRoot = await fs.mkdtemp(
+			path.join(os.tmpdir(), 'wpk-schema-')
+		);
+		const configPath = path.join(workspaceRoot, 'kernel.config.ts');
+		await fs.writeFile(configPath, '// config', 'utf8');
+		const absoluteSchema = path.join(workspaceRoot, 'abs.schema.json');
+		await fs.writeFile(absoluteSchema, '{}', 'utf8');
+
+		const absResult = await resolveSchemaPath(absoluteSchema, configPath);
+		expect(absResult).toBe(absoluteSchema);
+
+		const relativeDir = path.join(workspaceRoot, 'schemas');
+		await fs.mkdir(relativeDir, { recursive: true });
+		const relativeSchema = path.join(relativeDir, 'todo.json');
+		await fs.writeFile(relativeSchema, '{}', 'utf8');
+		const relativeResult = await resolveSchemaPath(
+			'./schemas/todo.json',
+			configPath
+		);
+		expect(relativeResult).toBe(relativeSchema);
+
+		const originalCwd = process.cwd();
+		try {
+			process.chdir(workspaceRoot);
+			const workspaceSchema = path.join(workspaceRoot, 'workspace.json');
+			await fs.writeFile(workspaceSchema, '{}', 'utf8');
+			const workspaceResult = await resolveSchemaPath(
+				'workspace.json',
+				configPath
+			);
+			expect(workspaceResult).toBe(workspaceSchema);
+		} finally {
+			process.chdir(originalCwd);
+			await fs.rm(workspaceRoot, { recursive: true, force: true });
+		}
+
+		await expect(
+			resolveSchemaPath('missing.json', configPath)
+		).rejects.toBeInstanceOf(KernelError);
+	});
+
+	it('validates file existence and propagates unexpected errors', async () => {
+		const tmp = await fs.mkdtemp(
+			path.join(os.tmpdir(), 'wpk-schema-file-')
+		);
+		const filePath = path.join(tmp, 'exists.json');
+		await fs.writeFile(filePath, '{}', 'utf8');
+
+		await expect(ensureFileExists(filePath)).resolves.toBeUndefined();
+		await expect(
+			ensureFileExists(path.join(tmp, 'missing.json'))
+		).rejects.toBeInstanceOf(KernelError);
+
+		const error = Object.assign(new Error('boom'), { code: 'EACCES' });
+		const statSpy = jest
+			.spyOn(fs, 'stat')
+			.mockRejectedValue(error as NodeJS.ErrnoException);
+
+		await expect(fileExists('/forbidden')).rejects.toThrow(error);
+		statSpy.mockRestore();
+
+		await fs.rm(tmp, { recursive: true, force: true });
+	});
+
+	it('loads JSON schema content and wraps parse errors', async () => {
+		const tmp = await fs.mkdtemp(
+			path.join(os.tmpdir(), 'wpk-schema-load-')
+		);
+		try {
+			const schemaPath = path.join(tmp, 'schema.json');
+			await fs.writeFile(schemaPath, '{"title":"ok"}', 'utf8');
+			const schema = await loadJsonSchema(schemaPath, 'ok');
+			expect(schema).toEqual({ title: 'ok' });
+
+			await fs.writeFile(schemaPath, '{ invalid', 'utf8');
+			await expect(
+				loadJsonSchema(schemaPath, 'ok')
+			).rejects.toBeInstanceOf(KernelError);
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it('synthesises schemas from storage metadata', () => {
+		const resource = {
+			name: 'job-board',
+			routes: {},
+			storage: {
+				mode: 'wp-post',
+				meta: {
+					department: { type: 'string', single: true },
+					tags: { type: 'string', single: false },
+				},
+			},
+		} as unknown as ResourceConfig;
+
+		const schema = synthesiseSchema(resource, 'example');
+		expect(schema.properties).toMatchObject({
+			department: { type: 'string' },
+			tags: { type: 'array', items: { type: 'string' } },
+		});
+	});
+
+	it('reuses synthesized schemas for auto resources and validates schema types', async () => {
+		const accumulator = createSchemaAccumulator();
+		const resource = {
+			name: 'job',
+			routes: {},
+			storage: { mode: 'wp-post' },
+		} as unknown as ResourceConfig;
+
+		const first = await resolveResourceSchema(
+			'job',
+			resource,
+			accumulator,
+			'example'
+		);
+		const second = await resolveResourceSchema(
+			'job',
+			resource,
+			accumulator,
+			'example'
+		);
+
+		expect(first.schemaKey).toBe(second.schemaKey);
+		expect(accumulator.entries).toHaveLength(1);
+
+		await expect(
+			resolveResourceSchema(
+				'invalid',
+				{
+					name: 'invalid',
+					routes: {},
+					schema: 42,
+				} as unknown as ResourceConfig,
+				accumulator,
+				'example'
+			)
+		).rejects.toBeInstanceOf(KernelError);
+	});
+
+	it('creates schema fragments from post meta descriptors', () => {
+		expect(
+			createSchemaFromPostMeta({ type: 'string', single: true })
+		).toEqual({ type: 'string' });
+		expect(
+			createSchemaFromPostMeta({ type: 'number', single: false })
+		).toEqual({ type: 'array', items: { type: 'number' } });
+	});
+
+	it('converts identifiers to title case', () => {
+		expect(toTitleCase('job-board_item')).toBe('Job Board Item');
+	});
+});

--- a/packages/cli/src/ir/__tests__/test-helpers.test.ts
+++ b/packages/cli/src/ir/__tests__/test-helpers.test.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+	sortValue,
+	canonicalHash,
+	withTempWorkspace,
+	withTempSchema,
+} from '../test-helpers';
+
+describe('IR test helpers', () => {
+	it('sorts values deterministically and normalises undefined', () => {
+		const value = {
+			b: [2, { d: undefined, c: 3 }],
+			a: undefined,
+		};
+		const sorted = sortValue(value);
+
+		expect(sorted).toEqual({
+			a: null,
+			b: [2, { c: 3, d: null }],
+		});
+	});
+
+	it('produces stable hashes for complex structures', () => {
+		const hashA = canonicalHash({ foo: 'bar', nested: [1, 2, 3] });
+		const hashB = canonicalHash({ nested: [1, 2, 3], foo: 'bar' });
+		expect(hashA).toBe(hashB);
+	});
+
+	it('manages temporary workspaces and schemas', async () => {
+		const touched: string[] = [];
+		await withTempWorkspace(
+			async (root) => {
+				const filePath = path.join(root, 'file.txt');
+				await fs.writeFile(filePath, 'hello', 'utf8');
+				touched.push(filePath);
+			},
+			async (root) => {
+				const contents = await fs.readFile(
+					path.join(root, 'file.txt'),
+					'utf8'
+				);
+				expect(contents).toBe('hello');
+			}
+		);
+
+		await withTempSchema('{}', async (schemaPath) => {
+			const exists = await fs.readFile(schemaPath, 'utf8');
+			expect(exists).toBe('{}');
+			touched.push(schemaPath);
+		});
+
+		for (const filePath of touched) {
+			await expect(fs.access(filePath)).rejects.toThrow();
+		}
+	});
+});

--- a/packages/cli/src/ir/block-discovery.ts
+++ b/packages/cli/src/ir/block-discovery.ts
@@ -53,7 +53,10 @@ function createBlockDiscoveryState(workspaceRoot: string): BlockDiscoveryState {
 	};
 }
 
-function isOutsideWorkspace(workspaceRoot: string, candidate: string): boolean {
+export function isOutsideWorkspace(
+	workspaceRoot: string,
+	candidate: string
+): boolean {
 	const relative = path.relative(workspaceRoot, candidate);
 	return relative.startsWith('..');
 }
@@ -105,7 +108,7 @@ function enqueueChildDirectories(options: {
 	}
 }
 
-function shouldSkipEntry(entry: Dirent): boolean {
+export function shouldSkipEntry(entry: Dirent): boolean {
 	if (entry.isSymbolicLink()) {
 		return true;
 	}
@@ -117,7 +120,7 @@ function shouldSkipEntry(entry: Dirent): boolean {
 	return IGNORED_DIRECTORIES.has(entry.name);
 }
 
-async function loadBlockEntry(
+export async function loadBlockEntry(
 	manifestPath: string,
 	directory: string,
 	workspaceRoot: string
@@ -171,7 +174,7 @@ async function loadBlockEntry(
 	};
 }
 
-async function fileExists(candidate: string): Promise<boolean> {
+export async function fileExists(candidate: string): Promise<boolean> {
 	try {
 		const stat = await fs.stat(candidate);
 		return stat.isFile();

--- a/packages/cli/src/ir/resource-builder.ts
+++ b/packages/cli/src/ir/resource-builder.ts
@@ -149,7 +149,7 @@ function collectWarnings(options: {
 	return sortWarnings(warnings);
 }
 
-function sortWarnings(warnings: IRWarning[]): IRWarning[] {
+export function sortWarnings(warnings: IRWarning[]): IRWarning[] {
 	return warnings.slice().sort((a, b) => {
 		const codeComparison = a.code.localeCompare(b.code);
 		if (codeComparison !== 0) {
@@ -160,7 +160,7 @@ function sortWarnings(warnings: IRWarning[]): IRWarning[] {
 	});
 }
 
-function normaliseQueryParams(
+export function normaliseQueryParams(
 	params: ResourceConfig['queryParams'] | undefined
 ): ResourceConfig['queryParams'] | undefined {
 	if (!params) {
@@ -170,7 +170,7 @@ function normaliseQueryParams(
 	return sortObject(params);
 }
 
-function recordPostTypeCollision(options: {
+export function recordPostTypeCollision(options: {
 	resourceKey: string;
 	registry: Map<string, string>;
 	storageResult: ReturnType<typeof prepareStorage>;
@@ -203,7 +203,7 @@ function recordPostTypeCollision(options: {
 	return [];
 }
 
-function inferIdentity(options: {
+export function inferIdentity(options: {
 	resourceKey: string;
 	provided: ResourceConfig['identity'];
 	routes: IRResource['routes'];
@@ -246,7 +246,7 @@ function inferIdentity(options: {
 	};
 }
 
-function pickRoutePlaceholder(
+export function pickRoutePlaceholder(
 	routes: IRResource['routes']
 ): string | undefined {
 	const priority = ['id', 'slug', 'uuid'];
@@ -273,7 +273,7 @@ function pickRoutePlaceholder(
 	return first;
 }
 
-function createIdentityFromPlaceholder(
+export function createIdentityFromPlaceholder(
 	placeholder: string
 ): ResourceConfig['identity'] | undefined {
 	switch (placeholder) {
@@ -288,7 +288,7 @@ function createIdentityFromPlaceholder(
 	}
 }
 
-function prepareStorage(options: {
+export function prepareStorage(options: {
 	resourceKey: string;
 	storage: ResourceConfig['storage'];
 	sanitizedNamespace: string;
@@ -330,7 +330,7 @@ function prepareStorage(options: {
 	};
 }
 
-function inferPostType(options: {
+export function inferPostType(options: {
 	resourceKey: string;
 	sanitizedNamespace: string;
 }): { postType: string; warnings: IRWarning[] } {
@@ -362,7 +362,7 @@ function inferPostType(options: {
 	return { postType: trimmed, warnings };
 }
 
-function hashResource(options: {
+export function hashResource(options: {
 	resourceConfig: ResourceConfig;
 	schemaKey: string;
 	schemaProvenance: SchemaProvenance;

--- a/packages/cli/src/ir/schema.ts
+++ b/packages/cli/src/ir/schema.ts
@@ -107,7 +107,7 @@ export async function resolveResourceSchema(
 	return { schemaKey: schema, provenance: irSchema.provenance };
 }
 
-function inferSchemaSetting(
+export function inferSchemaSetting(
 	resource: ResourceConfig
 ): ResourceConfig['schema'] | 'auto' {
 	if (resource.schema) {
@@ -121,7 +121,7 @@ function inferSchemaSetting(
 	return resource.schema;
 }
 
-async function resolveSchemaPath(
+export async function resolveSchemaPath(
 	schemaPath: string,
 	configPath: string
 ): Promise<string> {
@@ -148,7 +148,7 @@ async function resolveSchemaPath(
 	});
 }
 
-async function ensureFileExists(filePath: string): Promise<void> {
+export async function ensureFileExists(filePath: string): Promise<void> {
 	if (!(await fileExists(filePath))) {
 		throw new KernelError('ValidationError', {
 			message: `Schema file "${filePath}" does not exist.`,
@@ -157,7 +157,7 @@ async function ensureFileExists(filePath: string): Promise<void> {
 	}
 }
 
-async function fileExists(candidate: string): Promise<boolean> {
+export async function fileExists(candidate: string): Promise<boolean> {
 	try {
 		const stats = await fs.stat(candidate);
 		return stats.isFile();
@@ -170,7 +170,10 @@ async function fileExists(candidate: string): Promise<boolean> {
 	}
 }
 
-async function loadJsonSchema(filePath: string, key: string): Promise<unknown> {
+export async function loadJsonSchema(
+	filePath: string,
+	key: string
+): Promise<unknown> {
 	try {
 		const raw = await fs.readFile(filePath, 'utf8');
 		return JSON.parse(raw);
@@ -183,7 +186,7 @@ async function loadJsonSchema(filePath: string, key: string): Promise<unknown> {
 	}
 }
 
-function synthesiseSchema(
+export function synthesiseSchema(
 	resource: ResourceConfig,
 	sanitizedNamespace: string
 ): Record<string, unknown> {
@@ -212,7 +215,7 @@ function synthesiseSchema(
 	return sortObject(baseSchema);
 }
 
-function createSchemaFromPostMeta(
+export function createSchemaFromPostMeta(
 	descriptor: ResourcePostMetaDescriptor
 ): Record<string, unknown> {
 	const type = descriptor.type;
@@ -226,7 +229,7 @@ function createSchemaFromPostMeta(
 	return { type };
 }
 
-function toTitleCase(value: string): string {
+export function toTitleCase(value: string): string {
 	return value
 		.split(/[-_:]/)
 		.filter(Boolean)


### PR DESCRIPTION
## Summary
- export targeted helpers from the CLI config loader, validator, and IR modules so their edge cases can be tested directly
- add focused unit suites that exercise composer autoload validation, block discovery, resource builders, schema utilities, and IR test helpers
- raise branch coverage for the weakest CLI files above 90% to unblock downstream work

## Testing
- pnpm --filter @geekist/wp-kernel-cli test:coverage