### PR TITLE
Sprint 8: Accessibility surface audits

### DIFF
--- a/ACCESSIBILITY_COMPARISON.md
+++ b/ACCESSIBILITY_COMPARISON.md
@@ -49,24 +49,25 @@ Use these anchors when you need deeper package-specific rationales, example code
 
 ### Phase 0 – Establish Monorepo Accessibility Contracts
 
-**Status:** `<complete>` – Shared contracts are documented in the [kernel audit](packages/kernel/ACCESSIBILITY_AUDIT.md#phase-0--define-shared-contracts) and rolled into package READMEs so contributors know where the canonical lifecycle, namespace, and error definitions live.
+**Status:** `<complete>` – Shared constants are codified in [contracts/ACCESSIBILITY_CONTRACTS.md](contracts/ACCESSIBILITY_CONTRACTS.md) and exported via [`@geekist/wp-kernel/contracts`](packages/kernel/src/contracts/index.ts). Package READMEs now expose dedicated “Accessibility contracts & constants” sections so contributors know where to find lifecycle, namespace, error, and exit-code definitions before beginning work.
 
 - **Contract sources:**
-    - [Kernel README § Key Patterns](packages/kernel/README.md#key-patterns) captures lifecycle and namespace primitives for runtime consumers.
-    - [CLI README § Core workflow](packages/cli/README.md#core-workflow-init--generate--apply) references shared exit code messaging expectations for scaffolding pipelines.
-    - [E2E utilities README § Key Features](packages/e2e-utils/README.md#key-features) directs test authors to namespace-aware fixtures.
-    - [UI README § DataViews in practice](packages/ui/README.md#dataviews-in-practice) documents semantic expectations the UI layer must honour.
-- **Update protocol:** When contracts evolve, update the relevant README sections and link the ADR or spec inside the associated package audit before flipping the status back to `<pending>` or `<in-progress>`.
+    - [Accessibility & Observability Contracts](contracts/ACCESSIBILITY_CONTRACTS.md) – normative reference and change protocol.
+    - [Kernel README § Accessibility contracts & constants](packages/kernel/README.md#accessibility-contracts--constants) – how runtime developers should consume the exports.
+    - [CLI README § Accessibility contracts & constants](packages/cli/README.md#accessibility-contracts--constants) – guidance for scaffolding and reporter integrations.
+    - [E2E utilities README § Accessibility contracts & constants](packages/e2e-utils/README.md#accessibility-contracts--constants) – instructions for Playwright fixtures and assertions.
+    - [UI README § Accessibility contracts & constants](packages/ui/README.md#accessibility-contracts--constants) – expectations for UI controllers and semantic defaults.
+- **Update protocol:** When contracts evolve, update both the Markdown reference and `@geekist/wp-kernel/contracts` exports. Leave this phase at `<pending>` until each README and audit cross-links the new contract details.
 
 ### Phase 1 – Kernel as Source of Truth
 
-**Status:** `<complete>` – Kernel deliverables are scoped and linked for implementers: typed error migration, middleware hooks, and namespace overrides now reference concrete documentation so teams can begin execution without ambiguity.
+**Status:** `<complete>` – The kernel publishes lifecycle, namespace, error, and exit-code constants from [`packages/kernel/src/contracts/index.ts`](packages/kernel/src/contracts/index.ts) so downstream packages can import a single source of truth. Readmes and audits instruct teams to rely on these exports before extending middleware or observability hooks.
 
 - **Implementation checklist:**
-    - Follow [Kernel audit Phase 1 guidance](packages/kernel/ACCESSIBILITY_AUDIT.md#phase-1--harden-kernel-primitives) to drive the error and middleware updates.
-    - Align CLI observability with the kernel constants by consulting [CLI audit Phase 1 guidance](packages/cli/ACCESSIBILITY_AUDIT.md#phase-1--enable-extensible-registries).
-    - Capture namespace override details in [Kernel README § Quick Start](packages/kernel/README.md#quick-start) and mirror integration notes in downstream READMEs.
-- **Contract storage:** File implementation notes under `contracts/` (e.g., lifecycle ADRs) and cross-link them from the audits before marking subtasks complete.
+    - Follow [Kernel audit Phase 1 guidance](packages/kernel/ACCESSIBILITY_AUDIT.md#phase-1--harden-kernel-primitives) and import the contract exports when refactoring lifecycle or namespace code.
+    - Align CLI observability with the kernel constants by consulting [CLI audit Phase 1 guidance](packages/cli/ACCESSIBILITY_AUDIT.md#phase-1--enable-extensible-registries) and consuming `KERNEL_EXIT_CODES`.
+    - Capture namespace override details in [Kernel README § Accessibility contracts & constants](packages/kernel/README.md#accessibility-contracts--constants) before mirroring integration notes in downstream READMEs.
+- **Contract storage:** Keep living specifications in `contracts/` and reference them from package audits whenever new middleware or observability hooks are proposed.
 
 ### Phase 2 – Shared Consumer Enablement (CLI & E2E Utils)
 
@@ -86,11 +87,11 @@ Use these anchors when you need deeper package-specific rationales, example code
 
 ## Package README Reference Guide
 
-| Package                        | Key README Sections                                                                                                                                                                                                    | When to Consult                                                                                               |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `@geekist/wp-kernel`           | [Overview](packages/kernel/README.md#overview), [Quick Start](packages/kernel/README.md#quick-start), [Key Patterns](packages/kernel/README.md#key-patterns)                                                           | Understand runtime contracts, lifecycle primitives, and namespace conventions before altering core behaviour. |
-| `@geekist/wp-kernel-cli`       | [Overview](packages/cli/README.md#overview), [Core workflow: init → generate → apply](packages/cli/README.md#core-workflow-init--generate--apply), [Development commands](packages/cli/README.md#development-commands) | Align CLI work with the generation pipeline, exit code expectations, and recommended developer flows.         |
-| `@geekist/wp-kernel-e2e-utils` | [Overview](packages/e2e-utils/README.md#overview), [Key Features](packages/e2e-utils/README.md#key-features), [Validation Strategy](packages/e2e-utils/README.md#validation-strategy)                                  | Plan test utilities and fixtures that honour shared contracts and observability patterns.                     |
-| `@geekist/wp-kernel-ui`        | [Overview](packages/ui/README.md#overview), [Bootstrapping the runtime](packages/ui/README.md#bootstrapping-the-runtime), [DataViews in practice](packages/ui/README.md#dataviews-in-practice)                         | Ensure UI integrations respect kernel bootstrapping, accessibility defaults, and DataViews controllers.       |
+| Package                        | Key README Sections                                                                                                                                                                                                                                                                                                      | When to Consult                                                                                               |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `@geekist/wp-kernel`           | [Overview](packages/kernel/README.md#overview), [Quick Start](packages/kernel/README.md#quick-start), [Key Patterns](packages/kernel/README.md#key-patterns), [Accessibility contracts & constants](packages/kernel/README.md#accessibility-contracts--constants)                                                        | Understand runtime contracts, lifecycle primitives, and namespace conventions before altering core behaviour. |
+| `@geekist/wp-kernel-cli`       | [Overview](packages/cli/README.md#overview), [Core workflow: init → generate → apply](packages/cli/README.md#core-workflow-init--generate--apply), [Development commands](packages/cli/README.md#development-commands), [Accessibility contracts & constants](packages/cli/README.md#accessibility-contracts--constants) | Align CLI work with the generation pipeline, exit code expectations, and recommended developer flows.         |
+| `@geekist/wp-kernel-e2e-utils` | [Overview](packages/e2e-utils/README.md#overview), [Key Features](packages/e2e-utils/README.md#key-features), [Validation Strategy](packages/e2e-utils/README.md#validation-strategy), [Accessibility contracts & constants](packages/e2e-utils/README.md#accessibility-contracts--constants)                            | Plan test utilities and fixtures that honour shared contracts and observability patterns.                     |
+| `@geekist/wp-kernel-ui`        | [Overview](packages/ui/README.md#overview), [Bootstrapping the runtime](packages/ui/README.md#bootstrapping-the-runtime), [DataViews in practice](packages/ui/README.md#dataviews-in-practice), [Accessibility contracts & constants](packages/ui/README.md#accessibility-contracts--constants)                          | Ensure UI integrations respect kernel bootstrapping, accessibility defaults, and DataViews controllers.       |
 
 Keep this table in sync with README updates so contributors can discover the authoritative guidance for contract changes and implementation steps.

--- a/contracts/ACCESSIBILITY_CONTRACTS.md
+++ b/contracts/ACCESSIBILITY_CONTRACTS.md
@@ -1,0 +1,62 @@
+# Accessibility & Observability Contracts
+
+This document defines the cross-package constants and behavioural norms that underpin accessibility, observability, and error semantics across the WP Kernel monorepo. All packages must consume these contracts instead of hard-coding values to avoid drift.
+
+## Canonical TypeScript Exports
+
+The kernel package publishes the authoritative contract constants from `@geekist/wp-kernel/contracts`.
+
+| Contract                 | Export                          | Description                                                                                                             |
+| ------------------------ | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Action lifecycle phases  | `ACTION_LIFECYCLE_PHASES`       | Ordered tuple of `start`, `complete`, and `error` used to emit lifecycle events.                                        |
+| WordPress hook event map | `ACTION_LIFECYCLE_EVENT_HOOKS`  | Maps lifecycle phases to canonical `wpk.action.*` hook names.                                                           |
+| Kernel event bus map     | `ACTION_LIFECYCLE_BUS_EVENTS`   | Maps lifecycle phases to event bus topics (`action:start`, `action:complete`, `action:error`).                          |
+| Error taxonomy           | `KERNEL_ERROR_CODES`            | Enumerates the permitted `KernelError` codes for downstream packages.                                                   |
+| Namespace contract       | `KERNEL_NAMESPACE_CONTRACT`     | Provides the `wpk` root namespace and subsystem namespaces used for logging/telemetry.                                  |
+| Observability channels   | `KERNEL_OBSERVABILITY_CHANNELS` | Lists the broadcast channel names and hook topics that surface lifecycle telemetry.                                     |
+| CLI/base exit codes      | `KERNEL_EXIT_CODES`             | Canonical numeric exit codes (`SUCCESS`, `VALIDATION_ERROR`, `PRINTER_FAILURE`, `EXTENSION_FAILURE`) shared by tooling. |
+
+> **Usage rule:** import these values directly from `@geekist/wp-kernel/contracts` rather than duplicating literals. Extend the constants in-place when new lifecycle phases or exit codes are introduced.
+
+## Error Semantics
+
+All thrown errors must be instances of `KernelError` (or subclasses) using one of the `KERNEL_ERROR_CODES` values. When wrapping lower-level errors:
+
+1. Set `code` to the most specific enum value.
+2. Preserve the original error on `data.originalError`.
+3. Attach context such as `resourceName`, `actionName`, or `requestId`.
+
+If new error scenarios emerge, extend `KERNEL_ERROR_CODES` and update the defaults in `KernelError` simultaneously to keep runtime behaviour and documentation aligned.
+
+## Lifecycle Events
+
+Action middleware, UI bindings, and telemetry must reference lifecycle metadata via the shared constants:
+
+- Emit WordPress hooks with `ACTION_LIFECYCLE_EVENT_HOOKS[phase]`.
+- Emit kernel bus events with `ACTION_LIFECYCLE_BUS_EVENTS[phase]`.
+- Mark cross-tab payloads with `KERNEL_OBSERVABILITY_CHANNELS.broadcast.channel` and `messageType`.
+
+New lifecycle phases **must** be added to `ACTION_LIFECYCLE_PHASES` before implementation begins so all packages can update in lockstep.
+
+## Namespace Guarantees
+
+Use `KERNEL_NAMESPACE_CONTRACT.framework` (`"wpk"`) as the fallback namespace for reporters and generated code. Subsystems (e.g. `wpk.actions`) come from `KERNEL_NAMESPACE_CONTRACT.subsystems`. Do not invent ad-hoc namespaces-extend this contract if additional scopes are needed.
+
+## Exit Codes
+
+CLI commands and other tooling must communicate process state using `KERNEL_EXIT_CODES`:
+
+- `SUCCESS` – pipeline completed without errors (0)
+- `VALIDATION_ERROR` – user input or configuration invalid (1)
+- `PRINTER_FAILURE` – printers or apply steps failed (2)
+- `EXTENSION_FAILURE` – adapter extensions failed or rolled back (3)
+
+When a new exit path is required, extend `KERNEL_EXIT_CODES` and document the behaviour here before shipping changes.
+
+## Change Control
+
+1. Update this document and the `@geekist/wp-kernel/contracts` exports together.
+2. Reference the relevant ADR/spec (e.g., `configureKernel - Specification.md`) when introducing new contracts.
+3. Link downstream package READMEs and audits to the updated section so contributors immediately see the new expectations.
+
+Keeping these artefacts in sync ensures Phase 0 (shared contracts) and Phase 1 (kernel as source of truth) remain satisfied.

--- a/packages/cli/ACCESSIBILITY_AUDIT.md
+++ b/packages/cli/ACCESSIBILITY_AUDIT.md
@@ -45,8 +45,8 @@ This report inspects the CLI package with attention to the discoverability of co
 
 ### Phase 0 – Adopt Monorepo Contracts
 
-- Consume the shared lifecycle, namespace, and exit code constants published by the kernel once Phase 0 work lands there.
-- Update CLI documentation to reference the cross-package accessibility expectations (error handling, reporter structure, semantic messaging).
+- Consume the shared lifecycle, namespace, and exit code constants exported by `@geekist/wp-kernel/contracts` once Phase 0 work lands there.
+- Update CLI documentation to reference the cross-package accessibility expectations (error handling, reporter structure, semantic messaging) captured in [Accessibility & Observability Contracts](../../contracts/ACCESSIBILITY_CONTRACTS.md).
 - Ensure reporters map CLI error states into the shared `KernelError` taxonomy so downstream tooling observes consistent metadata.
 
 ### Phase 1 – Enable Extensible Registries
@@ -66,3 +66,5 @@ This report inspects the CLI package with attention to the discoverability of co
 - [README § Overview](README.md#overview) – orient new contributors on the CLI mission and supported pipelines before touching command surfaces.
 - [README § Core workflow: init → generate → apply](README.md#core-workflow-init--generate--apply) – understand how generation, reporters, and exit codes interact when designing accessibility improvements.
 - [README § Development commands](README.md#development-commands) – follow the recommended local workflows when validating new contracts, middleware hooks, or reporter changes.
+- [README § Accessibility contracts & constants](README.md#accessibility-contracts--constants) – reuse the shared lifecycle, namespace, and exit-code exports when extending commands.
+- [Accessibility & Observability Contracts](../../contracts/ACCESSIBILITY_CONTRACTS.md) – cross-package norms that must stay in sync with CLI reporters and help output.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -60,6 +60,12 @@ The `start` command replaces `wpk dev`; the latter remains as a deprecated alias
 - **[MVP CLI Spec](./mvp-cli-spec.md)** – authoritative reference for the pipeline
 - **[Kernel docs](https://thegeekist.github.io/wp-kernel/)** – framework guides and configuration reference
 
+## Accessibility contracts & constants
+
+- Start with the shared reference: [Accessibility & Observability Contracts](../../contracts/ACCESSIBILITY_CONTRACTS.md).
+- Import lifecycle phases, namespace helpers, and exit codes from `@geekist/wp-kernel/contracts` when wiring reporters or command registries.
+- Extend the shared constants in the kernel first, then update CLI command docs and reporters to reflect the new contract before shipping.
+
 ## Requirements
 
 - Node.js 20+

--- a/packages/e2e-utils/ACCESSIBILITY_AUDIT.md
+++ b/packages/e2e-utils/ACCESSIBILITY_AUDIT.md
@@ -45,8 +45,8 @@ Evaluate the end-to-end utilities package for discoverability of fixtures, consi
 
 ### Phase 0 – Align with Global Contracts
 
-- Adopt the shared error taxonomy and namespace constants delivered by the kernel, ensuring fixtures throw/report consistent metadata.
-- Update package docs to explain how Playwright tests should consume the cross-package accessibility and observability contracts.
+- Adopt the shared error taxonomy and namespace constants exported by `@geekist/wp-kernel/contracts`, ensuring fixtures throw/report consistent metadata.
+- Update package docs to explain how Playwright tests should consume the cross-package accessibility and observability contracts defined in [Accessibility & Observability Contracts](../../contracts/ACCESSIBILITY_CONTRACTS.md).
 - Coordinate with kernel and CLI teams to align reporter output so CI tooling can aggregate results without bespoke adapters.
 
 ### Phase 1 – Modularise Core Helpers
@@ -66,3 +66,5 @@ Evaluate the end-to-end utilities package for discoverability of fixtures, consi
 - [README § Overview](README.md#overview) – understand the fixture ecosystem and optional nature of the package before planning accessibility changes.
 - [README § Key Features](README.md#key-features) – map utilities to the shared contracts (auth, db, store) when expanding fixtures or adopting new error semantics.
 - [README § Validation Strategy](README.md#validation-strategy) – follow the recommended verification approach to confirm new helpers behave correctly inside real WordPress environments.
+- [README § Accessibility contracts & constants](README.md#accessibility-contracts--constants) – confirm Playwright helpers import the kernel contract exports before asserting lifecycle telemetry.
+- [Accessibility & Observability Contracts](../../contracts/ACCESSIBILITY_CONTRACTS.md) – definitive guidance on lifecycle phases, namespaces, errors, and exit codes for test authors.

--- a/packages/e2e-utils/README.md
+++ b/packages/e2e-utils/README.md
@@ -109,6 +109,12 @@ expect(await dataview.getSelectedCount()).toBeGreaterThan(0);
 - **[E2E Testing Guide](https://thegeekist.github.io/wp-kernel/guide/testing)** - Testing patterns and best practices
 - **[API Reference](https://thegeekist.github.io/wp-kernel/api/e2e-utils)** - Complete utility documentation
 
+## Accessibility contracts & constants
+
+- Review the cross-package expectations in [Accessibility & Observability Contracts](../../contracts/ACCESSIBILITY_CONTRACTS.md) before extending fixtures.
+- Import lifecycle hooks, namespace helpers, and exit codes from `@geekist/wp-kernel/contracts` when asserting telemetry or error states in tests.
+- When new assertions require additional constants, land them in the kernel contract module first and update this README so test authors can track the change.
+
 ## Requirements
 
 - **WordPress**: 6.7+

--- a/packages/kernel/ACCESSIBILITY_AUDIT.md
+++ b/packages/kernel/ACCESSIBILITY_AUDIT.md
@@ -46,8 +46,8 @@ This audit reviews the runtime kernel package through an accessibility and API-s
 
 ### Phase 0 – Define Shared Contracts
 
-- Finalise the canonical lifecycle phase, namespace, and error taxonomy constants that downstream packages will import.
-- Document how kernel errors should wrap lower-level exceptions so CLI, UI, and E2E tooling can adopt identical semantics.
+- Finalise the canonical lifecycle phase, namespace, and error taxonomy constants in [`packages/kernel/src/contracts/index.ts`](./src/contracts/index.ts) so downstream packages can import them.
+- Document how kernel errors should wrap lower-level exceptions so CLI, UI, and E2E tooling can adopt identical semantics in [Accessibility & Observability Contracts](../../contracts/ACCESSIBILITY_CONTRACTS.md).
 - Update specs (`configureKernel - Specification.md`, `Architecture Cohesion Proposal.md`) to capture the shared accessibility obligations before consumers depend on them.
 
 ### Phase 1 – Harden Kernel Primitives
@@ -67,3 +67,5 @@ This audit reviews the runtime kernel package through an accessibility and API-s
 - [README § Overview](README.md#overview) – recap the kernel’s architectural responsibilities before modifying runtime contracts.
 - [README § Quick Start](README.md#quick-start) – follow the bootstrapping path when validating namespace overrides or lifecycle helpers locally.
 - [README § Key Patterns](README.md#key-patterns) – consult examples of resources, actions, and jobs when aligning new accessibility contracts with existing naming conventions.
+- [README § Accessibility contracts & constants](README.md#accessibility-contracts--constants) – confirm which exported constants must be reused or extended during remediation.
+- [Accessibility & Observability Contracts](../../contracts/ACCESSIBILITY_CONTRACTS.md) – authoritative definitions for lifecycle phases, namespaces, errors, and exit codes.

--- a/packages/kernel/README.md
+++ b/packages/kernel/README.md
@@ -149,6 +149,12 @@ import { defineResource } from '@geekist/wp-kernel';
 - **[API Reference](https://thegeekist.github.io/wp-kernel/api/)** - Complete API documentation
 - **[Contracts Reference](https://thegeekist.github.io/wp-kernel/reference/contracts)** - Events, errors, cache keys
 
+## Accessibility contracts & constants
+
+- Read the monorepo contract source: [Accessibility & Observability Contracts](../../contracts/ACCESSIBILITY_CONTRACTS.md).
+- Import lifecycle phases, namespace values, error codes, and CLI exit codes from `@geekist/wp-kernel/contracts` instead of hard-coding literals.
+- When extending the contract, update both the Markdown reference and [`packages/kernel/src/contracts/index.ts`](./src/contracts/index.ts) before rolling changes into downstream packages.
+
 ## Requirements
 
 - **WordPress**: 6.7+ (Script Modules API required)

--- a/packages/kernel/src/contracts/index.ts
+++ b/packages/kernel/src/contracts/index.ts
@@ -1,0 +1,92 @@
+import {
+	WPK_EVENTS,
+	WPK_INFRASTRUCTURE,
+	WPK_NAMESPACE,
+	WPK_SUBSYSTEM_NAMESPACES,
+} from '../namespace/constants';
+import type { ErrorCode } from '../error/types';
+
+/**
+ * Ordered lifecycle phases emitted by the kernel action runtime.
+ */
+export const ACTION_LIFECYCLE_PHASES = ['start', 'complete', 'error'] as const;
+
+export type ActionLifecyclePhase = (typeof ACTION_LIFECYCLE_PHASES)[number];
+
+/**
+ * WordPress hook event names keyed by lifecycle phase.
+ */
+export const ACTION_LIFECYCLE_EVENT_HOOKS: Record<
+	ActionLifecyclePhase,
+	string
+> = {
+	start: WPK_EVENTS.ACTION_START,
+	complete: WPK_EVENTS.ACTION_COMPLETE,
+	error: WPK_EVENTS.ACTION_ERROR,
+} as const;
+
+/**
+ * Kernel event bus topics keyed by lifecycle phase.
+ */
+export const ACTION_LIFECYCLE_BUS_EVENTS = {
+	start: 'action:start',
+	complete: 'action:complete',
+	error: 'action:error',
+} as const satisfies Record<ActionLifecyclePhase, string>;
+
+/**
+ * Supported KernelError codes. Downstream packages should narrow to this union
+ * instead of hard-coding string literals.
+ */
+export const KERNEL_ERROR_CODES = [
+	'TransportError',
+	'ServerError',
+	'PolicyDenied',
+	'ValidationError',
+	'TimeoutError',
+	'NotImplementedError',
+	'DeveloperError',
+	'DeprecatedError',
+	'UnknownError',
+] as const satisfies ReadonlyArray<ErrorCode>;
+
+export type KernelErrorCode = (typeof KERNEL_ERROR_CODES)[number];
+
+/**
+ * Shared namespace contract including subsystem namespaces used for reporters
+ * and telemetry payloads.
+ */
+export const KERNEL_NAMESPACE_CONTRACT = {
+	framework: WPK_NAMESPACE,
+	subsystems: WPK_SUBSYSTEM_NAMESPACES,
+} as const;
+
+/**
+ * Observability channels used by lifecycle telemetry. Consumers should adopt
+ * these identifiers when broadcasting or listening for action events.
+ */
+export const KERNEL_OBSERVABILITY_CHANNELS = {
+	broadcast: {
+		channel: WPK_INFRASTRUCTURE.ACTIONS_CHANNEL,
+		messageTypes: {
+			lifecycle: WPK_INFRASTRUCTURE.ACTIONS_MESSAGE_TYPE_LIFECYCLE,
+			customEvent: WPK_INFRASTRUCTURE.ACTIONS_MESSAGE_TYPE_EVENT,
+		},
+	},
+	hooks: ACTION_LIFECYCLE_EVENT_HOOKS,
+	bus: ACTION_LIFECYCLE_BUS_EVENTS,
+} as const;
+
+/**
+ * Canonical exit codes shared by the CLI and other tooling pipelines. Extend
+ * this object when new error categories are introduced.
+ */
+export const KERNEL_EXIT_CODES = {
+	SUCCESS: 0,
+	VALIDATION_ERROR: 1,
+	PRINTER_FAILURE: 2,
+	EXTENSION_FAILURE: 3,
+} as const;
+
+export type KernelExitCode =
+	(typeof KERNEL_EXIT_CODES)[keyof typeof KERNEL_EXIT_CODES];

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -56,6 +56,7 @@ export * as actions from './actions/index.js';
 export * as policy from './policy/index.js';
 export * as data from './data/index.js';
 export * as events from './events/index.js';
+export * as contracts from './contracts/index.js';
 
 // ============================================================================
 // Flat Exports (Convenience aliases)
@@ -231,3 +232,19 @@ export type {
 	NamespaceDetectionMode,
 	NamespaceRuntimeContext,
 } from './namespace/detect.js';
+
+// Accessibility & observability contracts
+export {
+	ACTION_LIFECYCLE_PHASES,
+	ACTION_LIFECYCLE_EVENT_HOOKS,
+	ACTION_LIFECYCLE_BUS_EVENTS,
+	KERNEL_ERROR_CODES,
+	KERNEL_NAMESPACE_CONTRACT,
+	KERNEL_OBSERVABILITY_CHANNELS,
+	KERNEL_EXIT_CODES,
+} from './contracts/index.js';
+export type {
+	ActionLifecyclePhase,
+	KernelErrorCode,
+	KernelExitCode,
+} from './contracts/index.js';

--- a/packages/ui/ACCESSIBILITY_AUDIT.md
+++ b/packages/ui/ACCESSIBILITY_AUDIT.md
@@ -46,8 +46,8 @@ Assess the UI package for accessibility guarantees, naming consistency, and comp
 
 ### Phase 0 – Synchronise with Global Contracts
 
-- Adopt the shared error taxonomy and lifecycle constants from the kernel to drive UI state messaging and async boundaries.
-- Update UI documentation to reflect the monorepo accessibility contract, including expectations for semantic wrappers and observability hooks.
+- Adopt the shared error taxonomy and lifecycle constants from `@geekist/wp-kernel/contracts` to drive UI state messaging and async boundaries.
+- Update UI documentation to reflect the monorepo accessibility contract, including expectations for semantic wrappers and observability hooks described in [Accessibility & Observability Contracts](../../contracts/ACCESSIBILITY_CONTRACTS.md).
 - Ensure provider/runtime code surfaces the shared namespace helpers so UI integrations validate configuration consistently with other packages.
 
 ### Phase 1 – Decompose & Expose Headless Primitives
@@ -67,3 +67,5 @@ Assess the UI package for accessibility guarantees, naming consistency, and comp
 - [README § Overview](README.md#overview) – clarify the role of UI primitives before designing new accessibility defaults or contracts.
 - [README § Bootstrapping the runtime](README.md#bootstrapping-the-runtime) – ensure runtime wiring and provider expectations stay aligned while introducing new hooks or headless primitives.
 - [README § DataViews in practice](README.md#dataviews-in-practice) – follow the recommended controller patterns when extending DataView integrations or documenting accessibility wrappers.
+- [README § Accessibility contracts & constants](README.md#accessibility-contracts--constants) – reuse the shared lifecycle, namespace, and error contracts when building headless primitives or slots.
+- [Accessibility & Observability Contracts](../../contracts/ACCESSIBILITY_CONTRACTS.md) – authoritative definitions that UI components must honour when surfacing telemetry and error messaging.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -154,6 +154,12 @@ await dataview.runBulkAction('Publish');
 
 See the [DataViews guide](../../docs/guide/dataviews.md) for a full walkthrough covering configuration, CLI scaffolding, runtime integration, migration strategy, and accessibility follow-ups.
 
+## Accessibility contracts & constants
+
+- Consult [Accessibility & Observability Contracts](../../contracts/ACCESSIBILITY_CONTRACTS.md) before shipping new controllers or slots.
+- Import lifecycle hooks, namespace helpers, and error codes from `@geekist/wp-kernel/contracts` so UI components surface the same telemetry and messaging as the runtime.
+- Extend the kernel contract module first when adding new states or observability hooks, then update this README and the UI audit to keep guidance in sync.
+
 ## Additional resources
 
 - [DataViews Integration – Specification](./DataViews%20Integration%20-%20Specification.md)


### PR DESCRIPTION
## Summary
- add accessibility and API surface audit reports for the kernel, CLI, E2E utils, and UI packages
- add a monorepo comparison note summarising strengths, gaps, and cross-package recommendations

## Testing
- pnpm --recursive --filter './packages/*' --filter './app/*' run typecheck
- pnpm --recursive --filter './packages/*' --filter './app/*' run typecheck:tests
- pnpm test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68ecff355d088325adbadcf8acf1b63a