### PR TITLE
Workstream 4: prune build command and expand coverage

### DIFF
--- a/packages/cli/docs/next-cli.md
+++ b/packages/cli/docs/next-cli.md
@@ -166,8 +166,10 @@ _Update the relevant workstream below when scope changes or a milestone closes. 
     - Only `NextApplyCommand` exported; no next equivalents for `init`, `generate`, `start`, `build`, `doctor`.
 - **Tasks**
     1. Port helpers like `ensureGeneratedPhpClean`, `ensureCleanDirectory`, and prompt utilities into the next workspace layer.
-    2. Implement `createInitCommand`, `createGenerateCommand`, `createStartCommand`, `createBuildCommand`, and `createDoctorCommand` under `packages/cli/src/next/commands`, mirroring legacy behaviour via the new helpers.
+    2. Implement `createInitCommand`, `createGenerateCommand`, `createStartCommand`, and `createDoctorCommand` under `packages/cli/src/next/commands`, mirroring legacy behaviour via the new helpers while the legacy `build` workflow remains in place.
     3. Export the new commands through `packages/cli/src/next/index.ts` and update docs/tests accordingly.
+
+_Status update:_ Workspace helpers for git hygiene, directory safety, and confirmations now live under `next/workspace/utilities.ts`, and the next command surface exports factory wrappers for init, generate, start, and doctor while `build` remains a legacy-only workflow for now.
 
 ### Workstream 5 – Quality, Testing & Documentation
 

--- a/packages/cli/src/next/__tests__/index.test.ts
+++ b/packages/cli/src/next/__tests__/index.test.ts
@@ -1,5 +1,30 @@
+import { Command } from 'clipanion';
+
+function createStubCommand(name: string) {
+	class Stub extends Command {
+		static override paths = [[name]] as const;
+	}
+
+	return Stub;
+}
+
 describe('next index exports', () => {
 	it('re-exports builder factories and helpers', async () => {
+		jest.resetModules();
+
+		await jest.unstable_mockModule('../commands/init', () => ({
+			createInitCommand: () => createStubCommand('init'),
+		}));
+		await jest.unstable_mockModule('../commands/generate', () => ({
+			createGenerateCommand: () => createStubCommand('generate'),
+		}));
+		await jest.unstable_mockModule('../commands/start', () => ({
+			createStartCommand: () => createStubCommand('start'),
+		}));
+		await jest.unstable_mockModule('../commands/doctor', () => ({
+			createDoctorCommand: () => createStubCommand('doctor'),
+		}));
+
 		const next = await import('../index');
 		expect(typeof next.createHelper).toBe('function');
 		expect(typeof next.createPipeline).toBe('function');

--- a/packages/cli/src/next/commands/__tests__/factories.test.ts
+++ b/packages/cli/src/next/commands/__tests__/factories.test.ts
@@ -1,0 +1,321 @@
+import { Command } from 'clipanion';
+
+function createCommandContext() {
+	return {
+		stdout: { write: jest.fn() },
+		stderr: { write: jest.fn() },
+	} as const;
+}
+
+describe('command factories', () => {
+	beforeEach(() => {
+		jest.resetModules();
+	});
+
+	describe('createInitCommand', () => {
+		it('lazily loads the legacy command and forwards options', async () => {
+			const captured: unknown[] = [];
+
+			class LegacyInit extends Command {
+				static override paths = [['init']] as const;
+				static override usage = Command.Usage({
+					description: 'legacy init',
+				});
+
+				name?: string;
+				template?: string;
+				force = false;
+				verbose = false;
+				preferRegistryVersions = false;
+
+				override async execute(): Promise<number> {
+					captured.push({
+						context: this.context,
+						name: this.name,
+						template: this.template,
+						force: this.force,
+						verbose: this.verbose,
+						preferRegistryVersions: this.preferRegistryVersions,
+					});
+					return 7;
+				}
+			}
+
+			const loader = jest
+				.fn<() => Promise<typeof LegacyInit>>()
+				.mockResolvedValue(LegacyInit);
+			const { createInitCommand } = await import('../init');
+			const NextInit = createInitCommand({ loadCommand: loader });
+
+			expect(loader).not.toHaveBeenCalled();
+
+			const command = new NextInit();
+			command.cli = {} as never;
+			command.context = createCommandContext() as never;
+			command.name = 'demo';
+			command.template = 'plugin';
+			command.force = true;
+			command.verbose = true;
+			command.preferRegistryVersions = true;
+
+			const result = await command.execute();
+
+			expect(result).toBe(7);
+			expect(loader).toHaveBeenCalledTimes(1);
+			expect(captured).toEqual([
+				{
+					context: command.context,
+					name: 'demo',
+					template: 'plugin',
+					force: true,
+					verbose: true,
+					preferRegistryVersions: true,
+				},
+			]);
+		});
+
+		it('supports pre-resolved commands without invoking the loader', async () => {
+			class LegacyInit extends Command {
+				static override paths = [['init']] as const;
+				static override usage = Command.Usage({
+					description: 'legacy init',
+				});
+
+				override async execute(): Promise<void> {
+					return undefined;
+				}
+			}
+
+			const loader = jest
+				.fn<() => Promise<typeof LegacyInit>>()
+				.mockRejectedValue(new Error('should not load'));
+			const { createInitCommand } = await import('../init');
+			const NextInit = createInitCommand({
+				command: LegacyInit,
+				loadCommand: loader,
+			});
+
+			const command = new NextInit();
+			command.cli = {} as never;
+			command.context = createCommandContext() as never;
+
+			const exitCode = await command.execute();
+
+			expect(exitCode).toBe(0);
+			expect(loader).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('createGenerateCommand', () => {
+		it('copies CLI context and exposes summary from the legacy command', async () => {
+			const summary = { applied: 1 };
+			class LegacyGenerate extends Command {
+				static override paths = [['generate']] as const;
+				static override usage = Command.Usage({
+					description: 'legacy generate',
+				});
+
+				dryRun = false;
+				verbose = false;
+				summary?: typeof summary;
+
+				override async execute(): Promise<number> {
+					this.summary = summary;
+					return 0;
+				}
+			}
+
+			const loader = jest
+				.fn<() => Promise<typeof LegacyGenerate>>()
+				.mockResolvedValue(LegacyGenerate);
+			const { createGenerateCommand } = await import('../generate');
+			const NextGenerate = createGenerateCommand({
+				loadCommand: loader,
+			});
+
+			const command = new NextGenerate();
+			command.cli = {} as never;
+			command.context = createCommandContext() as never;
+			command.dryRun = true;
+			command.verbose = true;
+
+			const exitCode = await command.execute();
+
+			expect(exitCode).toBe(0);
+			expect(loader).toHaveBeenCalledTimes(1);
+			expect(command.summary).toBe(summary);
+		});
+
+		it('normalises non-numeric return values to zero', async () => {
+			class LegacyGenerate extends Command {
+				static override paths = [['generate']] as const;
+				static override usage = Command.Usage({
+					description: 'legacy generate',
+				});
+
+				dryRun = false;
+				verbose = false;
+
+				override async execute(): Promise<void> {
+					return undefined;
+				}
+			}
+
+			const loader = jest
+				.fn<() => Promise<typeof LegacyGenerate>>()
+				.mockResolvedValue(LegacyGenerate);
+			const { createGenerateCommand } = await import('../generate');
+			const NextGenerate = createGenerateCommand({
+				loadCommand: loader,
+			});
+
+			const command = new NextGenerate();
+			command.cli = {} as never;
+			command.context = createCommandContext() as never;
+
+			const exitCode = await command.execute();
+
+			expect(exitCode).toBe(0);
+			expect(command.summary).toBeUndefined();
+		});
+	});
+
+	describe('createStartCommand', () => {
+		it('forwards start options to the legacy command', async () => {
+			const captured: Array<{ verbose: boolean; auto: boolean }> = [];
+
+			class LegacyStart extends Command {
+				static override paths = [['start']] as const;
+				static override usage = Command.Usage({
+					description: 'legacy start',
+				});
+
+				verbose = false;
+				autoApplyPhp = false;
+
+				override async execute(): Promise<number> {
+					captured.push({
+						verbose: this.verbose,
+						auto: this.autoApplyPhp,
+					});
+					return 0;
+				}
+			}
+
+			const loader = jest
+				.fn<() => Promise<typeof LegacyStart>>()
+				.mockResolvedValue(LegacyStart);
+			const { createStartCommand } = await import('../start');
+			const NextStart = createStartCommand({ loadCommand: loader });
+
+			const command = new NextStart();
+			command.cli = {} as never;
+			command.context = createCommandContext() as never;
+			command.verbose = true;
+			command.autoApplyPhp = true;
+
+			await command.execute();
+
+			expect(loader).toHaveBeenCalledTimes(1);
+			expect(captured).toEqual([{ verbose: true, auto: true }]);
+		});
+
+		it('caches the legacy constructor across executions', async () => {
+			let executions = 0;
+
+			class LegacyStart extends Command {
+				static override paths = [['start']] as const;
+				static override usage = Command.Usage({
+					description: 'legacy start',
+				});
+
+				override async execute(): Promise<void> {
+					executions += 1;
+				}
+			}
+
+			const loader = jest
+				.fn<() => Promise<typeof LegacyStart>>()
+				.mockResolvedValue(LegacyStart);
+			const { createStartCommand } = await import('../start');
+			const NextStart = createStartCommand({ loadCommand: loader });
+
+			const first = new NextStart();
+			first.cli = {} as never;
+			first.context = createCommandContext() as never;
+
+			const second = new NextStart();
+			second.cli = {} as never;
+			second.context = createCommandContext() as never;
+
+			await first.execute();
+			await second.execute();
+
+			expect(loader).toHaveBeenCalledTimes(1);
+			expect(executions).toBe(2);
+		});
+	});
+
+	describe('createDoctorCommand', () => {
+		it('delegates execution to the legacy doctor command', async () => {
+			const execute = jest.fn().mockResolvedValue(undefined);
+
+			class LegacyDoctor extends Command {
+				static override paths = [['doctor']] as const;
+				static override usage = Command.Usage({
+					description: 'legacy doctor',
+				});
+
+				override async execute(): Promise<void> {
+					await execute();
+				}
+			}
+
+			const loader = jest
+				.fn<() => Promise<typeof LegacyDoctor>>()
+				.mockResolvedValue(LegacyDoctor);
+			const { createDoctorCommand } = await import('../doctor');
+			const NextDoctor = createDoctorCommand({
+				loadCommand: loader,
+			});
+
+			const command = new NextDoctor();
+			command.cli = {} as never;
+			command.context = createCommandContext() as never;
+
+			await command.execute();
+
+			expect(loader).toHaveBeenCalledTimes(1);
+			expect(execute).toHaveBeenCalledTimes(1);
+		});
+
+		it('supports pre-resolved commands without invoking the loader', async () => {
+			class LegacyDoctor extends Command {
+				static override paths = [['doctor']] as const;
+				static override usage = Command.Usage({
+					description: 'legacy doctor',
+				});
+
+				override async execute(): Promise<void> {
+					return undefined;
+				}
+			}
+
+			const loader = jest
+				.fn<() => Promise<typeof LegacyDoctor>>()
+				.mockRejectedValue(new Error('should not load'));
+			const { createDoctorCommand } = await import('../doctor');
+			const NextDoctor = createDoctorCommand({
+				command: LegacyDoctor,
+				loadCommand: loader,
+			});
+
+			const command = new NextDoctor();
+			command.cli = {} as never;
+			command.context = createCommandContext() as never;
+
+			await expect(command.execute()).resolves.toBeUndefined();
+			expect(loader).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/next/commands/doctor.ts
+++ b/packages/cli/src/next/commands/doctor.ts
@@ -1,0 +1,49 @@
+import { Command } from 'clipanion';
+import type { DoctorCommand as LegacyDoctorCommand } from '../../commands/doctor';
+import {
+	adoptCommandEnvironment,
+	createLegacyCommandLoader,
+	type LegacyCommandConstructor,
+} from './internal/delegate';
+
+export interface CreateDoctorCommandOptions {
+	readonly command?: LegacyCommandConstructor<LegacyDoctorCommand>;
+	readonly loadCommand?: () => Promise<
+		LegacyCommandConstructor<LegacyDoctorCommand>
+	>;
+}
+
+type DoctorConstructor = LegacyCommandConstructor<LegacyDoctorCommand>;
+
+async function defaultLoadCommand(): Promise<DoctorConstructor> {
+	const module = await import('../../commands/doctor');
+	return module.DoctorCommand;
+}
+
+export function createDoctorCommand(
+	options: CreateDoctorCommandOptions = {}
+): DoctorConstructor {
+	const load = createLegacyCommandLoader({
+		command: options.command,
+		loadCommand: options.loadCommand,
+		defaultLoad: defaultLoadCommand,
+	});
+
+	class NextDoctorCommand extends Command {
+		static override paths = [['doctor']];
+
+		static override usage = Command.Usage({
+			description:
+				'Check project setup and dependencies (placeholder - implementation pending).',
+		});
+
+		override async execute(): Promise<number | void> {
+			const Constructor = await load();
+			const delegate = new Constructor();
+			adoptCommandEnvironment(this, delegate);
+			return delegate.execute();
+		}
+	}
+
+	return NextDoctorCommand as unknown as DoctorConstructor;
+}

--- a/packages/cli/src/next/commands/generate.ts
+++ b/packages/cli/src/next/commands/generate.ts
@@ -1,0 +1,71 @@
+import { Command, Option } from 'clipanion';
+import type { GenerateCommand as LegacyGenerateCommand } from '../../commands/generate';
+import {
+	adoptCommandEnvironment,
+	createLegacyCommandLoader,
+	type LegacyCommandConstructor,
+} from './internal/delegate';
+
+export interface CreateGenerateCommandOptions {
+	readonly command?: LegacyCommandConstructor<LegacyGenerateCommand>;
+	readonly loadCommand?: () => Promise<
+		LegacyCommandConstructor<LegacyGenerateCommand>
+	>;
+}
+
+type GenerateConstructor = LegacyCommandConstructor<LegacyGenerateCommand>;
+type LegacyGenerateInstance = InstanceType<GenerateConstructor>;
+
+async function defaultLoadCommand(): Promise<GenerateConstructor> {
+	const module = await import('../../commands/generate');
+	return module.GenerateCommand;
+}
+
+export function createGenerateCommand(
+	options: CreateGenerateCommandOptions = {}
+): GenerateConstructor {
+	const load = createLegacyCommandLoader({
+		command: options.command,
+		loadCommand: options.loadCommand,
+		defaultLoad: defaultLoadCommand,
+	});
+
+	class NextGenerateCommand extends Command {
+		static override paths = [['generate']];
+
+		static override usage = Command.Usage({
+			description: 'Generate WP Kernel artifacts from kernel.config.*.',
+			examples: [
+				['Generate artifacts into .generated/', 'wpk generate'],
+				[
+					'Preview changes without writing files',
+					'wpk generate --dry-run',
+				],
+				[
+					'Verbose logging including per-file status',
+					'wpk generate --verbose',
+				],
+			],
+		});
+
+		dryRun = Option.Boolean('--dry-run', false);
+		verbose = Option.Boolean('--verbose', false);
+
+		public summary?: LegacyGenerateInstance['summary'];
+
+		override async execute(): Promise<number> {
+			const Constructor = await load();
+			const delegate = new Constructor();
+
+			adoptCommandEnvironment(this, delegate);
+			(delegate as { dryRun?: boolean }).dryRun = this.dryRun;
+			(delegate as { verbose?: boolean }).verbose = this.verbose;
+
+			const result = await delegate.execute();
+			this.summary = (delegate as LegacyGenerateInstance).summary;
+			return typeof result === 'number' ? result : 0;
+		}
+	}
+
+	return NextGenerateCommand as unknown as GenerateConstructor;
+}

--- a/packages/cli/src/next/commands/index.ts
+++ b/packages/cli/src/next/commands/index.ts
@@ -1,2 +1,6 @@
 export { NextApplyCommand } from './apply';
+export { createInitCommand } from './init';
+export { createGenerateCommand } from './generate';
+export { createStartCommand } from './start';
+export { createDoctorCommand } from './doctor';
 export type { PatchManifest, PatchRecord, PatchStatus } from './apply';

--- a/packages/cli/src/next/commands/init.ts
+++ b/packages/cli/src/next/commands/init.ts
@@ -1,0 +1,82 @@
+import { Command, Option } from 'clipanion';
+import type { InitCommand as LegacyInitCommand } from '../../commands/init';
+import {
+	adoptCommandEnvironment,
+	createLegacyCommandLoader,
+	type LegacyCommandConstructor,
+} from './internal/delegate';
+
+export interface CreateInitCommandOptions {
+	readonly command?: LegacyCommandConstructor<LegacyInitCommand>;
+	readonly loadCommand?: () => Promise<
+		LegacyCommandConstructor<LegacyInitCommand>
+	>;
+}
+
+type InitConstructor = LegacyCommandConstructor<LegacyInitCommand>;
+
+async function defaultLoadCommand(): Promise<InitConstructor> {
+	const module = await import('../../commands/init');
+	return module.InitCommand;
+}
+
+export function createInitCommand(
+	options: CreateInitCommandOptions = {}
+): InitConstructor {
+	const load = createLegacyCommandLoader({
+		command: options.command,
+		loadCommand: options.loadCommand,
+		defaultLoad: defaultLoadCommand,
+	});
+
+	class NextInitCommand extends Command {
+		static override paths = [['init']];
+
+		static override usage = Command.Usage({
+			description:
+				'Initialise a WP Kernel project by scaffolding config, entrypoint, and linting presets.',
+			examples: [
+				['Scaffold project files', 'wpk init --name=my-plugin'],
+				['Overwrite existing files', 'wpk init --force'],
+			],
+		});
+
+		name = Option.String('--name', {
+			description: 'Project slug used for namespace/package defaults',
+			required: false,
+		});
+		template = Option.String('--template', {
+			description:
+				'Reserved for future templates (plugin/theme/headless)',
+			required: false,
+		});
+		force = Option.Boolean('--force', false);
+		verbose = Option.Boolean('--verbose', false);
+		preferRegistryVersions = Option.Boolean(
+			'--prefer-registry-versions',
+			false
+		);
+
+		override async execute(): Promise<number> {
+			const Constructor = await load();
+			const delegate = new Constructor();
+
+			adoptCommandEnvironment(this, delegate);
+			(delegate as { name?: string | undefined }).name = this.name;
+			(delegate as { template?: string | undefined }).template =
+				this.template;
+			(delegate as { force?: boolean }).force = this.force;
+			(delegate as { verbose?: boolean }).verbose = this.verbose;
+			(
+				delegate as {
+					preferRegistryVersions?: boolean;
+				}
+			).preferRegistryVersions = this.preferRegistryVersions;
+
+			const result = await delegate.execute();
+			return typeof result === 'number' ? result : 0;
+		}
+	}
+
+	return NextInitCommand as unknown as InitConstructor;
+}

--- a/packages/cli/src/next/commands/internal/delegate.ts
+++ b/packages/cli/src/next/commands/internal/delegate.ts
@@ -1,0 +1,50 @@
+import type { Command } from 'clipanion';
+
+export type LegacyCommandConstructor<T extends Command> = new () => T;
+
+export interface LegacyCommandLoaderOptions<T extends Command> {
+	readonly command?: LegacyCommandConstructor<T>;
+	readonly loadCommand?: () => Promise<LegacyCommandConstructor<T>>;
+	readonly defaultLoad: () => Promise<LegacyCommandConstructor<T>>;
+}
+
+export function createLegacyCommandLoader<T extends Command>({
+	command,
+	loadCommand,
+	defaultLoad,
+}: LegacyCommandLoaderOptions<T>): () => Promise<LegacyCommandConstructor<T>> {
+	let cached: LegacyCommandConstructor<T> | undefined = command;
+	let loading: Promise<LegacyCommandConstructor<T>> | null = null;
+
+	const loader = loadCommand ?? defaultLoad;
+
+	return async () => {
+		if (cached) {
+			return cached;
+		}
+
+		if (!loading) {
+			loading = loader().then((ctor) => {
+				cached = ctor;
+				return ctor;
+			});
+		}
+
+		return loading;
+	};
+}
+
+export function adoptCommandEnvironment(
+	source: Command,
+	target: Command
+): void {
+	const sourceFields = source as unknown as Record<string, unknown>;
+	const targetFields = target as unknown as Record<string, unknown>;
+
+	targetFields.cli = sourceFields.cli;
+	targetFields.context = sourceFields.context;
+	targetFields.path = sourceFields.path;
+	targetFields.stdin = sourceFields.stdin;
+	targetFields.stdout = sourceFields.stdout;
+	targetFields.stderr = sourceFields.stderr;
+}

--- a/packages/cli/src/next/commands/start.ts
+++ b/packages/cli/src/next/commands/start.ts
@@ -1,0 +1,65 @@
+import { Command, Option } from 'clipanion';
+import type { StartCommand as LegacyStartCommand } from '../../commands/start';
+import {
+	adoptCommandEnvironment,
+	createLegacyCommandLoader,
+	type LegacyCommandConstructor,
+} from './internal/delegate';
+
+export interface CreateStartCommandOptions {
+	readonly command?: LegacyCommandConstructor<LegacyStartCommand>;
+	readonly loadCommand?: () => Promise<
+		LegacyCommandConstructor<LegacyStartCommand>
+	>;
+}
+
+type StartConstructor = LegacyCommandConstructor<LegacyStartCommand>;
+
+async function defaultLoadCommand(): Promise<StartConstructor> {
+	const module = await import('../../commands/start');
+	return module.StartCommand;
+}
+
+export function createStartCommand(
+	options: CreateStartCommandOptions = {}
+): StartConstructor {
+	const load = createLegacyCommandLoader({
+		command: options.command,
+		loadCommand: options.loadCommand,
+		defaultLoad: defaultLoadCommand,
+	});
+
+	class NextStartCommand extends Command {
+		static override paths = [['start']];
+
+		static override usage = Command.Usage({
+			description:
+				'Watch kernel sources, regenerate on change, and run the Vite dev server.',
+			examples: [
+				['Start watch mode with default settings', 'wpk start'],
+				[
+					'Enable verbose logging and PHP auto-apply',
+					'wpk start --verbose --auto-apply-php',
+				],
+			],
+		});
+
+		verbose = Option.Boolean('--verbose', false);
+		autoApplyPhp = Option.Boolean('--auto-apply-php', false);
+
+		override async execute(): Promise<number> {
+			const Constructor = await load();
+			const delegate = new Constructor();
+
+			adoptCommandEnvironment(this, delegate);
+			(delegate as { verbose?: boolean }).verbose = this.verbose;
+			(delegate as { autoApplyPhp?: boolean }).autoApplyPhp =
+				this.autoApplyPhp;
+
+			const result = await delegate.execute();
+			return typeof result === 'number' ? result : 0;
+		}
+	}
+
+	return NextStartCommand as unknown as StartConstructor;
+}

--- a/packages/cli/src/next/workspace/__tests__/utilities.test.ts
+++ b/packages/cli/src/next/workspace/__tests__/utilities.test.ts
@@ -1,0 +1,368 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { Readable, Writable } from 'node:stream';
+import { execFile as execFileCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import { KernelError } from '@wpkernel/core/error';
+import { createReporterMock } from '@wpkernel/test-utils/cli';
+import { createWorkspace } from '../filesystem';
+import {
+	ensureGeneratedPhpClean,
+	ensureCleanDirectory,
+	promptConfirm,
+	toWorkspaceRelative,
+	__testing,
+} from '../utilities';
+
+const execFile = promisify(execFileCallback);
+
+async function createWorkspaceRoot(prefix: string): Promise<string> {
+	return await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+describe('workspace utilities', () => {
+	describe('ensureGeneratedPhpClean', () => {
+		it('skips git checks when --yes is provided', async () => {
+			const root = await createWorkspaceRoot('next-util-git-yes-');
+			const workspace = createWorkspace(root);
+			const reporter = createReporterMock();
+
+			await ensureGeneratedPhpClean({
+				workspace,
+				reporter,
+				yes: true,
+			});
+
+			expect(reporter.warn).toHaveBeenCalledWith(
+				'Skipping generated PHP cleanliness check (--yes provided).'
+			);
+			expect(reporter.debug).not.toHaveBeenCalled();
+		});
+
+		it('skips when directory is missing', async () => {
+			const root = await createWorkspaceRoot('next-util-git-missing-');
+			const workspace = createWorkspace(root);
+			const reporter = createReporterMock();
+
+			await ensureGeneratedPhpClean({
+				workspace,
+				reporter,
+				yes: false,
+			});
+
+			expect(reporter.warn).not.toHaveBeenCalled();
+			expect(reporter.debug).not.toHaveBeenCalled();
+		});
+
+		it('does not throw in non-git workspaces', async () => {
+			const root = await createWorkspaceRoot('next-util-git-none-');
+			const generated = path.join(root, '.generated', 'php');
+			await fs.mkdir(generated, { recursive: true });
+			const workspace = createWorkspace(root);
+			const reporter = createReporterMock();
+
+			await ensureGeneratedPhpClean({
+				workspace,
+				reporter,
+				yes: false,
+			});
+
+			expect(reporter.debug).toHaveBeenCalledWith(
+				'Skipping generated PHP cleanliness check (not a git repository).'
+			);
+		});
+
+		it('throws when generated PHP contains uncommitted changes', async () => {
+			const root = await createWorkspaceRoot('next-util-git-dirty-');
+			await execFile('git', ['init'], { cwd: root });
+			const generated = path.join(root, '.generated', 'php');
+			await fs.mkdir(generated, { recursive: true });
+			await fs.writeFile(
+				path.join(generated, 'example.php'),
+				'<?php echo 1;\n'
+			);
+
+			const workspace = createWorkspace(root);
+			const reporter = createReporterMock();
+
+			await expect(
+				ensureGeneratedPhpClean({
+					workspace,
+					reporter,
+					yes: false,
+				})
+			).rejects.toMatchObject({
+				code: 'ValidationError',
+			});
+		});
+
+		it('passes when git workspace is clean', async () => {
+			const root = await createWorkspaceRoot('next-util-git-clean-');
+			await execFile('git', ['init'], { cwd: root });
+			const generated = path.join(root, '.generated', 'php');
+			await fs.mkdir(generated, { recursive: true });
+
+			const workspace = createWorkspace(root);
+			const reporter = createReporterMock();
+
+			await expect(
+				ensureGeneratedPhpClean({
+					workspace,
+					reporter,
+					yes: false,
+				})
+			).resolves.toBeUndefined();
+		});
+	});
+
+	describe('ensureCleanDirectory', () => {
+		it('creates the directory when missing', async () => {
+			const root = await createWorkspaceRoot('next-util-dir-create-');
+			const workspace = createWorkspace(root);
+			const reporter = createReporterMock();
+			const target = path.join('build');
+
+			await ensureCleanDirectory({
+				workspace,
+				directory: target,
+				reporter,
+			});
+
+			const stat = await fs.stat(path.join(root, target));
+			expect(stat.isDirectory()).toBe(true);
+		});
+
+		it('skips creation when missing and create is false', async () => {
+			const root = await createWorkspaceRoot(
+				'next-util-dir-skip-create-'
+			);
+			const workspace = createWorkspace(root);
+
+			await ensureCleanDirectory({
+				workspace,
+				directory: 'skip',
+				create: false,
+			});
+
+			await expect(
+				fs.stat(path.join(root, 'skip'))
+			).rejects.toMatchObject({ code: 'ENOENT' });
+		});
+
+		it('throws when directory is not empty and force is false', async () => {
+			const root = await createWorkspaceRoot('next-util-dir-dirty-');
+			const workspace = createWorkspace(root);
+			const target = path.join('build');
+			await fs.mkdir(path.join(root, target), { recursive: true });
+			await fs.writeFile(
+				path.join(root, target, 'asset.js'),
+				'console.log(1);\n'
+			);
+
+			await expect(
+				ensureCleanDirectory({
+					workspace,
+					directory: target,
+				})
+			).rejects.toBeInstanceOf(KernelError);
+		});
+
+		it('clears directory contents when force is true', async () => {
+			const root = await createWorkspaceRoot('next-util-dir-force-');
+			const workspace = createWorkspace(root);
+			const reporter = createReporterMock();
+			const target = path.join('build');
+			await fs.mkdir(path.join(root, target), { recursive: true });
+			await fs.writeFile(
+				path.join(root, target, 'asset.js'),
+				'console.log(1);\n'
+			);
+
+			await ensureCleanDirectory({
+				workspace,
+				directory: target,
+				force: true,
+				reporter,
+			});
+
+			const entries = await fs.readdir(path.join(root, target));
+			expect(entries).toHaveLength(0);
+			expect(reporter.info).toHaveBeenCalledWith(
+				'Clearing directory contents.',
+				{
+					path: 'build',
+				}
+			);
+		});
+
+		it('returns early for empty directories without logging', async () => {
+			const root = await createWorkspaceRoot('next-util-dir-empty-');
+			const workspace = createWorkspace(root);
+			const reporter = createReporterMock();
+			const target = path.join('empty-dir');
+			await fs.mkdir(path.join(root, target), { recursive: true });
+
+			await ensureCleanDirectory({
+				workspace,
+				directory: target,
+				reporter,
+			});
+
+			expect(reporter.info).not.toHaveBeenCalled();
+		});
+
+		it('throws when the target is not a directory', async () => {
+			const root = await createWorkspaceRoot('next-util-dir-file-');
+			const workspace = createWorkspace(root);
+			const reporter = createReporterMock();
+			const target = path.join('not-a-directory');
+			await fs.writeFile(path.join(root, target), '');
+
+			await expect(
+				ensureCleanDirectory({
+					workspace,
+					directory: target,
+					reporter,
+				})
+			).rejects.toMatchObject({ code: 'ValidationError' });
+		});
+	});
+
+	describe('promptConfirm', () => {
+		it('resolves to true when user answers yes', async () => {
+			const input = Readable.from(['y\n']);
+			const outputChunks: string[] = [];
+			const output = new Writable({
+				write(chunk, _encoding, callback) {
+					outputChunks.push(chunk.toString());
+					callback();
+				},
+			});
+
+			const result = await promptConfirm({
+				message: 'Proceed?',
+				input,
+				output,
+			});
+
+			expect(result).toBe(true);
+			expect(outputChunks.join('')).toContain('Proceed?');
+		});
+
+		it('uses the default value when input is empty', async () => {
+			const input = Readable.from(['\n']);
+			const output = new Writable({
+				write(_chunk, _encoding, callback) {
+					callback();
+				},
+			});
+
+			const result = await promptConfirm({
+				message: 'Proceed?',
+				defaultValue: true,
+				input,
+				output,
+			});
+
+			expect(result).toBe(true);
+		});
+
+		it('resolves to false when user answers no', async () => {
+			const input = Readable.from(['No\n']);
+			const output = new Writable({
+				write(_chunk, _encoding, callback) {
+					callback();
+				},
+			});
+
+			const result = await promptConfirm({
+				message: 'Proceed?',
+				defaultValue: true,
+				input,
+				output,
+			});
+
+			expect(result).toBe(false);
+		});
+
+		it('falls back to false when input is invalid without a default', async () => {
+			const input = Readable.from(['maybe\n']);
+			const output = new Writable({
+				write(_chunk, _encoding, callback) {
+					callback();
+				},
+			});
+
+			const result = await promptConfirm({
+				message: 'Proceed?',
+				input,
+				output,
+			});
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('toWorkspaceRelative', () => {
+		it('normalises separators and handles root path', async () => {
+			const root = await createWorkspaceRoot('next-util-relative-');
+			const workspace = createWorkspace(root);
+			const absolute = path.join(root, 'nested', 'file.txt');
+			const relative = toWorkspaceRelative(workspace, absolute);
+
+			expect(relative).toBe('nested/file.txt');
+			expect(toWorkspaceRelative(workspace, root)).toBe('.');
+		});
+	});
+
+	describe('__testing utilities', () => {
+		it('formats prompts with appropriate suffixes', () => {
+			expect(__testing.formatPrompt('Question?', undefined)).toBe(
+				'Question? (y/n) '
+			);
+			expect(__testing.formatPrompt('Question?', true)).toBe(
+				'Question? (Y/n) '
+			);
+			expect(__testing.formatPrompt('Question?', false)).toBe(
+				'Question? (y/N) '
+			);
+		});
+
+		it('parses boolean answers with fallbacks', () => {
+			expect(__testing.parseBooleanAnswer('yes', undefined)).toBe(true);
+			expect(__testing.parseBooleanAnswer('No', true)).toBe(false);
+			expect(__testing.parseBooleanAnswer('  ', true)).toBe(true);
+			expect(__testing.parseBooleanAnswer('maybe', undefined)).toBe(
+				false
+			);
+		});
+
+		it('detects missing git repositories from diverse errors', () => {
+			expect(
+				__testing.isGitRepositoryMissing('fatal: not a git repository')
+			).toBe(true);
+			expect(
+				__testing.isGitRepositoryMissing({
+					message: 'fatal: not a git repository',
+				})
+			).toBe(true);
+			expect(
+				__testing.isGitRepositoryMissing({
+					stderr: 'fatal: not a git repository',
+				})
+			).toBe(true);
+			expect(__testing.isGitRepositoryMissing(null)).toBe(false);
+		});
+
+		it('normalises directories relative to the workspace root', async () => {
+			const root = await createWorkspaceRoot('next-util-normalise-');
+			const workspace = createWorkspace(root);
+
+			expect(__testing.normaliseDirectory(root, workspace)).toBe(root);
+			expect(__testing.normaliseDirectory('nested', workspace)).toBe(
+				path.join(root, 'nested')
+			);
+		});
+	});
+});

--- a/packages/cli/src/next/workspace/index.ts
+++ b/packages/cli/src/next/workspace/index.ts
@@ -1,4 +1,15 @@
 export { createWorkspace } from './filesystem';
+export {
+	ensureGeneratedPhpClean,
+	ensureCleanDirectory,
+	promptConfirm,
+	toWorkspaceRelative,
+} from './utilities';
+export type {
+	EnsureGeneratedPhpCleanOptions,
+	EnsureCleanDirectoryOptions,
+	ConfirmPromptOptions,
+} from './utilities';
 export type {
 	Workspace,
 	FileManifest,

--- a/packages/cli/src/next/workspace/utilities.ts
+++ b/packages/cli/src/next/workspace/utilities.ts
@@ -1,0 +1,259 @@
+import fs from 'node:fs/promises';
+import type { Stats } from 'node:fs';
+import path from 'node:path';
+import { execFile as execFileCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import readline from 'node:readline/promises';
+import { stdin as defaultStdin, stdout as defaultStdout } from 'node:process';
+import type { Reporter } from '@wpkernel/core/reporter';
+import { KernelError } from '@wpkernel/core/error';
+import type { Workspace } from './types';
+import { serialiseError } from '../../commands/apply/errors';
+
+const execFile = promisify(execFileCallback);
+
+export interface EnsureGeneratedPhpCleanOptions {
+	readonly workspace: Workspace;
+	readonly reporter: Reporter;
+	readonly yes: boolean;
+	readonly directory?: string;
+}
+
+export interface EnsureCleanDirectoryOptions {
+	readonly workspace: Workspace;
+	readonly directory: string;
+	readonly force?: boolean;
+	readonly create?: boolean;
+	readonly reporter?: Reporter;
+}
+
+export interface ConfirmPromptOptions {
+	readonly message: string;
+	readonly defaultValue?: boolean;
+	readonly input?: NodeJS.ReadableStream;
+	readonly output?: NodeJS.WritableStream;
+}
+
+async function statIfExists(target: string): Promise<Stats | null> {
+	try {
+		return await fs.lstat(target);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+			return null;
+		}
+
+		throw error;
+	}
+}
+
+function toWorkspaceRelative(workspace: Workspace, absolute: string): string {
+	const relative = path.relative(workspace.root, absolute);
+	if (relative === '') {
+		return '.';
+	}
+
+	return relative.split(path.sep).join('/');
+}
+
+function normaliseDirectory(directory: string, workspace: Workspace): string {
+	if (path.isAbsolute(directory)) {
+		return directory;
+	}
+
+	return workspace.resolve(directory);
+}
+
+function isGitRepositoryMissing(error: unknown): boolean {
+	if (typeof error === 'string') {
+		return error.includes('not a git repository');
+	}
+
+	if (typeof error === 'object' && error !== null) {
+		const message =
+			typeof (error as { message?: unknown }).message === 'string'
+				? ((error as { message?: string }).message as string)
+				: '';
+		const stderr =
+			typeof (error as { stderr?: unknown }).stderr === 'string'
+				? ((error as { stderr?: string }).stderr as string)
+				: '';
+
+		if (message.includes('not a git repository')) {
+			return true;
+		}
+
+		if (stderr.includes('not a git repository')) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+export async function ensureGeneratedPhpClean({
+	workspace,
+	reporter,
+	yes,
+	directory = path.join('.generated', 'php'),
+}: EnsureGeneratedPhpCleanOptions): Promise<void> {
+	if (yes) {
+		reporter.warn(
+			'Skipping generated PHP cleanliness check (--yes provided).'
+		);
+		return;
+	}
+
+	const absoluteDirectory = normaliseDirectory(directory, workspace);
+	const stat = await statIfExists(absoluteDirectory);
+	if (!stat || !stat.isDirectory()) {
+		return;
+	}
+
+	const relativeSource = toWorkspaceRelative(workspace, absoluteDirectory);
+
+	try {
+		const { stdout } = await execFile(
+			'git',
+			['status', '--porcelain', '--', relativeSource],
+			{ cwd: workspace.root }
+		);
+
+		if (stdout.trim().length > 0) {
+			throw new KernelError('ValidationError', {
+				message: 'Generated PHP directory has uncommitted changes.',
+				context: {
+					path: relativeSource,
+					statusOutput: stdout.trim().split('\n'),
+				},
+			});
+		}
+	} catch (error) {
+		if (isGitRepositoryMissing(error)) {
+			reporter.debug(
+				'Skipping generated PHP cleanliness check (not a git repository).'
+			);
+			return;
+		}
+
+		if (KernelError.isKernelError(error)) {
+			throw error;
+		}
+
+		/* istanbul ignore next - git invocation failed unexpectedly */
+		throw new KernelError('DeveloperError', {
+			message: 'Unable to verify generated PHP cleanliness.',
+			context: {
+				path: relativeSource,
+				error: serialiseError(error),
+			},
+		});
+	}
+}
+
+export async function ensureCleanDirectory({
+	workspace,
+	directory,
+	force = false,
+	create = true,
+	reporter,
+}: EnsureCleanDirectoryOptions): Promise<void> {
+	const absoluteDirectory = normaliseDirectory(directory, workspace);
+	const relativeDirectory = toWorkspaceRelative(workspace, absoluteDirectory);
+	const stat = await statIfExists(absoluteDirectory);
+
+	if (!stat) {
+		if (create) {
+			await fs.mkdir(absoluteDirectory, { recursive: true });
+		}
+		return;
+	}
+
+	if (!stat.isDirectory()) {
+		throw new KernelError('ValidationError', {
+			message: 'Expected a directory.',
+			context: { path: relativeDirectory },
+		});
+	}
+
+	const entries = await fs.readdir(absoluteDirectory);
+	if (entries.length === 0) {
+		return;
+	}
+
+	if (!force) {
+		throw new KernelError('ValidationError', {
+			message: 'Directory is not empty.',
+			context: {
+				path: relativeDirectory,
+				entries: entries.sort(),
+			},
+		});
+	}
+
+	reporter?.info?.('Clearing directory contents.', {
+		path: relativeDirectory,
+	});
+	await fs.rm(absoluteDirectory, { recursive: true, force: true });
+	await fs.mkdir(absoluteDirectory, { recursive: true });
+}
+
+function formatPrompt(
+	message: string,
+	defaultValue: boolean | undefined
+): string {
+	let suffix = ' (y/n) ';
+
+	if (defaultValue === true) {
+		suffix = ' (Y/n) ';
+	} else if (defaultValue === false) {
+		suffix = ' (y/N) ';
+	}
+
+	return `${message}${suffix}`;
+}
+
+function parseBooleanAnswer(
+	answer: string,
+	defaultValue: boolean | undefined
+): boolean {
+	const normalised = answer.trim().toLowerCase();
+	if (normalised === '') {
+		return defaultValue ?? false;
+	}
+
+	if (normalised === 'y' || normalised === 'yes') {
+		return true;
+	}
+
+	if (normalised === 'n' || normalised === 'no') {
+		return false;
+	}
+
+	return defaultValue ?? false;
+}
+
+export async function promptConfirm({
+	message,
+	defaultValue,
+	input = defaultStdin,
+	output = defaultStdout,
+}: ConfirmPromptOptions): Promise<boolean> {
+	const rl = readline.createInterface({ input, output });
+
+	try {
+		const question = formatPrompt(message, defaultValue);
+		const answer = await rl.question(question);
+		return parseBooleanAnswer(answer, defaultValue);
+	} finally {
+		rl.close();
+	}
+}
+
+export { toWorkspaceRelative };
+
+export const __testing = Object.freeze({
+	formatPrompt,
+	parseBooleanAnswer,
+	isGitRepositoryMissing,
+	normaliseDirectory,
+});


### PR DESCRIPTION
## Summary
- drop the next build command export so the new surface only exposes init, generate, start, and doctor
- expose workspace utility internals for targeted tests and exercise git, directory, and prompt edge cases with shared reporter mocks
- harden the command factory suites for generate/start/doctor and update the workstream doc to note the build workflow remains legacy-only

## Testing
- `pnpm --filter @wpkernel/cli lint --fix`
- `pnpm --filter @wpkernel/cli typecheck`
- `pnpm --filter @wpkernel/cli typecheck:tests`
- `pnpm --filter @wpkernel/cli test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68f27efdac48832587a102c8f7b0c79f