### PR TITLE
Sprint 5: WP_Query AST helpers

### DIFF
--- a/packages/cli/src/next/builders/php/ast/__tests__/factories.cacheMetadata.test.ts
+++ b/packages/cli/src/next/builders/php/ast/__tests__/factories.cacheMetadata.test.ts
@@ -1,0 +1,121 @@
+import type {
+	PhpFileMetadata,
+	ResourceControllerCacheEvent,
+	ResourceControllerMetadata,
+} from '../types';
+import {
+	appendResourceControllerCacheEvent,
+	type ResourceMetadataHost,
+} from '../factories/cacheMetadata';
+
+function createHost(metadata: PhpFileMetadata): ResourceMetadataHost & {
+	readonly setMetadata: jest.Mock<void, [PhpFileMetadata]>;
+} {
+	const host = {
+		current: metadata,
+		getMetadata(): PhpFileMetadata {
+			return this.current;
+		},
+		setMetadata: jest.fn(function (
+			this: typeof host,
+			next: PhpFileMetadata
+		) {
+			this.current = next;
+		}),
+	};
+
+	return host as ResourceMetadataHost & {
+		readonly setMetadata: jest.Mock<void, [PhpFileMetadata]>;
+	};
+}
+
+describe('appendResourceControllerCacheEvent', () => {
+	it('appends cache events to resource metadata', () => {
+		const metadata: ResourceControllerMetadata = {
+			kind: 'resource-controller',
+			name: 'job',
+			identity: { type: 'string', param: 'slug' },
+			routes: [],
+		};
+		const host = createHost(metadata);
+		const event: ResourceControllerCacheEvent = {
+			scope: 'list',
+			operation: 'read',
+			segments: ['job', 'list'],
+		};
+
+		appendResourceControllerCacheEvent(host, event);
+
+		expect(host.setMetadata).toHaveBeenCalledTimes(1);
+		const [next] = host.setMetadata.mock.calls[0];
+		if (next.kind !== 'resource-controller') {
+			throw new Error('metadata mutated to unexpected kind');
+		}
+		expect(next.cache?.events).toEqual([
+			{
+				scope: 'list',
+				operation: 'read',
+				segments: ['job', 'list'],
+			},
+		]);
+		expect(metadata.cache).toBeUndefined();
+	});
+
+	it('preserves existing events and avoids shared references', () => {
+		const existingEvent: ResourceControllerCacheEvent = {
+			scope: 'get',
+			operation: 'read',
+			segments: ['job', 'get'],
+		};
+		const metadata: ResourceControllerMetadata = {
+			kind: 'resource-controller',
+			name: 'job',
+			identity: { type: 'number', param: 'id' },
+			routes: [],
+			cache: { events: [existingEvent] },
+		};
+		const host = createHost(metadata);
+		const event: ResourceControllerCacheEvent = {
+			scope: 'list',
+			operation: 'prime',
+			segments: ['job', 'list'],
+		};
+
+		appendResourceControllerCacheEvent(host, event);
+
+		const [next] = host.setMetadata.mock.calls[0];
+		if (next.kind !== 'resource-controller') {
+			throw new Error('metadata mutated to unexpected kind');
+		}
+
+		expect(next.cache?.events[0]).toBe(existingEvent);
+		expect(next.cache?.events[1]).toEqual({
+			scope: 'list',
+			operation: 'prime',
+			segments: ['job', 'list'],
+		});
+
+		event.segments.push('mutated');
+		expect(next.cache?.events[1]).toEqual({
+			scope: 'list',
+			operation: 'prime',
+			segments: ['job', 'list'],
+		});
+	});
+
+	it('ignores non resource-controller metadata', () => {
+		const metadata: PhpFileMetadata = {
+			kind: 'policy-helper',
+			name: 'demo',
+		};
+		const host = createHost(metadata);
+
+		appendResourceControllerCacheEvent(host, {
+			scope: 'list',
+			operation: 'invalidate',
+			segments: ['job', 'list'],
+		});
+
+		expect(host.setMetadata).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/next/builders/php/ast/__tests__/factories.wpQuery.test.ts
+++ b/packages/cli/src/next/builders/php/ast/__tests__/factories.wpQuery.test.ts
@@ -1,0 +1,47 @@
+import { createWpQueryInstantiation } from '../factories/wpQuery';
+
+describe('createWpQueryInstantiation', () => {
+	it('creates a WP_Query instantiation with default formatting', () => {
+		const printable = createWpQueryInstantiation({
+			target: 'query',
+			argsVariable: 'query_args',
+		});
+
+		expect(printable.lines).toEqual([
+			'$query = new WP_Query( $query_args );',
+		]);
+		expect(printable.node.expr).toMatchObject({
+			nodeType: 'Expr_Assign',
+			expr: {
+				nodeType: 'Expr_New',
+				class: { parts: ['WP_Query'] },
+			},
+		});
+	});
+
+	it('supports custom indentation and variable prefixes', () => {
+		const printable = createWpQueryInstantiation({
+			target: '$customQuery',
+			argsVariable: '$args',
+			indentLevel: 2,
+			indentUnit: '  ',
+		});
+
+		expect(printable.lines).toEqual([
+			'    $customQuery = new WP_Query( $args );',
+		]);
+		expect(printable.node.expr).toMatchObject({
+			nodeType: 'Expr_Assign',
+			expr: {
+				nodeType: 'Expr_New',
+				args: [expect.anything()],
+			},
+		});
+	});
+
+	it('throws when provided with empty variable names', () => {
+		expect(() =>
+			createWpQueryInstantiation({ target: '', argsVariable: 'args' })
+		).toThrow('Variable name must not be empty.');
+	});
+});

--- a/packages/cli/src/next/builders/php/ast/factories/cacheMetadata.ts
+++ b/packages/cli/src/next/builders/php/ast/factories/cacheMetadata.ts
@@ -1,0 +1,55 @@
+import type {
+	PhpFileMetadata,
+	ResourceControllerCacheEvent,
+	ResourceControllerCacheMetadata,
+	ResourceControllerMetadata,
+} from '../types';
+
+export interface ResourceMetadataHost {
+	getMetadata: () => PhpFileMetadata;
+	setMetadata: (metadata: PhpFileMetadata) => void;
+}
+
+function isResourceControllerMetadata(
+	metadata: PhpFileMetadata
+): metadata is ResourceControllerMetadata {
+	return metadata.kind === 'resource-controller';
+}
+
+function cloneCacheEvent(
+	event: ResourceControllerCacheEvent
+): ResourceControllerCacheEvent {
+	return {
+		...event,
+		segments: [...event.segments],
+	};
+}
+
+function mergeCacheMetadata(
+	cache: ResourceControllerCacheMetadata | undefined,
+	event: ResourceControllerCacheEvent
+): ResourceControllerCacheMetadata {
+	if (!cache) {
+		return { events: [cloneCacheEvent(event)] };
+	}
+
+	return {
+		events: [...cache.events, cloneCacheEvent(event)],
+	};
+}
+
+export function appendResourceControllerCacheEvent(
+	host: ResourceMetadataHost,
+	event: ResourceControllerCacheEvent
+): void {
+	const metadata = host.getMetadata();
+	if (!isResourceControllerMetadata(metadata)) {
+		return;
+	}
+
+	const nextCache = mergeCacheMetadata(metadata.cache, event);
+	host.setMetadata({
+		...metadata,
+		cache: nextCache,
+	});
+}

--- a/packages/cli/src/next/builders/php/ast/factories/index.ts
+++ b/packages/cli/src/next/builders/php/ast/factories/index.ts
@@ -1,0 +1,2 @@
+export * from './wpQuery';
+export * from './cacheMetadata';

--- a/packages/cli/src/next/builders/php/ast/factories/wpQuery.ts
+++ b/packages/cli/src/next/builders/php/ast/factories/wpQuery.ts
@@ -1,0 +1,73 @@
+import { KernelError } from '@wpkernel/core/contracts';
+import {
+	createArg,
+	createAssign,
+	createExpressionStatement,
+	createName,
+	createNode,
+	createVariable,
+	type PhpExprNew,
+	type PhpStmtExpression,
+} from '../nodes';
+import { createPrintable, type PhpPrintable } from '../printables';
+
+const DEFAULT_INDENT_UNIT = '        ';
+
+export interface CreateWpQueryInstantiationOptions {
+	readonly target: string;
+	readonly argsVariable: string;
+	readonly indentLevel?: number;
+	readonly indentUnit?: string;
+}
+
+interface NormalisedVariableName {
+	readonly raw: string;
+	readonly display: string;
+}
+
+function normaliseVariableName(name: string): NormalisedVariableName {
+	const trimmed = name.trim();
+	if (!trimmed) {
+		throw new KernelError('DeveloperError', {
+			message: 'Variable name must not be empty.',
+			context: { name },
+		});
+	}
+
+	if (trimmed.startsWith('$')) {
+		const raw = trimmed.slice(1);
+		if (!raw) {
+			throw new KernelError('DeveloperError', {
+				message: 'Variable name must include an identifier.',
+				context: { name },
+			});
+		}
+		return { raw, display: trimmed };
+	}
+
+	return { raw: trimmed, display: `$${trimmed}` };
+}
+
+export function createWpQueryInstantiation(
+	options: CreateWpQueryInstantiationOptions
+): PhpPrintable<PhpStmtExpression> {
+	const indentUnit = options.indentUnit ?? DEFAULT_INDENT_UNIT;
+	const indentLevel = options.indentLevel ?? 0;
+	const indent = indentUnit.repeat(indentLevel);
+	const target = normaliseVariableName(options.target);
+	const args = normaliseVariableName(options.argsVariable);
+
+	const expression = createExpressionStatement(
+		createAssign(
+			createVariable(target.raw),
+			createNode<PhpExprNew>('Expr_New', {
+				class: createName(['WP_Query']),
+				args: [createArg(createVariable(args.raw))],
+			})
+		)
+	);
+
+	const line = `${indent}${target.display} = new WP_Query( ${args.display} );`;
+
+	return createPrintable(expression, [line]);
+}

--- a/packages/cli/src/next/builders/php/ast/index.ts
+++ b/packages/cli/src/next/builders/php/ast/index.ts
@@ -9,3 +9,4 @@ export * from './templates';
 export * from './types';
 export * from './utils';
 export * from './valueRenderers';
+export * from './factories';

--- a/packages/cli/src/next/builders/php/ast/types.ts
+++ b/packages/cli/src/next/builders/php/ast/types.ts
@@ -14,6 +14,23 @@ export interface ResourceControllerMetadata {
 		readonly param: string;
 	};
 	readonly routes: readonly ResourceControllerRouteMetadata[];
+	readonly cache?: ResourceControllerCacheMetadata;
+}
+
+export type ResourceControllerCacheScope =
+	ResourceControllerRouteMetadata['kind'];
+
+export type ResourceControllerCacheOperation = 'read' | 'prime' | 'invalidate';
+
+export interface ResourceControllerCacheEvent {
+	readonly scope: ResourceControllerCacheScope;
+	readonly operation: ResourceControllerCacheOperation;
+	readonly segments: readonly string[];
+	readonly description?: string;
+}
+
+export interface ResourceControllerCacheMetadata {
+	readonly events: readonly ResourceControllerCacheEvent[];
 }
 
 export interface GenericPhpFileMetadata {


### PR DESCRIPTION
## Summary
- add PHP AST factory utilities for WP_Query instantiation and cache metadata mutation
- expose new cache metadata types on resource controller metadata and re-export factory helpers
- cover the new helpers with focused Jest suites to ensure correct nodes and metadata behaviour

## Testing
- pnpm --filter @wpkernel/cli test:coverage *(fails: coverage thresholds currently unmet for this workspace)*
- pnpm --filter @wpkernel/cli typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f58e0aceb48325a197b9cab9ae3e3c