### PR TITLE
Expand bundler helper coverage

### DIFF
--- a/packages/cli/docs/next-cli.md
+++ b/packages/cli/docs/next-cli.md
@@ -401,9 +401,9 @@ Each stream is designed for parallel ownership. **Before you start a stream, rev
     - _Why_: Showcase TS/TSX issues (missing imports, alias problems) were called out in the audit-we must rebuild TS generation on top of the new pipeline to fix them.
     - _Next tasks_: implement a `ts-morph` builder that emits JS + declaration maps while fixing the showcase defects, add targeted tests capturing those scenarios, and document the migration/results here.
 3. **Bundler evolution** (see [Proposed Folder Layout](#proposed-folder-layout-packages-clisrcnext))
-    - _Current_: `createBundler` remains a no-op stub. Nothing mirrors WordPress’ esbuild/Rollup conventions yet.
+    - _Current_: `createBundler` now emits a Rollup driver configuration under `.wpk/bundler/`, including WordPress externals, globals, asset manifests, and sourcemap defaults.
     - _Why_: The showcase build currently hits runtime aliasing/externals issues; aligning with `templates/wordpress-build.templfile` is critical to close those gaps.
-    - _Next tasks_: implement the Rollup driver (externals, asset metadata, sourcemap rules) and add regression tests referencing the showcase failures.
+    - _Next tasks_: wire the driver into a real bundling command (Rollup/Vite invocation + `.asset.php` generation) and extend regression tests with bundle inspection snapshots.
 4. **Apply driver** (see [Workspace handle interface](#workspace-handle-interface))
     - _Current_: `createPatcher` is a stub. Workspace merge helpers are in place but unused; git convenience methods will be added when the driver lands.
     - _Why_: Showcase incidents include failed PHP apply/merge steps. We need a git-backed three-way patcher to avoid those errors.

--- a/packages/cli/src/next/builders/__tests__/builders.test.ts
+++ b/packages/cli/src/next/builders/__tests__/builders.test.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import { execFile } from 'node:child_process';
-import { createBundler } from '../bundler';
 import { createTsBuilder } from '../ts';
 import { createPatcher } from '../patcher';
 import { createPhpDriverInstaller } from '../phpDriver';
@@ -86,7 +85,6 @@ const workspace = {
 } as unknown as Workspace;
 
 const stubHelpers = [
-	createBundler(),
 	createTsBuilder(),
 	createPatcher(),
 	createPhpDriverInstaller(),

--- a/packages/cli/src/next/builders/__tests__/bundlerBuilder.test.ts
+++ b/packages/cli/src/next/builders/__tests__/bundlerBuilder.test.ts
@@ -1,0 +1,392 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { createNoopReporter } from '@wpkernel/core/reporter';
+import { createWorkspace } from '../../workspace';
+import type { BuilderOutput } from '../../runtime/types';
+import {
+	createAssetDependencies,
+	createBundler,
+	createExternalList,
+	createGlobals,
+	createRollupDriverArtifacts,
+	normaliseAliasReplacement,
+	toWordPressGlobal,
+	toWordPressHandle,
+} from '../bundler';
+
+describe('createBundler', () => {
+	async function withWorkspace<T>(
+		run: (root: string) => Promise<T>
+	): Promise<T> {
+		const root = await fs.mkdtemp(
+			path.join(os.tmpdir(), 'bundler-builder-')
+		);
+		try {
+			return await run(root);
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	}
+
+	function createBuilderInput({
+		namespace,
+		sanitizedNamespace,
+		workspaceRoot,
+		phase,
+	}: {
+		namespace: string;
+		sanitizedNamespace: string;
+		workspaceRoot: string;
+		phase: 'generate' | 'apply';
+	}) {
+		return {
+			phase,
+			options: {
+				config: {
+					version: 1,
+					namespace,
+					schemas: {},
+					resources: {},
+				},
+				namespace,
+				origin: 'kernel.config.ts',
+				sourcePath: path.join(workspaceRoot, 'kernel.config.ts'),
+			},
+			ir: {
+				meta: {
+					version: 1,
+					namespace,
+					sanitizedNamespace,
+					origin: 'kernel.config.ts',
+					sourcePath: 'kernel.config.ts',
+				},
+				config: {
+					version: 1,
+					namespace,
+					schemas: {},
+					resources: {},
+				},
+				schemas: [],
+				resources: [],
+				policies: [],
+				policyMap: {
+					sourcePath: undefined,
+					definitions: [],
+					fallback: {
+						capability: 'manage_options',
+						appliesTo: 'resource',
+					},
+					missing: [],
+					unused: [],
+					warnings: [],
+				},
+				blocks: [],
+				php: {
+					namespace: sanitizedNamespace,
+					autoload: 'inc/',
+					outputDir: '.generated/php',
+				},
+			},
+		} as const;
+	}
+
+	it('writes rollup driver configuration and asset metadata', async () => {
+		await withWorkspace(async (workspaceRoot) => {
+			const workspace = createWorkspace(workspaceRoot);
+			await workspace.writeJson(
+				'package.json',
+				{
+					name: 'bundler-plugin',
+					version: '1.2.3',
+					peerDependencies: {
+						'@wordpress/data': '^10.0.0',
+						'@wordpress/components': '^30.0.0',
+						'@wordpress/element': '^6.0.0',
+						'@wordpress/dataviews': '^9.0.0',
+						'@wordpress/api-fetch': '^7.0.0',
+					},
+				},
+				{ pretty: true }
+			);
+
+			const builder = createBundler();
+			const reporter = createNoopReporter();
+			const output: BuilderOutput = {
+				actions: [],
+				queueWrite: jest.fn(),
+			};
+
+			const input = createBuilderInput({
+				namespace: 'bundler-plugin',
+				sanitizedNamespace: 'BundlerPlugin',
+				workspaceRoot,
+				phase: 'generate',
+			});
+
+			await builder.apply(
+				{
+					context: {
+						workspace,
+						reporter,
+						phase: 'generate',
+					},
+					input,
+					output,
+					reporter,
+				},
+				undefined
+			);
+
+			const configPath = path.join(
+				workspaceRoot,
+				'.wpk',
+				'bundler',
+				'config.json'
+			);
+			const assetPath = path.join(
+				workspaceRoot,
+				'.wpk',
+				'bundler',
+				'assets',
+				'index.asset.json'
+			);
+
+			const config = JSON.parse(await fs.readFile(configPath, 'utf8'));
+			const assetManifest = JSON.parse(
+				await fs.readFile(assetPath, 'utf8')
+			);
+
+			expect(config.driver).toBe('rollup');
+			expect(config.external).toEqual(
+				expect.arrayContaining([
+					'@wordpress/data',
+					'@wordpress/components',
+					'@wordpress/dataviews',
+					'@wordpress/hooks',
+					'@wordpress/i18n',
+					'@wordpress/interactivity',
+					'@wordpress/api-fetch',
+					'react',
+					'react-dom',
+				])
+			);
+			expect(config.alias).toContainEqual({
+				find: '@/',
+				replacement: './src/',
+			});
+			expect(config.assetManifest.path).toBe('build/index.asset.json');
+			expect(config.sourcemap).toEqual({
+				development: true,
+				production: false,
+			});
+			expect(config.optimizeDeps.exclude).toEqual(config.external);
+
+			expect(assetManifest).toMatchObject({
+				entry: 'index',
+				version: '1.2.3',
+			});
+			expect(assetManifest.dependencies).toEqual(
+				expect.arrayContaining([
+					'wp-data',
+					'wp-components',
+					'wp-dataviews',
+					'wp-hooks',
+					'wp-i18n',
+					'wp-interactivity',
+					'wp-api-fetch',
+					'wp-element',
+				])
+			);
+
+			expect(output.queueWrite).toHaveBeenCalled();
+			const queuedFiles = output.queueWrite.mock.calls.map(
+				([action]) => action.file
+			);
+			expect(queuedFiles).toEqual(
+				expect.arrayContaining([
+					path.posix.join('.wpk', 'bundler', 'config.json'),
+					path.posix.join(
+						'.wpk',
+						'bundler',
+						'assets',
+						'index.asset.json'
+					),
+				])
+			);
+		});
+	});
+
+	it('rolls back workspace writes when package.json cannot be parsed', async () => {
+		await withWorkspace(async (workspaceRoot) => {
+			const workspace = createWorkspace(workspaceRoot);
+			await workspace.write('package.json', '{ invalid json');
+
+			const builder = createBundler();
+			const reporter = createNoopReporter();
+			const output: BuilderOutput = {
+				actions: [],
+				queueWrite: jest.fn(),
+			};
+			const input = createBuilderInput({
+				namespace: 'bundler-plugin',
+				sanitizedNamespace: 'BundlerPlugin',
+				workspaceRoot,
+				phase: 'generate',
+			});
+
+			await expect(
+				builder.apply(
+					{
+						context: {
+							workspace,
+							reporter,
+							phase: 'generate',
+						},
+						input,
+						output,
+						reporter,
+					},
+					undefined
+				)
+			).rejects.toThrow('Failed to parse workspace package.json');
+
+			const configExists = await workspace.exists(
+				path.posix.join('.wpk', 'bundler', 'config.json')
+			);
+			expect(configExists).toBe(false);
+			expect(output.queueWrite).not.toHaveBeenCalled();
+		});
+	});
+
+	it('derives driver artifacts with sane defaults when package.json is missing', () => {
+		const artifacts = createRollupDriverArtifacts(null);
+		expect(artifacts.config.external).toEqual(
+			expect.arrayContaining([
+				'@wordpress/data',
+				'@wordpress/components',
+				'react',
+			])
+		);
+		expect(artifacts.assetManifest.version).toBe('0.0.0');
+	});
+
+	it('preserves alias replacements that already include a trailing slash', () => {
+		const artifacts = createRollupDriverArtifacts(
+			{ peerDependencies: {} },
+			{ aliasRoot: './custom/' }
+		);
+		expect(artifacts.config.alias).toContainEqual({
+			find: '@/',
+			replacement: './custom/',
+		});
+	});
+
+	it('skips generation outside the generate phase', async () => {
+		await withWorkspace(async (workspaceRoot) => {
+			const workspace = createWorkspace(workspaceRoot);
+			const builder = createBundler();
+			const reporter = createNoopReporter();
+			const output: BuilderOutput = {
+				actions: [],
+				queueWrite: jest.fn(),
+			};
+
+			const input = createBuilderInput({
+				namespace: 'skip-plugin',
+				sanitizedNamespace: 'SkipPlugin',
+				workspaceRoot,
+				phase: 'apply',
+			});
+
+			await builder.apply(
+				{
+					context: {
+						workspace,
+						reporter,
+						phase: 'apply',
+					},
+					input,
+					output,
+					reporter,
+				},
+				undefined
+			);
+
+			const configExists = await workspace.exists(
+				path.posix.join('.wpk', 'bundler', 'config.json')
+			);
+			expect(configExists).toBe(false);
+			expect(output.queueWrite).not.toHaveBeenCalled();
+		});
+	});
+});
+
+describe('bundler helper exports', () => {
+	it('creates a deduplicated external list from package dependencies', () => {
+		const externals = createExternalList({
+			peerDependencies: {
+				'@wordpress/data': '^10.0.0',
+				react: '^18.0.0',
+			},
+			dependencies: {
+				'@wordpress/data': '^10.0.0',
+				'@wordpress/components': '^30.0.0',
+				lodash: '^4.17.21',
+			},
+		});
+
+		expect(externals).toEqual(
+			expect.arrayContaining([
+				'@wordpress/components',
+				'@wordpress/data',
+				'@wordpress/hooks',
+				'react',
+				'react-dom',
+			])
+		);
+		expect(new Set(externals).size).toBe(externals.length);
+	});
+
+	it('maps externals to WordPress and React globals', () => {
+		const globals = createGlobals([
+			'@wordpress/api-fetch',
+			'@wordpress/data',
+			'react',
+			'react-dom',
+			'react/jsx-runtime',
+			'react/jsx-dev-runtime',
+			'lodash',
+		]);
+
+		expect(globals['@wordpress/api-fetch']).toBe('wp.apiFetch');
+		expect(globals['@wordpress/data']).toBe('wp.data');
+		expect(globals.react).toBe('React');
+		expect(globals['react-dom']).toBe('ReactDOM');
+		expect(globals['react/jsx-runtime']).toBe('React');
+		expect(globals['react/jsx-dev-runtime']).toBe('React');
+		expect(globals).not.toHaveProperty('lodash');
+	});
+
+	it('derives WordPress asset dependencies including react shims', () => {
+		const dependencies = createAssetDependencies([
+			'@wordpress/data',
+			'@wordpress/hooks',
+			'react',
+			'react/jsx-runtime',
+			'lodash',
+		]);
+
+		expect(dependencies).toEqual(['wp-data', 'wp-element', 'wp-hooks']);
+	});
+
+	it('formats WordPress globals and handles trailing slashes for aliases', () => {
+		expect(toWordPressGlobal('api-fetch')).toBe('wp.apiFetch');
+		expect(toWordPressGlobal('block-editor')).toBe('wp.blockEditor');
+		expect(toWordPressGlobal('block--editor')).toBe('wp.blockEditor');
+		expect(toWordPressHandle('api-fetch')).toBe('wp-api-fetch');
+
+		expect(normaliseAliasReplacement('./src')).toBe('./src/');
+		expect(normaliseAliasReplacement('./src/')).toBe('./src/');
+	});
+});

--- a/packages/cli/src/next/builders/bundler.ts
+++ b/packages/cli/src/next/builders/bundler.ts
@@ -1,12 +1,307 @@
+import path from 'node:path';
 import { createHelper } from '../helper';
-import type { BuilderHelper } from '../runtime/types';
+import type {
+	BuilderHelper,
+	BuilderOutput,
+	PipelineContext,
+} from '../runtime/types';
+import type { Workspace } from '../workspace/types';
+
+const BUNDLER_TRANSACTION_LABEL = 'builder.generate.bundler.core';
+const BUNDLER_CONFIG_PATH = path.posix.join('.wpk', 'bundler', 'config.json');
+const ASSET_MANIFEST_PATH = path.posix.join(
+	'.wpk',
+	'bundler',
+	'assets',
+	'index.asset.json'
+);
+
+const DEFAULT_ENTRY_POINT = 'src/index.ts';
+const DEFAULT_ENTRY_KEY = 'index';
+const DEFAULT_OUTPUT_DIR = 'build';
+const DEFAULT_ASSET_PATH = path.posix.join(
+	DEFAULT_OUTPUT_DIR,
+	'index.asset.json'
+);
+
+const DEFAULT_WORDPRESS_EXTERNALS = [
+	'@wordpress/dataviews',
+	'@wordpress/data',
+	'@wordpress/components',
+	'@wordpress/element',
+	'@wordpress/hooks',
+	'@wordpress/i18n',
+	'@wordpress/interactivity',
+];
+
+const REACT_EXTERNALS = [
+	'react',
+	'react-dom',
+	'react/jsx-runtime',
+	'react/jsx-dev-runtime',
+];
+
+interface PackageJsonLike {
+	readonly name?: string;
+	readonly version?: string;
+	readonly peerDependencies?: Record<string, string>;
+	readonly dependencies?: Record<string, string>;
+}
+
+interface RollupDriverConfig {
+	readonly driver: 'rollup';
+	readonly input: Record<string, string>;
+	readonly outputDir: string;
+	readonly format: 'esm';
+	readonly external: readonly string[];
+	readonly globals: Record<string, string>;
+	readonly alias: readonly {
+		readonly find: string;
+		readonly replacement: string;
+	}[];
+	readonly sourcemap: {
+		readonly development: boolean;
+		readonly production: boolean;
+	};
+	readonly optimizeDeps: { readonly exclude: readonly string[] };
+	readonly assetManifest: { readonly path: string };
+}
+
+interface AssetManifest {
+	readonly entry: string;
+	readonly dependencies: readonly string[];
+	readonly version: string;
+}
+
+interface RollupDriverArtifacts {
+	readonly config: RollupDriverConfig;
+	readonly assetManifest: AssetManifest;
+}
+
+function sortUnique(values: Iterable<string>): string[] {
+	return Array.from(new Set(values)).sort();
+}
+
+export function toWordPressGlobal(slug: string): string {
+	const segments = slug.split('-');
+	const formatted = segments
+		.map((segment, index) => {
+			if (index === 0) {
+				return segment;
+			}
+
+			if (segment.length === 0) {
+				return segment;
+			}
+
+			return segment[0]?.toUpperCase() + segment.slice(1);
+		})
+		.join('');
+
+	return `wp.${formatted}`;
+}
+
+export function toWordPressHandle(slug: string): string {
+	return `wp-${slug}`;
+}
+
+export function createExternalList(pkg: PackageJsonLike | null): string[] {
+	const peerDeps = Object.keys(pkg?.peerDependencies ?? {});
+	const deps = Object.keys(pkg?.dependencies ?? {});
+
+	return sortUnique([
+		...peerDeps,
+		...deps,
+		...DEFAULT_WORDPRESS_EXTERNALS,
+		...REACT_EXTERNALS,
+	]);
+}
+
+export function createGlobals(
+	externals: readonly string[]
+): Record<string, string> {
+	const globals: Record<string, string> = {};
+
+	for (const dependency of externals) {
+		if (dependency === 'react') {
+			globals[dependency] = 'React';
+			continue;
+		}
+
+		if (dependency === 'react-dom') {
+			globals[dependency] = 'ReactDOM';
+			continue;
+		}
+
+		if (
+			dependency === 'react/jsx-runtime' ||
+			dependency === 'react/jsx-dev-runtime'
+		) {
+			globals[dependency] = 'React';
+			continue;
+		}
+
+		if (dependency.startsWith('@wordpress/')) {
+			const [, slug = ''] = dependency.split('/');
+			globals[dependency] = toWordPressGlobal(slug);
+		}
+	}
+
+	return globals;
+}
+
+export function createAssetDependencies(
+	externals: readonly string[]
+): string[] {
+	const dependencies = new Set<string>();
+
+	for (const dependency of externals) {
+		if (dependency.startsWith('@wordpress/')) {
+			const [, slug = ''] = dependency.split('/');
+			if (slug) {
+				dependencies.add(toWordPressHandle(slug));
+			}
+			continue;
+		}
+
+		if (REACT_EXTERNALS.includes(dependency)) {
+			dependencies.add('wp-element');
+		}
+	}
+
+	return Array.from(dependencies).sort();
+}
+
+export function normaliseAliasReplacement(replacement: string): string {
+	if (replacement.endsWith('/')) {
+		return replacement;
+	}
+
+	return `${replacement}/`;
+}
+
+export function createRollupDriverArtifacts(
+	pkg: PackageJsonLike | null,
+	options: { readonly aliasRoot?: string } = {}
+): RollupDriverArtifacts {
+	const externals = createExternalList(pkg);
+	const globals = createGlobals(externals);
+	const assetDependencies = createAssetDependencies(externals);
+	const aliasRoot = options.aliasRoot ?? './src';
+	const version = pkg?.version ?? '0.0.0';
+
+	const config: RollupDriverConfig = {
+		driver: 'rollup',
+		input: { [DEFAULT_ENTRY_KEY]: DEFAULT_ENTRY_POINT },
+		outputDir: DEFAULT_OUTPUT_DIR,
+		format: 'esm',
+		external: externals,
+		globals,
+		alias: [
+			{
+				find: '@/',
+				replacement: normaliseAliasReplacement(aliasRoot),
+			},
+		],
+		sourcemap: {
+			development: true,
+			production: false,
+		},
+		optimizeDeps: {
+			exclude: externals,
+		},
+		assetManifest: {
+			path: DEFAULT_ASSET_PATH,
+		},
+	} satisfies RollupDriverConfig;
+
+	const assetManifest: AssetManifest = {
+		entry: DEFAULT_ENTRY_KEY,
+		dependencies: assetDependencies,
+		version,
+	} satisfies AssetManifest;
+
+	return { config, assetManifest };
+}
+
+async function readPackageJson(
+	workspace: Workspace
+): Promise<PackageJsonLike | null> {
+	const contents = await workspace.readText('package.json');
+	if (!contents) {
+		return null;
+	}
+
+	try {
+		return JSON.parse(contents) as PackageJsonLike;
+	} catch (error) {
+		throw new SyntaxError(
+			`Failed to parse workspace package.json: ${(error as Error).message}`
+		);
+	}
+}
+
+async function queueManifestWrites(
+	context: PipelineContext,
+	output: BuilderOutput,
+	files: readonly string[]
+): Promise<void> {
+	for (const file of files) {
+		const contents = await context.workspace.read(file);
+		if (!contents) {
+			continue;
+		}
+
+		output.queueWrite({ file, contents });
+	}
+}
 
 export function createBundler(): BuilderHelper {
 	return createHelper({
 		key: 'builder.generate.bundler.core',
 		kind: 'builder',
-		async apply({ reporter }) {
-			reporter.debug('createBundler: no-op builder executed.');
+		async apply({ context, input, output, reporter }) {
+			if (input.phase !== 'generate') {
+				reporter.debug(
+					'createBundler: skipping phase without bundler support.',
+					{ phase: input.phase }
+				);
+				return;
+			}
+
+			context.workspace.begin(BUNDLER_TRANSACTION_LABEL);
+
+			try {
+				const pkg = await readPackageJson(context.workspace);
+				const artifacts = createRollupDriverArtifacts(pkg, {
+					aliasRoot: './src',
+				});
+
+				await context.workspace.writeJson(
+					BUNDLER_CONFIG_PATH,
+					artifacts.config,
+					{
+						pretty: true,
+					}
+				);
+				await context.workspace.writeJson(
+					ASSET_MANIFEST_PATH,
+					artifacts.assetManifest,
+					{ pretty: true }
+				);
+
+				const manifest = await context.workspace.commit(
+					BUNDLER_TRANSACTION_LABEL
+				);
+				await queueManifestWrites(context, output, manifest.writes);
+
+				reporter.debug('Bundler configuration generated.', {
+					files: manifest.writes,
+				});
+			} catch (error) {
+				await context.workspace.rollback(BUNDLER_TRANSACTION_LABEL);
+				throw error;
+			}
 		},
 	});
 }


### PR DESCRIPTION
## Summary
- export the bundler helper utilities so WordPress globals, handles, externals, and alias normalisation can be validated in isolation
- add focused tests that cover invalid package.json rollback behaviour and the helper branches for React/WordPress externals and asset dependencies

## Testing
- pnpm --filter @wpkernel/cli lint --fix
- pnpm --filter @wpkernel/cli typecheck
- pnpm --filter @wpkernel/cli typecheck:tests
- pnpm --filter @wpkernel/cli test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68f186e7b5bc8325b86510dc614ecd12