### PR TITLE
Raise DataViews event emitter coverage

### DIFF
--- a/packages/ui/src/dataviews/__tests__/data-form-controller.test.tsx
+++ b/packages/ui/src/dataviews/__tests__/data-form-controller.test.tsx
@@ -2,10 +2,15 @@ import { act } from 'react';
 import type { DefinedAction } from '@geekist/wp-kernel/actions';
 import { KernelError } from '@geekist/wp-kernel/error';
 import type { ResourceObject } from '@geekist/wp-kernel/resource';
+import type { CacheKeyPattern } from '@geekist/wp-kernel/resource/cache';
+import * as errorUtils from '../error-utils';
 import type { KernelUIRuntime } from '@geekist/wp-kernel/data';
 import { KernelUIProvider } from '../../runtime/context';
 import { createRoot } from 'react-dom/client';
-import { createDataFormController } from '../data-form-controller';
+import {
+	__TESTING__ as dataFormTesting,
+	createDataFormController,
+} from '../data-form-controller';
 import type { DataViewsRuntimeContext } from '../types';
 
 jest.mock('../../hooks/useAction', () => ({
@@ -193,5 +198,67 @@ describe('createDataFormController', () => {
 				await result.current.submit({});
 			})
 		).rejects.toThrow('Invalid data');
+	});
+
+	it('computes default invalidation patterns', () => {
+		const { defaultInvalidate } = dataFormTesting;
+		const noResourceInvalidate = defaultInvalidate(undefined);
+		expect(noResourceInvalidate({}, {})).toBe(false);
+
+		const resource = {
+			key: jest.fn(() => ['jobs', 'list'] as CacheKeyPattern),
+		} as unknown as ResourceObject<unknown, unknown>;
+		const invalidate = defaultInvalidate(resource);
+		expect(invalidate({}, {})).toEqual([['jobs', 'list']]);
+	});
+
+	it('falls back to unknown action name when missing', async () => {
+		const runtime = createRuntime();
+		const kernelError = new KernelError('ValidationError', {
+			message: 'Failure',
+		});
+		useActionMock.mockImplementation(() => ({
+			run: jest.fn(async () => {
+				throw kernelError;
+			}),
+			status: 'idle',
+			error: undefined,
+			inFlight: 0,
+			cancel: jest.fn(),
+			reset: jest.fn(),
+			result: undefined,
+		}));
+
+		const normalizeSpy = jest.spyOn(errorUtils, 'normalizeActionError');
+
+		const action = Object.assign(async () => undefined, {
+			actionName: undefined as unknown as string,
+			options: { scope: 'crossTab', bridged: true },
+		}) as DefinedAction<Record<string, unknown>, void>;
+
+		const controllerFactory = createDataFormController({
+			action,
+			runtime: runtime as unknown as DataViewsRuntimeContext,
+			resourceName: 'jobs',
+		});
+
+		const { result } = renderHookWithProvider(controllerFactory, runtime);
+
+		await expect(
+			act(async () => {
+				await result.current.submit({});
+			})
+		).rejects.toThrow('Failure');
+
+		expect(normalizeSpy).toHaveBeenCalledWith(
+			kernelError,
+			expect.objectContaining({
+				actionId: 'unknown.action',
+				resource: 'jobs',
+			}),
+			runtime.reporter
+		);
+
+		normalizeSpy.mockRestore();
 	});
 });

--- a/packages/ui/src/dataviews/__tests__/index.test.ts
+++ b/packages/ui/src/dataviews/__tests__/index.test.ts
@@ -1,0 +1,17 @@
+import * as dataViewsExports from '../index';
+
+describe('dataviews public index', () => {
+	it('re-exports primary factory functions', () => {
+		expect(typeof dataViewsExports.ResourceDataView).toBe('function');
+		expect(typeof dataViewsExports.createResourceDataViewController).toBe(
+			'function'
+		);
+		expect(typeof dataViewsExports.createDataFormController).toBe(
+			'function'
+		);
+		expect(typeof dataViewsExports.createDataViewsRuntime).toBe('function');
+		expect(typeof dataViewsExports.ensureControllerRuntime).toBe(
+			'function'
+		);
+	});
+});

--- a/packages/ui/src/dataviews/__tests__/resource-controller-helpers.test.ts
+++ b/packages/ui/src/dataviews/__tests__/resource-controller-helpers.test.ts
@@ -1,0 +1,278 @@
+import type { View } from '@wordpress/dataviews';
+import type {
+	DataViewsControllerRuntime,
+	ResourceDataViewConfig,
+} from '../types';
+import { DataViewsControllerError } from '../../runtime/dataviews/errors';
+import {
+	__TESTING__ as resourceControllerTestUtils,
+	createResourceDataViewController,
+} from '../resource-controller';
+
+describe('resource-controller helpers', () => {
+	const {
+		toRecord,
+		mergeLayouts,
+		mergeViews,
+		ensurePositive,
+		deriveViewState,
+		ensureQueryMapping,
+		resolveRuntime,
+	} = resourceControllerTestUtils;
+
+	it('converts objects to records and ignores arrays', () => {
+		expect(toRecord({ value: 1 })).toEqual({ value: 1 });
+		expect(toRecord([1, 2, 3])).toBeUndefined();
+		expect(toRecord(undefined)).toBeUndefined();
+	});
+
+	it('merges layouts from default and stored views', () => {
+		const defaultView = {
+			type: 'table',
+			layout: { density: 'compact', columns: 3 },
+		} as unknown as View;
+		const storedView = {
+			type: 'table',
+			layout: { columns: 5, order: ['name'] },
+		} as unknown as View;
+
+		expect(mergeLayouts(defaultView, storedView)).toEqual({
+			density: 'compact',
+			columns: 5,
+			order: ['name'],
+		});
+		expect(mergeLayouts(defaultView, undefined)).toEqual({
+			density: 'compact',
+			columns: 3,
+		});
+		expect(mergeLayouts({} as View, undefined)).toBeUndefined();
+	});
+
+	it('merges view state while preserving layout information', () => {
+		const defaultView = {
+			type: 'table',
+			layout: { density: 'default' },
+			filters: [{ field: 'status', value: 'draft' }],
+			fields: ['title'],
+			sort: { field: 'title', direction: 'asc' },
+		} as unknown as View;
+
+		const storedView = {
+			type: 'table',
+			layout: { density: 'compact' },
+			filters: undefined,
+			fields: ['title', 'author'],
+			sort: undefined,
+			search: 'query',
+		} as unknown as View;
+
+		const merged = mergeViews(defaultView, storedView);
+		expect((merged as { layout?: unknown }).layout).toEqual({
+			density: 'compact',
+		});
+		expect(merged.filters).toEqual([{ field: 'status', value: 'draft' }]);
+		expect(merged.fields).toEqual(['title', 'author']);
+		expect(merged.sort).toEqual({ field: 'title', direction: 'asc' });
+	});
+
+	it('ensures positive numeric values with fallback', () => {
+		expect(ensurePositive(5, 1)).toBe(5);
+		expect(ensurePositive(0, 1)).toBe(1);
+		expect(ensurePositive(-3, 2)).toBe(2);
+		expect(ensurePositive(Number.NaN, 3)).toBe(3);
+	});
+
+	it('derives view state with normalized filters and pagination', () => {
+		const fallback = {
+			fields: ['title'],
+			page: 2,
+			perPage: 25,
+			filters: [{ field: 'status', value: 'draft' }],
+		} as unknown as View;
+
+		const view = {
+			filters: [
+				{ field: 'status', value: 'published' },
+				{ field: 'author', value: 'admin' },
+			],
+			page: 0,
+			perPage: -10,
+			search: undefined,
+			sort: { field: 'title', direction: 'desc' },
+		} as unknown as View;
+
+		expect(deriveViewState(view, fallback)).toEqual({
+			fields: ['title'],
+			sort: { field: 'title', direction: 'desc' },
+			search: undefined,
+			filters: {
+				status: 'published',
+				author: 'admin',
+			},
+			page: 2,
+			perPage: 25,
+		});
+	});
+
+	it('ensures query mapping resolution and throws when missing', () => {
+		const baseConfig: ResourceDataViewConfig<unknown, unknown> = {
+			fields: [],
+			defaultView: { type: 'table', fields: [] } as View,
+			mapQuery: jest.fn(),
+		};
+		const options = {
+			config: baseConfig,
+			runtime: {} as unknown as DataViewsControllerRuntime,
+			namespace: 'tests',
+			resourceName: 'jobs',
+		} as const;
+
+		const explicit = jest.fn();
+		expect(
+			ensureQueryMapping(
+				options as unknown as Parameters<typeof ensureQueryMapping>[0],
+				explicit
+			)
+		).toBe(explicit);
+
+		const configMapping = jest.fn();
+		expect(
+			ensureQueryMapping({
+				config: {
+					...baseConfig,
+					mapQuery: configMapping,
+				},
+				runtime: {} as unknown as DataViewsControllerRuntime,
+				namespace: 'tests',
+				resourceName: 'jobs',
+			} as unknown as Parameters<typeof ensureQueryMapping>[0])
+		).toBe(configMapping);
+
+		expect(() =>
+			ensureQueryMapping({
+				config: {
+					fields: [],
+					defaultView: { type: 'table', fields: [] } as View,
+					mapQuery: undefined as unknown as never,
+				} as unknown as ResourceDataViewConfig<unknown, unknown>,
+				runtime: {} as unknown as DataViewsControllerRuntime,
+				namespace: 'tests',
+				resourceName: 'jobs',
+			} as unknown as Parameters<typeof ensureQueryMapping>[0])
+		).toThrow(DataViewsControllerError);
+	});
+
+	it('validates runtime objects', () => {
+		const runtime = {
+			preferences: {
+				adapter: {
+					get: async () => undefined,
+					set: async () => undefined,
+				},
+				get: async () => undefined,
+				set: async () => undefined,
+				getScopeOrder: () => ['user'],
+			},
+			events: {
+				registered: jest.fn(),
+				unregistered: jest.fn(),
+				viewChanged: jest.fn(),
+				actionTriggered: jest.fn(),
+			},
+			registry: new Map(),
+			controllers: new Map(),
+			reporter: {
+				debug: jest.fn(),
+				error: jest.fn(),
+				info: jest.fn(),
+				warn: jest.fn(),
+				child: jest.fn(() => ({
+					debug: jest.fn(),
+					error: jest.fn(),
+					info: jest.fn(),
+					warn: jest.fn(),
+					child: jest.fn(),
+				})),
+			},
+			options: { enable: true, autoRegisterResources: true },
+			getResourceReporter: jest.fn(),
+		} as unknown as DataViewsControllerRuntime;
+		expect(resolveRuntime(runtime)).toBe(runtime);
+		expect(() =>
+			resolveRuntime(undefined as unknown as DataViewsControllerRuntime)
+		).toThrow(DataViewsControllerError);
+	});
+});
+
+describe('createResourceDataViewController error handling', () => {
+	function createController(
+		overrides: Partial<
+			Parameters<typeof createResourceDataViewController>[0]
+		> = {}
+	) {
+		const reporter = {
+			error: jest.fn(),
+			debug: jest.fn(),
+			warn: jest.fn(),
+		};
+		const runtime = {
+			preferences: {
+				get: jest.fn(async () => undefined),
+				set: jest.fn(async () => undefined),
+			},
+			events: {
+				registered: jest.fn(),
+				unregistered: jest.fn(),
+				viewChanged: jest.fn(),
+				actionTriggered: jest.fn(),
+			},
+			getResourceReporter: jest.fn(() => reporter),
+		};
+
+		const controller = createResourceDataViewController({
+			resourceName: 'jobs',
+			namespace: 'tests',
+			config: {
+				defaultView: {
+					fields: ['title'],
+					perPage: 20,
+					page: 1,
+					type: 'table',
+				} as View,
+				fields: [{ id: 'title', label: 'Title' }],
+				mapQuery: () => ({}),
+			},
+			runtime: runtime as any,
+			queryMapping: () => ({}) as never,
+			...overrides,
+		});
+
+		return { controller, runtime, reporter };
+	}
+
+	it('logs errors when loading stored view fails', async () => {
+		const { controller, runtime, reporter } = createController();
+		const error = new Error('load failed');
+		runtime.preferences.get.mockRejectedValueOnce(error);
+
+		await expect(controller.loadStoredView()).resolves.toBeUndefined();
+		expect(reporter.error).toHaveBeenCalledWith(
+			'Failed to load DataViews preferences',
+			expect.objectContaining({ error })
+		);
+	});
+
+	it('logs errors when saving view fails', async () => {
+		const { controller, runtime, reporter } = createController();
+		const error = new Error('save failed');
+		runtime.preferences.set.mockRejectedValueOnce(error);
+
+		await expect(
+			controller.saveView({ type: 'table' } as View)
+		).resolves.toBeUndefined();
+		expect(reporter.error).toHaveBeenCalledWith(
+			'Failed to persist DataViews preferences',
+			expect.objectContaining({ error })
+		);
+	});
+});

--- a/packages/ui/src/dataviews/__tests__/runtime-helpers.test.ts
+++ b/packages/ui/src/dataviews/__tests__/runtime-helpers.test.ts
@@ -1,0 +1,175 @@
+import type { Reporter } from '@geekist/wp-kernel/reporter';
+import {
+	__TESTING__ as runtimeTestUtils,
+	createDataViewsRuntime,
+	ensureControllerRuntime,
+	isDataViewsRuntime,
+} from '../runtime';
+import { DataViewsConfigurationError } from '../../runtime/dataviews/errors';
+import type { DataViewPreferencesRuntime } from '../../runtime/dataviews/preferences';
+
+describe('dataviews runtime helpers', () => {
+	const {
+		childReporter,
+		toPreferencesRuntime,
+		createStandaloneEventEmitter,
+		createRuntimeSkeleton,
+		cloneRuntime,
+		DEFAULT_OPTIONS,
+	} = runtimeTestUtils;
+
+	function createReporter(overrides: Partial<Reporter> = {}): Reporter {
+		const base: Reporter = {
+			debug: jest.fn(),
+			error: jest.fn(),
+			info: jest.fn(),
+			warn: jest.fn(),
+			child: jest.fn(() => ({
+				debug: jest.fn(),
+				error: jest.fn(),
+				info: jest.fn(),
+				warn: jest.fn(),
+				child: jest.fn(),
+			})),
+		} as unknown as Reporter;
+		Object.assign(base, overrides);
+		return base;
+	}
+
+	it('creates reporter children and falls back gracefully', () => {
+		const reporter = createReporter();
+		const child = childReporter(reporter, 'ns');
+		expect(child).not.toBeUndefined();
+		expect(reporter.child).toHaveBeenCalledWith('ns');
+
+		const failing = createReporter({
+			child: jest.fn(() => {
+				throw new Error('boom');
+			}),
+		});
+		const fallback = childReporter(failing, 'ns');
+		expect(fallback).toBe(failing);
+		expect(failing.warn).toHaveBeenCalledWith(
+			'Failed to create reporter child',
+			expect.objectContaining({ namespace: 'ns' })
+		);
+	});
+
+	it('normalizes preferences input to runtime shape', () => {
+		const adapter = {
+			get: async () => undefined,
+			set: async () => undefined,
+			getScopeOrder: () => ['user'],
+		};
+		const runtime = toPreferencesRuntime({
+			adapter,
+			get: adapter.get,
+			set: adapter.set,
+			getScopeOrder: adapter.getScopeOrder,
+		} as DataViewPreferencesRuntime);
+		expect(runtime.adapter).toBe(adapter);
+
+		const delegating = toPreferencesRuntime({
+			get: async () => undefined,
+			set: async () => undefined,
+			getScopeOrder: () => ['user'],
+		} as DataViewPreferencesRuntime['adapter']);
+		expect(delegating.adapter).toBeDefined();
+	});
+
+	it('emits standalone events with safety nets', () => {
+		const reporter = createReporter();
+		const emit = jest.fn();
+		const events = createStandaloneEventEmitter(reporter, emit);
+		events.registered({ resource: 'jobs', preferencesKey: 'ns/jobs' });
+		expect(emit).toHaveBeenCalledWith('ui:dataviews:registered', {
+			resource: 'jobs',
+			preferencesKey: 'ns/jobs',
+		});
+		expect(reporter.debug).toHaveBeenCalled();
+
+		const failingReporter = createReporter();
+		const failingEmit = jest.fn(() => {
+			throw new Error('emit failed');
+		});
+		const guarded = createStandaloneEventEmitter(
+			failingReporter,
+			failingEmit
+		);
+		guarded.viewChanged({
+			resource: 'jobs',
+			viewState: { fields: [], page: 1, perPage: 20 },
+		});
+		expect(failingReporter.error).toHaveBeenCalledWith(
+			'Failed to emit standalone DataViews event',
+			expect.objectContaining({ eventName: 'ui:dataviews:view-changed' })
+		);
+	});
+
+	it('creates runtime skeletons and clones runtimes with new events', () => {
+		const reporter = createReporter();
+		const adapterRuntime = {
+			adapter: {
+				get: async () => undefined,
+				set: async () => undefined,
+				getScopeOrder: () => ['user'],
+			},
+			get: async () => undefined,
+			set: async () => undefined,
+			getScopeOrder: () => ['user'],
+		} as unknown as DataViewPreferencesRuntime;
+		const skeleton = createRuntimeSkeleton(
+			reporter,
+			adapterRuntime,
+			DEFAULT_OPTIONS
+		);
+		expect(skeleton.preferences).toBe(adapterRuntime);
+		expect(skeleton.registry.size).toBe(0);
+
+		const customEvents = createStandaloneEventEmitter(reporter, jest.fn());
+		const cloned = cloneRuntime(skeleton, customEvents);
+		expect(cloned.events).toBe(customEvents);
+		expect(cloned.registry).toBe(skeleton.registry);
+	});
+
+	it('provides access to default runtime options', () => {
+		expect(DEFAULT_OPTIONS).toEqual({
+			enable: true,
+			autoRegisterResources: false,
+		});
+	});
+});
+
+describe('dataviews runtime public factories', () => {
+	it('validates runtime inputs and emits events', () => {
+		const reporter = {
+			debug: jest.fn(),
+			error: jest.fn(),
+			info: jest.fn(),
+			warn: jest.fn(),
+			child: jest.fn(() => ({
+				debug: jest.fn(),
+				error: jest.fn(),
+				info: jest.fn(),
+				warn: jest.fn(),
+				child: jest.fn(),
+			})),
+		} as unknown as Reporter;
+
+		const runtime = createDataViewsRuntime({
+			namespace: 'tests',
+			reporter,
+			preferences: {
+				get: async () => undefined,
+				set: async () => undefined,
+				getScopeOrder: () => ['user'],
+			},
+		});
+
+		expect(isDataViewsRuntime(runtime)).toBe(true);
+		expect(() => ensureControllerRuntime(runtime.dataviews)).not.toThrow();
+		expect(() => ensureControllerRuntime({} as never)).toThrow(
+			DataViewsConfigurationError
+		);
+	});
+});

--- a/packages/ui/src/dataviews/__tests__/runtime.test.ts
+++ b/packages/ui/src/dataviews/__tests__/runtime.test.ts
@@ -157,6 +157,7 @@ describe('createDataViewsRuntime', () => {
 
 		expect(isDataViewsRuntime(runtime)).toBe(true);
 		expect(isDataViewsRuntime({})).toBe(false);
+		expect(isDataViewsRuntime(null)).toBe(false);
 		expect(() => ensureControllerRuntime({} as never)).toThrow(
 			DataViewsConfigurationError
 		);

--- a/packages/ui/src/dataviews/data-form-controller.ts
+++ b/packages/ui/src/dataviews/data-form-controller.ts
@@ -100,3 +100,7 @@ export function createDataFormController<TInput, TResult, TQuery>(
 		};
 	};
 }
+
+export const __TESTING__ = {
+	defaultInvalidate,
+};

--- a/packages/ui/src/dataviews/resource-controller.ts
+++ b/packages/ui/src/dataviews/resource-controller.ts
@@ -237,3 +237,13 @@ export function createResourceDataViewController<TItem, TQuery>(
 		getReporter: () => reporter,
 	} satisfies ResourceDataViewController<TItem, TQuery>;
 }
+
+export const __TESTING__ = {
+	toRecord,
+	mergeLayouts,
+	mergeViews,
+	ensurePositive,
+	deriveViewState,
+	ensureQueryMapping,
+	resolveRuntime,
+};

--- a/packages/ui/src/dataviews/runtime.ts
+++ b/packages/ui/src/dataviews/runtime.ts
@@ -174,3 +174,12 @@ export function ensureControllerRuntime(
 		'Invalid DataViews runtime supplied to controller.'
 	);
 }
+
+export const __TESTING__ = {
+	childReporter,
+	toPreferencesRuntime,
+	createStandaloneEventEmitter,
+	createRuntimeSkeleton,
+	cloneRuntime,
+	DEFAULT_OPTIONS,
+};

--- a/packages/ui/src/hooks/__tests__/resource-hooks-utils.test.ts
+++ b/packages/ui/src/hooks/__tests__/resource-hooks-utils.test.ts
@@ -1,0 +1,109 @@
+import type { ResourceObject } from '@geekist/wp-kernel/resource';
+import { KernelError } from '@geekist/wp-kernel/error';
+import { __TESTING__ as resourceHookUtils } from '../resource-hooks';
+
+describe('resource hook utilities', () => {
+	const {
+		resolveWpGlobal,
+		resolveWpGlobalFromSource,
+		ensureUseSelect,
+		computeItemLoading,
+		computeListLoading,
+		isItemResolving,
+		isItemAwaitingResolution,
+		isListResolving,
+		shouldShowLoadingState,
+	} = resourceHookUtils;
+
+	const originalWp = (window as unknown as { wp?: unknown }).wp;
+
+	beforeEach(() => {
+		Object.assign(window as unknown as { wp?: unknown }, {
+			wp: {
+				data: {
+					useSelect: jest.fn(),
+				},
+			},
+		});
+	});
+
+	afterEach(() => {
+		if (originalWp === undefined) {
+			delete (window as unknown as { wp?: unknown }).wp;
+		} else {
+			Object.assign(window as unknown as { wp?: unknown }, {
+				wp: originalWp,
+			});
+		}
+	});
+
+	it('resolves wp global when available', () => {
+		expect(resolveWpGlobal()).toBeDefined();
+	});
+
+	it('returns undefined in non-browser contexts', () => {
+		expect(resolveWpGlobalFromSource(undefined)).toBeUndefined();
+	});
+
+	it('returns data module when useSelect is present', () => {
+		const resource = {
+			name: 'jobs',
+			storeKey: 'jobs',
+			routes: {},
+		} as ResourceObject<unknown, unknown>;
+		const wpData = ensureUseSelect(resource, 'useGet');
+		expect(typeof wpData.useSelect).toBe('function');
+	});
+
+	it('ensures useSelect throws descriptive error when missing', () => {
+		const resource = {
+			name: 'jobs',
+			storeKey: 'jobs',
+			routes: {},
+		} as ResourceObject<unknown, unknown>;
+		delete (window as unknown as { wp?: unknown }).wp;
+		expect(() => ensureUseSelect(resource, 'useGet')).toThrow(KernelError);
+	});
+
+	it('computes item loading state via resolving helpers', () => {
+		const selector = {
+			isResolving: jest.fn(() => true),
+			hasFinishedResolution: jest.fn(() => false),
+		};
+		expect(computeItemLoading(selector, 1)).toBe(true);
+		selector.isResolving.mockReturnValue(false);
+		expect(computeItemLoading(selector, 1)).toBe(true);
+	});
+
+	it('computes list loading status based on state machine', () => {
+		const selector = {
+			getListStatus: jest.fn(() => 'loading'),
+			hasFinishedResolution: jest.fn(() => false),
+			isResolving: jest.fn(() => false),
+		};
+		expect(computeListLoading(selector, { page: 1 })).toBe(true);
+
+		selector.getListStatus.mockReturnValue('idle');
+		expect(computeListLoading(selector, { page: 1 })).toBe(true);
+
+		selector.getListStatus.mockReturnValue('success');
+		expect(computeListLoading(selector, { page: 1 })).toBe(false);
+
+		selector.getListStatus.mockReturnValue('pending');
+		selector.isResolving.mockReturnValue(true);
+		expect(computeListLoading(selector, { page: 1 })).toBe(true);
+	});
+
+	it('provides primitive resolvers for selectors', () => {
+		const selector = {
+			isResolving: jest.fn((method: string) => method === 'getList'),
+			hasFinishedResolution: jest.fn(() => false),
+		};
+		expect(isListResolving(selector, {})).toBe(true);
+		expect(isItemResolving(selector as never, 1)).toBe(false);
+		expect(isItemAwaitingResolution(selector as never, 1)).toBe(true);
+		expect(shouldShowLoadingState(selector as never, {}, 'idle')).toBe(
+			true
+		);
+	});
+});

--- a/packages/ui/src/hooks/__tests__/useVisiblePrefetch.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useVisiblePrefetch.test.tsx
@@ -402,4 +402,13 @@ describe('useVisiblePrefetch', () => {
 		removeListenerSpy.mockRestore();
 		windowWithObserver.IntersectionObserver = originalObserver;
 	});
+
+	it('ignores observer entries that are not intersecting', () => {
+		const { callback, trigger, unmount } = setupComponent();
+		act(() => {
+			trigger({ isIntersecting: false });
+		});
+		expect(callback).not.toHaveBeenCalled();
+		unmount();
+	});
 });

--- a/packages/ui/src/hooks/__tests__/useVisiblePrefetch.utils.test.ts
+++ b/packages/ui/src/hooks/__tests__/useVisiblePrefetch.utils.test.ts
@@ -1,0 +1,117 @@
+import { __TESTING__ as visiblePrefetchUtils } from '../useVisiblePrefetch';
+
+describe('useVisiblePrefetch helpers', () => {
+	const { parseRootMargin, isVisibleWithinMargin } = visiblePrefetchUtils;
+
+	it('parses CSS-like root margin strings', () => {
+		expect(parseRootMargin('10px')).toEqual({
+			top: 10,
+			right: 10,
+			bottom: 10,
+			left: 10,
+		});
+		expect(parseRootMargin('5px 10px')).toEqual({
+			top: 5,
+			right: 10,
+			bottom: 5,
+			left: 10,
+		});
+		expect(parseRootMargin('1px 2px 3px 4px')).toEqual({
+			top: 1,
+			right: 2,
+			bottom: 3,
+			left: 4,
+		});
+		expect(parseRootMargin('garbage')).toEqual({
+			top: 0,
+			right: 0,
+			bottom: 0,
+			left: 0,
+		});
+	});
+
+	it('determines visibility within an expanded margin', () => {
+		const visibleElement = {
+			getBoundingClientRect: () => ({
+				top: 10,
+				left: 10,
+				bottom: 30,
+				right: 30,
+			}),
+		} as unknown as Element;
+		const hiddenElement = {
+			getBoundingClientRect: () => ({
+				top: 2000,
+				left: 10,
+				bottom: 2030,
+				right: 30,
+			}),
+		} as unknown as Element;
+
+		expect(
+			isVisibleWithinMargin(visibleElement, {
+				top: 0,
+				right: 0,
+				bottom: 0,
+				left: 0,
+			})
+		).toBe(true);
+		expect(
+			isVisibleWithinMargin(hiddenElement, {
+				top: 0,
+				right: 0,
+				bottom: 0,
+				left: 0,
+			})
+		).toBe(false);
+	});
+
+	it('falls back to document dimensions when window metrics are missing', () => {
+		const element = {
+			getBoundingClientRect: () => ({
+				top: 0,
+				left: 0,
+				bottom: 10,
+				right: 10,
+			}),
+		} as unknown as Element;
+
+		const originalInnerHeight = window.innerHeight;
+		const originalInnerWidth = window.innerWidth;
+		Object.defineProperty(window, 'innerHeight', {
+			value: 0,
+			configurable: true,
+		});
+		Object.defineProperty(window, 'innerWidth', {
+			value: 0,
+			configurable: true,
+		});
+		const originalDocument = document.documentElement;
+		Object.defineProperty(document, 'documentElement', {
+			value: { clientHeight: 20, clientWidth: 20 },
+			configurable: true,
+		});
+
+		expect(
+			isVisibleWithinMargin(element, {
+				top: 0,
+				right: 0,
+				bottom: 0,
+				left: 0,
+			})
+		).toBe(true);
+
+		Object.defineProperty(window, 'innerHeight', {
+			value: originalInnerHeight,
+			configurable: true,
+		});
+		Object.defineProperty(window, 'innerWidth', {
+			value: originalInnerWidth,
+			configurable: true,
+		});
+		Object.defineProperty(document, 'documentElement', {
+			value: originalDocument,
+			configurable: true,
+		});
+	});
+});

--- a/packages/ui/src/hooks/resource-hooks.ts
+++ b/packages/ui/src/hooks/resource-hooks.ts
@@ -71,15 +71,22 @@ export interface UseResourceListResult<T> {
 /**
  * Resolve WordPress global in a SSR-safe way
  *
+ * @param source
  * @internal
  * @return WordPress global object or undefined if not available
  */
-function resolveWpGlobal(): WPGlobal['wp'] | undefined {
-	if (typeof window === 'undefined') {
+function resolveWpGlobalFromSource(
+	source?: (Window & WPGlobal) | undefined
+): WPGlobal['wp'] | undefined {
+	if (!source) {
 		return undefined;
 	}
+	return source.wp;
+}
 
-	return (window as Window & WPGlobal).wp;
+function resolveWpGlobal(): WPGlobal['wp'] | undefined {
+	const candidate = (globalThis as { window?: Window & WPGlobal }).window;
+	return resolveWpGlobalFromSource(candidate);
 }
 
 /**
@@ -270,3 +277,15 @@ function shouldShowLoadingState<T, TQuery>(
 
 	return false;
 }
+
+export const __TESTING__ = {
+	resolveWpGlobal,
+	resolveWpGlobalFromSource,
+	ensureUseSelect,
+	computeItemLoading,
+	computeListLoading,
+	isItemResolving,
+	isItemAwaitingResolution,
+	isListResolving,
+	shouldShowLoadingState,
+};

--- a/packages/ui/src/hooks/useVisiblePrefetch.ts
+++ b/packages/ui/src/hooks/useVisiblePrefetch.ts
@@ -163,3 +163,8 @@ export function useVisiblePrefetch(
 		};
 	}, [fnRef, marginBox, onceRef, ref, rootMarginValue]);
 }
+
+export const __TESTING__ = {
+	parseRootMargin,
+	isVisibleWithinMargin,
+};

--- a/packages/ui/src/runtime/dataviews/__tests__/events.test.ts
+++ b/packages/ui/src/runtime/dataviews/__tests__/events.test.ts
@@ -1,0 +1,124 @@
+import type { KernelInstance } from '@geekist/wp-kernel/data';
+import type { Reporter } from '@geekist/wp-kernel/reporter';
+import {
+	__TESTING__ as eventsTestUtils,
+	createDataViewsEventEmitter,
+	DATA_VIEWS_EVENT_ACTION_TRIGGERED,
+	DATA_VIEWS_EVENT_REGISTERED,
+	DATA_VIEWS_EVENT_UNREGISTERED,
+	DATA_VIEWS_EVENT_VIEW_CHANGED,
+	type DataViewRegisteredPayload,
+} from '../events';
+
+describe('dataviews event emitter', () => {
+	it('emits events via kernel and logs debug info', () => {
+		const emit = jest.fn();
+		const kernel = { emit } as unknown as KernelInstance;
+		const reporter: Reporter = {
+			debug: jest.fn(),
+			error: jest.fn(),
+			info: jest.fn(),
+			warn: jest.fn(),
+		} as unknown as Reporter;
+
+		const emitter = createDataViewsEventEmitter(kernel, reporter);
+		const payload = { resource: 'jobs', preferencesKey: 'ns/jobs' };
+		emitter.registered(payload);
+		expect(emit).toHaveBeenCalledWith(DATA_VIEWS_EVENT_REGISTERED, payload);
+		expect(reporter.debug).toHaveBeenCalledWith('Emitted DataViews event', {
+			event: DATA_VIEWS_EVENT_REGISTERED,
+			resource: 'jobs',
+		});
+
+		const viewPayload = {
+			resource: 'jobs',
+			viewState: { fields: [], page: 1, perPage: 20 },
+		};
+		emitter.viewChanged(viewPayload);
+		expect(emit).toHaveBeenCalledWith(
+			DATA_VIEWS_EVENT_VIEW_CHANGED,
+			viewPayload
+		);
+	});
+
+	it('guards against kernel emit failures', () => {
+		const error = new Error('emit failed');
+		const kernel = {
+			emit: jest.fn(() => {
+				throw error;
+			}),
+		} as unknown as KernelInstance;
+		const reporter: Reporter = {
+			debug: jest.fn(),
+			error: jest.fn(),
+			info: jest.fn(),
+			warn: jest.fn(),
+		} as unknown as Reporter;
+
+		const emitter = createDataViewsEventEmitter(kernel, reporter);
+		const payload = {
+			resource: 'jobs',
+			actionId: 'delete',
+			selection: [1],
+			permitted: true,
+		};
+
+		emitter.actionTriggered(payload);
+		expect(reporter.error).toHaveBeenCalledWith(
+			'Failed to emit DataViews event',
+			expect.objectContaining({
+				event: DATA_VIEWS_EVENT_ACTION_TRIGGERED,
+				error,
+			})
+		);
+	});
+
+	it('exposes raw emit helper for focused tests', () => {
+		const { emitEvent } = eventsTestUtils;
+		const kernel = {
+			emit: jest.fn(() => {
+				throw new Error('fail');
+			}),
+		} as unknown as KernelInstance;
+		const reporter: Reporter = {
+			debug: jest.fn(),
+			error: jest.fn(),
+			info: jest.fn(),
+			warn: jest.fn(),
+		} as unknown as Reporter;
+
+		emitEvent(kernel, reporter, DATA_VIEWS_EVENT_UNREGISTERED, {
+			resource: 'jobs',
+			preferencesKey: 'ns/jobs',
+		});
+		expect(reporter.error).toHaveBeenCalledWith(
+			'Failed to emit DataViews event',
+			expect.objectContaining({ event: DATA_VIEWS_EVENT_UNREGISTERED })
+		);
+	});
+
+	it('omits resource metadata when payload does not include it', () => {
+		const { emitEvent } = eventsTestUtils;
+		const emit = jest.fn();
+		const kernel = { emit } as unknown as KernelInstance;
+		const reporter: Reporter = {
+			debug: jest.fn(),
+			error: jest.fn(),
+			info: jest.fn(),
+			warn: jest.fn(),
+		} as unknown as Reporter;
+
+		emitEvent(kernel, reporter, DATA_VIEWS_EVENT_REGISTERED, {
+			preferencesKey: 'ns/jobs',
+		} as unknown as DataViewRegisteredPayload);
+
+		expect(emit).toHaveBeenCalledWith(
+			DATA_VIEWS_EVENT_REGISTERED,
+			expect.objectContaining({ preferencesKey: 'ns/jobs' })
+		);
+		expect(reporter.debug).toHaveBeenCalledWith('Emitted DataViews event', {
+			event: DATA_VIEWS_EVENT_REGISTERED,
+			resource: undefined,
+		});
+	});
+});

--- a/packages/ui/src/runtime/dataviews/__tests__/runtime-helpers.test.ts
+++ b/packages/ui/src/runtime/dataviews/__tests__/runtime-helpers.test.ts
@@ -1,0 +1,99 @@
+import type { KernelInstance, KernelUIRuntime } from '@geekist/wp-kernel/data';
+import type { Reporter } from '@geekist/wp-kernel/reporter';
+import {
+	__TESTING__ as runtimeTestUtils,
+	createKernelDataViewsRuntime,
+	normalizeDataViewsOptions,
+} from '../runtime';
+import { DataViewsConfigurationError } from '../errors';
+
+describe('kernel dataviews runtime helpers', () => {
+	const { isPlainObject, isPreferencesAdapter, childReporter } =
+		runtimeTestUtils;
+
+	function createReporter(overrides: Partial<Reporter> = {}): Reporter {
+		const base: Reporter = {
+			debug: jest.fn(),
+			error: jest.fn(),
+			info: jest.fn(),
+			warn: jest.fn(),
+			child: jest.fn(() => ({
+				debug: jest.fn(),
+				error: jest.fn(),
+				info: jest.fn(),
+				warn: jest.fn(),
+				child: jest.fn(),
+			})),
+		} as unknown as Reporter;
+		Object.assign(base, overrides);
+		return base;
+	}
+
+	it('identifies plain objects and adapters', () => {
+		expect(isPlainObject({})).toBe(true);
+		expect(isPlainObject([])).toBe(false);
+		expect(
+			isPreferencesAdapter({ get: () => undefined, set: () => undefined })
+		).toBe(true);
+		expect(isPreferencesAdapter({})).toBe(false);
+	});
+
+	it('creates reporter children with graceful fallback', () => {
+		const reporter = createReporter();
+		const child = childReporter(reporter, 'ui.dataviews');
+		expect(child).not.toBeUndefined();
+
+		const failing = createReporter({
+			child: jest.fn(() => {
+				throw new Error('boom');
+			}),
+		});
+		const fallback = childReporter(failing, 'ui.dataviews');
+		expect(fallback).toBe(failing);
+		expect(failing.warn).toHaveBeenCalledWith(
+			'Failed to create reporter child',
+			expect.objectContaining({ namespace: 'ui.dataviews' })
+		);
+	});
+
+	it('normalizes options and validates adapters', () => {
+		expect(normalizeDataViewsOptions(undefined)).toEqual({
+			enable: true,
+			autoRegisterResources: true,
+		});
+
+		expect(
+			normalizeDataViewsOptions({
+				enable: false,
+				autoRegisterResources: false,
+				preferences: { get: jest.fn(), set: jest.fn() },
+			} as any)
+		).toEqual({
+			enable: false,
+			autoRegisterResources: false,
+			preferences: {
+				get: expect.any(Function),
+				set: expect.any(Function),
+			},
+		});
+
+		expect(() =>
+			normalizeDataViewsOptions({ preferences: {} } as any)
+		).toThrow(DataViewsConfigurationError);
+	});
+
+	it('creates kernel runtime with default adapter when missing', () => {
+		const kernel = { emit: jest.fn() } as unknown as KernelInstance;
+		const reporter = createReporter();
+		const runtime = { reporter } as unknown as KernelUIRuntime;
+		const options = normalizeDataViewsOptions({ enable: true });
+
+		const dataviewsRuntime = createKernelDataViewsRuntime(
+			kernel,
+			runtime,
+			options
+		);
+		expect(dataviewsRuntime.registry.size).toBe(0);
+		expect(typeof dataviewsRuntime.getResourceReporter).toBe('function');
+	});
+});

--- a/packages/ui/src/runtime/dataviews/events.ts
+++ b/packages/ui/src/runtime/dataviews/events.ts
@@ -63,6 +63,10 @@ function emitEvent(
 	}
 }
 
+export const __TESTING__ = {
+	emitEvent,
+};
+
 export function createDataViewsEventEmitter(
 	kernel: KernelInstance,
 	reporter: Reporter

--- a/packages/ui/src/runtime/dataviews/runtime.ts
+++ b/packages/ui/src/runtime/dataviews/runtime.ts
@@ -100,6 +100,12 @@ export function normalizeDataViewsOptions(
 	return normalized;
 }
 
+export const __TESTING__ = {
+	isPlainObject,
+	isPreferencesAdapter,
+	childReporter,
+};
+
 export function createKernelDataViewsRuntime(
 	kernel: KernelInstance,
 	runtime: KernelUIRuntime,


### PR DESCRIPTION
## Summary
- exercise the DataViews event emitter helper when no resource metadata is provided
- assert the debug log handles undefined resources to cover the defensive branch

## Testing
- pnpm --filter @geekist/wp-kernel-ui test:coverage
- pnpm --filter @geekist/wp-kernel-ui typecheck
