### PR TITLE
Sprint MVP: Phase 2B wp-post CRUD printer fixes

### DIFF
--- a/packages/cli/MVP-PHASES.md
+++ b/packages/cli/MVP-PHASES.md
@@ -67,7 +67,7 @@ Finally you find that imports from other packages are sometimes missing, it usua
 
 **DoD:** Tests pass; IR golden files updated with transport/identity/postType metadata.
 
-**Status Log:** Started 2025-02-14 - Completed 2025-02-14
+**Status Log:** Started 2025-02-15 - Completed 2025-02-15
 
 ---
 

--- a/packages/cli/mvp-cli-spec.md
+++ b/packages/cli/mvp-cli-spec.md
@@ -94,6 +94,28 @@ Replace current skeleton emission with behaviour driven entirely by the IR:
 | Local routes + no storage                         | Stub methods returning `WP_Error( 501, 'Not Implemented' )` with TODO comment.                        |
 | Routes pointing outside namespace / absolute URLs | Skip PHP emission for those routes (client-only).                                                     |
 
+Example generated fragment for a `wp-post` resource:
+
+```php
+$query = new WP_Query( $args );
+$items = array();
+foreach ( $query->posts as $post_item ) {
+        $post_object = get_post( $post_item );
+        if ( ! ( $post_object instanceof WP_Post ) ) {
+                continue;
+        }
+
+        $items[] = $this->format_post_response( $post_object );
+}
+
+return rest_ensure_response( array(
+        'items'      => $items,
+        'total'      => (int) $query->found_posts,
+        'hasMore'    => $query->max_num_pages > $page,
+        'nextCursor' => $query->max_num_pages > $page ? (string) ( $page + 1 ) : null,
+) );
+```
+
 Additional responsibilities:
 
 - Build a `rest_api_init` bootstrap registering only the routes that require controllers.

--- a/packages/cli/src/printers/__tests__/emit-generated-artifacts.test.ts
+++ b/packages/cli/src/printers/__tests__/emit-generated-artifacts.test.ts
@@ -148,6 +148,7 @@ describe('emitGeneratedArtifacts', () => {
 
 			const jobContents = await fs.readFile(jobControllerPath, 'utf8');
 			expect(jobContents).toContain('use WP_Error;');
+			expect(jobContents).toContain('use WP_Post;');
 			expect(jobContents).toContain('use WP_REST_Request;');
 			expect(jobContents).toContain(
 				'class JobController extends BaseController'
@@ -161,11 +162,21 @@ describe('emitGeneratedArtifacts', () => {
 			expect(jobContents).toContain(
 				'public function postJobs( WP_REST_Request $request )'
 			);
+			expect(jobContents).toContain('$query = new WP_Query( $args );');
 			expect(jobContents).toContain(
-				'// TODO: Implement handler for [POST] /jobs.'
+				'$post_id = wp_insert_post( $post_data, true );'
 			);
 			expect(jobContents).toContain(
-				"return new WP_Error( 501, 'Not Implemented' );"
+				'return rest_ensure_response( $response );'
+			);
+			expect(jobContents).toContain(
+				'return rest_ensure_response( $this->format_post_response( $post ) );'
+			);
+			expect(jobContents).toContain(
+				'private function find_post_for_request'
+			);
+			expect(jobContents).toContain(
+				'private function prepare_post_payload'
 			);
 
 			const jobRestArgs = extractPhpArrayPayload(jobContents);
@@ -234,10 +245,10 @@ describe('emitGeneratedArtifacts', () => {
 				},
 			});
 			expect(taskContents).toContain(
-				"$slug = $request->get_param( 'slug' );"
+				'return rest_ensure_response( $this->format_post_response( $post ) );'
 			);
 			expect(taskContents).toContain(
-				'// TODO: Implement handler for [GET] /tasks/:slug.'
+				'private function find_post_for_request'
 			);
 
 			const orphanContents = await fs.readFile(

--- a/packages/cli/src/printers/__tests__/php-printer.wp-post.test.ts
+++ b/packages/cli/src/printers/__tests__/php-printer.wp-post.test.ts
@@ -1,0 +1,267 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { emitPhpArtifacts } from '../php/printer';
+import type { PrinterContext } from '../types';
+import type { IRResource, IRSchema, IRv1 } from '../../ir';
+import type { KernelConfigV1 } from '../../config/types';
+
+const TMP_PREFIX = path.join(os.tmpdir(), 'wpk-php-printer-');
+
+describe('php printer – wp-post storage', () => {
+	it('emits slug-based lookups using get_page_by_path', async () => {
+		await withTempDir(async (tempDir) => {
+			const context = createPhpPrinterContext(tempDir, {
+				identity: {
+					type: 'string',
+					param: 'slug',
+				} as IRResource['identity'],
+			});
+
+			await emitPhpArtifacts(context);
+
+			const controllerPath = path.join(
+				context.outputDir,
+				'php',
+				'Rest',
+				'PostController.php'
+			);
+			const contents = await fs.readFile(controllerPath, 'utf8');
+
+			expect(contents).toContain(
+				'get_page_by_path( $slug, OBJECT, array( $post_type ) );'
+			);
+			expect(contents).toContain(
+				'return rest_ensure_response( $this->format_post_response( $post ) );'
+			);
+			expect(contents).not.toContain('is_numeric( $slug )');
+		});
+	});
+
+	it('queries UUID identities via meta lookups', async () => {
+		await withTempDir(async (tempDir) => {
+			const context = createPhpPrinterContext(tempDir, {
+				identity: {
+					type: 'string',
+					param: 'uuid',
+				} as IRResource['identity'],
+			});
+
+			await emitPhpArtifacts(context);
+
+			const controllerPath = path.join(
+				context.outputDir,
+				'php',
+				'Rest',
+				'PostController.php'
+			);
+			const contents = await fs.readFile(controllerPath, 'utf8');
+
+			expect(contents).toContain("'meta_key' => 'uuid'");
+			expect(contents).toContain("'meta_value' => $uuid");
+			expect(contents).toContain('$query = new WP_Query( array(');
+		});
+	});
+
+	it('treats custom string identities as slugs without numeric coercion', async () => {
+		await withTempDir(async (tempDir) => {
+			const context = createPhpPrinterContext(tempDir, {
+				identity: {
+					type: 'string',
+					param: 'handle',
+				} as IRResource['identity'],
+			});
+
+			await emitPhpArtifacts(context);
+
+			const controllerPath = path.join(
+				context.outputDir,
+				'php',
+				'Rest',
+				'PostController.php'
+			);
+			const contents = await fs.readFile(controllerPath, 'utf8');
+
+			expect(contents).toContain(
+				"$handle = $request->get_param( 'handle' );"
+			);
+			expect(contents).toContain(
+				'get_page_by_path( $handle, OBJECT, array( $post_type ) );'
+			);
+			expect(contents).not.toContain('is_numeric( $handle )');
+			expect(contents).not.toContain('$post_id = (int) $handle;');
+		});
+	});
+});
+
+async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
+	const tempDir = await fs.mkdtemp(TMP_PREFIX);
+	try {
+		await run(tempDir);
+	} finally {
+		await fs.rm(tempDir, { recursive: true, force: true });
+	}
+}
+
+function createPhpPrinterContext(
+	tempDir: string,
+	overrides: { identity: IRResource['identity'] }
+): PrinterContext {
+	const ir = createIr(overrides.identity);
+	const outputDir = path.join(tempDir, '.generated');
+
+	const context: PrinterContext = {
+		ir,
+		outputDir,
+		configDirectory: tempDir,
+		formatPhp: async (_filePath, contents) =>
+			ensureTrailingNewline(contents),
+		formatTs: async (_filePath, contents) =>
+			ensureTrailingNewline(contents),
+		writeFile: async (filePath, contents) => {
+			await fs.mkdir(path.dirname(filePath), { recursive: true });
+			await fs.writeFile(
+				filePath,
+				ensureTrailingNewline(contents),
+				'utf8'
+			);
+		},
+		ensureDirectory: async (directoryPath) => {
+			await fs.mkdir(directoryPath, { recursive: true });
+		},
+	} as PrinterContext;
+
+	return context;
+}
+
+function createIr(identity: IRResource['identity']): IRv1 {
+	const identityParam =
+		identity?.param ?? (identity?.type === 'number' ? 'id' : 'slug');
+	const config: KernelConfigV1 = {
+		version: 1,
+		namespace: 'demo-namespace',
+		schemas: {} as KernelConfigV1['schemas'],
+		resources: {} as KernelConfigV1['resources'],
+	} as KernelConfigV1;
+
+	const schema: IRSchema = {
+		key: 'post',
+		sourcePath: 'contracts/post.schema.json',
+		hash: 'schema-post',
+		schema: {
+			type: 'object',
+			required: ['id', 'title'],
+			properties: {
+				id: { type: 'integer' },
+				title: { type: 'string' },
+				status: { type: 'string' },
+			},
+		},
+		provenance: 'manual',
+	};
+
+	const resource: IRResource = {
+		name: 'post',
+		schemaKey: schema.key,
+		schemaProvenance: schema.provenance,
+		routes: [
+			{
+				method: 'GET',
+				path: '/demo/v1/posts',
+				policy: 'posts.read',
+				hash: 'route-post-list',
+				transport: 'local',
+			},
+			{
+				method: 'GET',
+				path: `/demo/v1/posts/:${identityParam}`,
+				policy: 'posts.read',
+				hash: 'route-post-get',
+				transport: 'local',
+			},
+			{
+				method: 'POST',
+				path: '/demo/v1/posts',
+				policy: 'posts.create',
+				hash: 'route-post-create',
+				transport: 'local',
+			},
+			{
+				method: 'PUT',
+				path: `/demo/v1/posts/:${identityParam}`,
+				policy: 'posts.update',
+				hash: 'route-post-update',
+				transport: 'local',
+			},
+			{
+				method: 'DELETE',
+				path: `/demo/v1/posts/:${identityParam}`,
+				policy: 'posts.delete',
+				hash: 'route-post-delete',
+				transport: 'local',
+			},
+		],
+		cacheKeys: {
+			list: {
+				segments: Object.freeze(['post', 'list']),
+				source: 'config',
+			},
+			get: {
+				segments: Object.freeze(['post', 'get', '__wpk_id__']),
+				source: 'default',
+			},
+			create: undefined,
+			update: undefined,
+			remove: undefined,
+		},
+		identity,
+		storage: {
+			mode: 'wp-post',
+			postType: 'demo_post',
+			statuses: ['draft'],
+			supports: ['title', 'editor', 'excerpt'],
+			meta: {
+				department_code: { type: 'string', single: true },
+				tags: { type: 'array', single: false },
+			},
+			taxonomies: {
+				department: { taxonomy: 'demo_department' },
+			},
+		},
+		queryParams: {
+			q: { type: 'string', optional: true },
+			status: { type: 'enum', enum: ['publish', 'draft'] },
+			department: { type: 'string', optional: true },
+			department_code: { type: 'string', optional: true },
+		},
+		ui: undefined,
+		hash: 'resource-post',
+		warnings: [],
+	} as IRResource;
+
+	const ir: IRv1 = {
+		meta: {
+			version: 1,
+			namespace: 'demo-namespace',
+			sourcePath: 'kernel.config.ts',
+			origin: 'kernel.config.ts',
+			sanitizedNamespace: 'Demo\\Namespace',
+		},
+		config,
+		schemas: [schema],
+		resources: [resource],
+		policies: [],
+		blocks: [],
+		php: {
+			namespace: 'Demo\\Namespace',
+			autoload: 'inc/',
+			outputDir: '.generated/php',
+		},
+	};
+
+	return ir;
+}
+
+function ensureTrailingNewline(value: string): string {
+	return value.endsWith('\n') ? value : `${value}\n`;
+}


### PR DESCRIPTION
## Summary
Sprint MVP: Phase 2B wp-post CRUD printer

**Sprint:** Norms (CLI MVP)
**Scope:** cli

## Links

- Roadmap section: [MVP Phases](packages/cli/MVP-PHASES.md#phase-2b---wp-post-storage-implementation)
- Sprint doc / spec: [MVP CLI Spec §4.3](packages/cli/mvp-cli-spec.md#43-php-printer-delta)
- Related issues: <!-- #123, #456 -->
- Demo/preview (if any): <!-- URL -->

## Why

Phase 2B replaces placeholder REST controllers for `wp-post` storage with real CRUD handlers so generated PHP can be exercised without manual edits.

## What

- Extend the PHP printer to emit `wp-post` list/get/create/update/delete handlers that call the appropriate WordPress APIs, including query/meta/tax handling and identity resolution helpers.
- Capture REST argument shapes from IR schemas/query params for list and detail routes.
- Refresh printer integration tests and add a dedicated suite for slug/UUID identity coverage in generated controllers.
- Ensure string-based identities never coerce numeric-looking values to IDs and cover the regression with targeted printer tests.
- Document the phase completion and add a spec snippet showing the generated query fragment.

## How

The printer now resolves each route through a helper that selects the right template for CRUD operations. Generated controllers share helper methods (`get_post_type`, `find_post_for_request`, etc.) to keep complexity in check while ensuring meta/taxonomy payloads, pagination, and REST responses align with WordPress best practices. Tests regenerate controllers from fixture IR and assert on key code paths for different identity modes. Identity resolution now guards the numeric lookup to only run for numeric identity types so slug- and UUID-based resources remain string-first.

## Testing

How reviewers test locally:

1. `pnpm --filter @geekist/wp-kernel-cli lint --fix`
   **Expected:** eslint finishes without errors.
2. `pnpm --filter @geekist/wp-kernel-cli test`
   **Expected:** CLI test suite passes.
3. `pnpm --filter @geekist/wp-kernel-cli test:coverage`
   **Expected:** Coverage meets CLI thresholds.
4. `pnpm --filter @geekist/wp-kernel-cli build`
   **Expected:** Vite build and TypeScript compilation succeed.

### Test Matrix (tick what’s covered)

- [x] Unit (pnpm test)
- [ ] E2E (pnpm e2e)
- [x] Types (pnpm typecheck)
- [ ] Docs examples (build/run)
- [ ] WordPress playground / wp-env sanity

## Screenshots / Recordings (if applicable)

N/A

## Breaking Changes

- [x] None

## Affected Packages

Tick any public packages this PR changes functionally.

- [ ] `@geekist/wp-kernel`
- [ ] `@geekist/wp-kernel-ui`
- [x] `@geekist/wp-kernel-cli`
- [ ] `@geekist/wp-kernel-e2e-utils`

## Release

- [x] **minor** — feature sprint (default) (0.x.0)

> Update CHANGELOG.md files in affected packages with summary of changes.
> _If infra/docs-only, add label **no-release**._

## Checklist

- [x] Tests pass (`pnpm test`, where relevant: `pnpm e2e`)
- [x] Lint passes (`pnpm lint`)
- [x] Types pass (`pnpm typecheck`, `pnpm typecheck:tests`)
- [ ] CHANGELOG.md updated in affected packages (or PR labelled `no-release`)
- [x] Docs updated (site/README)
- [ ] Examples updated (if API changed)