### PR TITLE
Improve init tsconfig scaffolding and taxonomy generation

### DIFF
--- a/examples/showcase/.generated/php/Rest/JobController.php
+++ b/examples/showcase/.generated/php/Rest/JobController.php
@@ -308,7 +308,7 @@ class JobController extends BaseController
             $departmentTerms = array_filter(
                 array_map("intval", (array) $departmentTerms),
             );
-            if (empty(${variable})) {
+            if (empty($departmentTerms)) {
                 continue;
             }
             $tax_query[] = [
@@ -325,7 +325,7 @@ class JobController extends BaseController
             $locationTerms = array_filter(
                 array_map("intval", (array) $locationTerms),
             );
-            if (empty(${variable})) {
+            if (empty($locationTerms)) {
                 continue;
             }
             $tax_query[] = [

--- a/examples/showcase/tsconfig.json
+++ b/examples/showcase/tsconfig.json
@@ -8,16 +8,16 @@
 		"jsx": "react-jsx",
 		"jsxImportSource": "react",
 		"paths": {
-			"@/*": ["./examples/showcase/src/*"],
-			"@wpkernel/core": ["./packages/core/src/index.ts"],
-			"@wpkernel/core/*": ["./packages/core/src/*"],
-			"@wpkernel/ui": ["./packages/ui/src/index.ts"],
-			"@wpkernel/ui/*": ["./packages/ui/src/*"],
-			"@wpkernel/cli": ["./packages/cli/src/index.ts"],
-			"@wpkernel/cli/*": ["./packages/cli/src/*"],
-			"@wpkernel/e2e-utils": ["./packages/e2e-utils/src/index.ts"],
-			"@wpkernel/e2e-utils/*": ["./packages/e2e-utils/src/*"],
-			"@test-utils/*": ["./tests/test-utils/*"]
+			"@/*": ["./src/*"],
+			"@wpkernel/core": ["../../packages/core/src/index.ts"],
+			"@wpkernel/core/*": ["../../packages/core/src/*"],
+			"@wpkernel/ui": ["../../packages/ui/src/index.ts"],
+			"@wpkernel/ui/*": ["../../packages/ui/src/*"],
+			"@wpkernel/cli": ["../../packages/cli/src/index.ts"],
+			"@wpkernel/cli/*": ["../../packages/cli/src/*"],
+			"@wpkernel/e2e-utils": ["../../packages/e2e-utils/src/index.ts"],
+			"@wpkernel/e2e-utils/*": ["../../packages/e2e-utils/src/*"],
+			"@test-utils/*": ["../../tests/test-utils/*"]
 		}
 	},
 	"include": [

--- a/packages/cli/src/printers/php/wp-post/taxonomies.ts
+++ b/packages/cli/src/printers/php/wp-post/taxonomies.ts
@@ -18,7 +18,7 @@ export function appendTaxonomyQueryBuilder(
 		body.line(
 			`        ${variable} = array_filter( array_map( 'intval', (array) ${variable} ) );`
 		);
-		body.line('        if ( empty( ${variable} ) ) {');
+		body.line(`        if ( empty( ${variable} ) ) {`);
 		body.line('                continue;');
 		body.line('        }');
 		body.line('        $tax_query[] = array(');

--- a/packages/cli/templates/init/tsconfig.json
+++ b/packages/cli/templates/init/tsconfig.json
@@ -5,12 +5,15 @@
 		"module": "ESNext",
 		"moduleResolution": "Bundler",
 		"jsx": "react-jsx",
+		"jsxImportSource": "react",
 		"strict": true,
 		"esModuleInterop": true,
 		"moduleDetection": "force",
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
-		"types": ["node"]
+		"types": ["node"],
+		"paths": "__WPK_TSCONFIG_PATHS__"
 	},
-	"include": ["src", "kernel.config.ts"]
+	"include": ["src/**/*", ".generated/types/**/*.d.ts", "kernel.config.ts"],
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,6 +66,11 @@
 			"import": "./dist/hooks/useNextPagePrefetch.js",
 			"default": "./dist/hooks/useNextPagePrefetch.js"
 		},
+		"./dataviews": {
+			"types": "./dist/dataviews/index.d.ts",
+			"import": "./dist/dataviews/index.js",
+			"default": "./dist/dataviews/index.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"files": [


### PR DESCRIPTION
## Summary
- expose the dataviews entry points from @wpkernel/ui so consumers can import them directly
- teach the CLI init template to scaffold tsconfig.json with workspace-aware path aliases and add coverage
- ensure taxonomy controllers emit real variable names and sync the showcase job controller and tsconfig

## Testing
- pnpm --filter @wpkernel/cli build
- pnpm --filter @wpkernel/cli test:coverage
- pnpm --filter wp-kernel-showcase exec node ../../packages/cli/bin/wpk.js init --force --name showcase-demo
- (from examples/showcase) node ../../packages/cli/bin/wpk.js generate
- (from examples/showcase) node ../../packages/cli/bin/wpk.js apply


------
https://chatgpt.com/codex/tasks/task_e_68efa38c22b08325ab5dfc6cf9e049b0