### PR TITLE
feat(cli): add wp-post mutation macros

### DIFF
--- a/packages/cli/src/next/builders/php/ast/types.ts
+++ b/packages/cli/src/next/builders/php/ast/types.ts
@@ -33,6 +33,12 @@ export interface ResourceControllerCacheMetadata {
 	readonly events: readonly ResourceControllerCacheEvent[];
 }
 
+export interface ResourceMacroMetadata {
+	readonly kind: 'resource-macro';
+	readonly macro: string;
+	readonly tags: Readonly<Record<string, string>>;
+}
+
 export interface GenericPhpFileMetadata {
 	readonly kind:
 		| 'base-controller'
@@ -46,7 +52,8 @@ export interface GenericPhpFileMetadata {
 
 export type PhpFileMetadata =
 	| GenericPhpFileMetadata
-	| ResourceControllerMetadata;
+	| ResourceControllerMetadata
+	| ResourceMacroMetadata;
 
 export interface PhpAstBuilder {
 	getNamespace: () => string;

--- a/packages/cli/src/next/builders/php/printers/__tests__/__snapshots__/wpPostMutations.macros.test.ts.snap
+++ b/packages/cli/src/next/builders/php/printers/__tests__/__snapshots__/wpPostMutations.macros.test.ts.snap
@@ -1,0 +1,1018 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`wp-post mutation macros appends status validation without guard: status-validation-macro 1`] = `
+[
+  {
+    "attributes": {},
+    "declares": [
+      {
+        "attributes": {},
+        "key": {
+          "attributes": {},
+          "name": "strict_types",
+          "nodeType": "Identifier",
+        },
+        "nodeType": "DeclareItem",
+        "value": {
+          "attributes": {},
+          "nodeType": "Scalar_LNumber",
+          "value": 1,
+        },
+      },
+    ],
+    "nodeType": "Stmt_Declare",
+    "stmts": null,
+  },
+  {
+    "attributes": {},
+    "name": {
+      "attributes": {},
+      "nodeType": "Name",
+      "parts": [
+        "Demo",
+        "Rest",
+      ],
+    },
+    "nodeType": "Stmt_Namespace",
+    "stmts": [
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:BEGIN AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+      {
+        "attrGroups": [],
+        "attributes": {},
+        "extends": null,
+        "flags": 0,
+        "implements": [],
+        "name": {
+          "attributes": {},
+          "name": "MacroHarness",
+          "nodeType": "Identifier",
+        },
+        "namespacedName": null,
+        "nodeType": "Stmt_Class",
+        "stmts": [
+          {
+            "attrGroups": [],
+            "attributes": {},
+            "byRef": false,
+            "flags": 0,
+            "name": {
+              "attributes": {},
+              "name": "invoke",
+              "nodeType": "Identifier",
+            },
+            "nodeType": "Stmt_ClassMethod",
+            "params": [],
+            "returnType": null,
+            "stmts": [
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation status-validation",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:status normalise",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "nodeType": "Scalar_String",
+                          "value": "status",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "get_param",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "request",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "status",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "status",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "normaliseBooksStatus",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "this",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "post_status",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:END AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+    ],
+  },
+]
+`;
+
+exports[`wp-post mutation macros guards status validation when null checks are enabled: status-validation-guarded-macro 1`] = `
+[
+  {
+    "attributes": {},
+    "declares": [
+      {
+        "attributes": {},
+        "key": {
+          "attributes": {},
+          "name": "strict_types",
+          "nodeType": "Identifier",
+        },
+        "nodeType": "DeclareItem",
+        "value": {
+          "attributes": {},
+          "nodeType": "Scalar_LNumber",
+          "value": 1,
+        },
+      },
+    ],
+    "nodeType": "Stmt_Declare",
+    "stmts": null,
+  },
+  {
+    "attributes": {},
+    "name": {
+      "attributes": {},
+      "nodeType": "Name",
+      "parts": [
+        "Demo",
+        "Rest",
+      ],
+    },
+    "nodeType": "Stmt_Namespace",
+    "stmts": [
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:BEGIN AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+      {
+        "attrGroups": [],
+        "attributes": {},
+        "extends": null,
+        "flags": 0,
+        "implements": [],
+        "name": {
+          "attributes": {},
+          "name": "MacroHarness",
+          "nodeType": "Identifier",
+        },
+        "namespacedName": null,
+        "nodeType": "Stmt_Class",
+        "stmts": [
+          {
+            "attrGroups": [],
+            "attributes": {},
+            "byRef": false,
+            "flags": 0,
+            "name": {
+              "attributes": {},
+              "name": "invoke",
+              "nodeType": "Identifier",
+            },
+            "nodeType": "Stmt_ClassMethod",
+            "params": [],
+            "returnType": null,
+            "stmts": [
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation status-validation",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:status normalise",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "nodeType": "Scalar_String",
+                          "value": "status",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "get_param",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "request",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "status",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "attributes": {},
+                  "left": {
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "null",
+                      ],
+                    },
+                    "nodeType": "Expr_ConstFetch",
+                  },
+                  "nodeType": "Expr_BinaryOp_NotIdentical",
+                  "right": {
+                    "attributes": {},
+                    "name": "status",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "attributes": {},
+                      "expr": {
+                        "args": [
+                          {
+                            "attributes": {},
+                            "byRef": false,
+                            "name": null,
+                            "nodeType": "Arg",
+                            "unpack": false,
+                            "value": {
+                              "attributes": {},
+                              "name": "status",
+                              "nodeType": "Expr_Variable",
+                            },
+                          },
+                        ],
+                        "attributes": {},
+                        "name": {
+                          "attributes": {},
+                          "name": "normaliseBooksStatus",
+                          "nodeType": "Identifier",
+                        },
+                        "nodeType": "Expr_MethodCall",
+                        "var": {
+                          "attributes": {},
+                          "name": "this",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                      "nodeType": "Expr_Assign",
+                      "var": {
+                        "attributes": {},
+                        "dim": {
+                          "attributes": {},
+                          "nodeType": "Scalar_String",
+                          "value": "post_status",
+                        },
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "var": {
+                          "attributes": {},
+                          "name": "post_data",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    },
+                    "nodeType": "Stmt_Expression",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:END AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+    ],
+  },
+]
+`;
+
+exports[`wp-post mutation macros primes cache after mutations: cache-priming-macro 1`] = `
+[
+  {
+    "attributes": {},
+    "declares": [
+      {
+        "attributes": {},
+        "key": {
+          "attributes": {},
+          "name": "strict_types",
+          "nodeType": "Identifier",
+        },
+        "nodeType": "DeclareItem",
+        "value": {
+          "attributes": {},
+          "nodeType": "Scalar_LNumber",
+          "value": 1,
+        },
+      },
+    ],
+    "nodeType": "Stmt_Declare",
+    "stmts": null,
+  },
+  {
+    "attributes": {},
+    "name": {
+      "attributes": {},
+      "nodeType": "Name",
+      "parts": [
+        "Demo",
+        "Rest",
+      ],
+    },
+    "nodeType": "Stmt_Namespace",
+    "stmts": [
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:BEGIN AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+      {
+        "attrGroups": [],
+        "attributes": {},
+        "extends": null,
+        "flags": 0,
+        "implements": [],
+        "name": {
+          "attributes": {},
+          "name": "MacroHarness",
+          "nodeType": "Identifier",
+        },
+        "namespacedName": null,
+        "nodeType": "Stmt_Class",
+        "stmts": [
+          {
+            "attrGroups": [],
+            "attributes": {},
+            "byRef": false,
+            "flags": 0,
+            "name": {
+              "attributes": {},
+              "name": "invoke",
+              "nodeType": "Identifier",
+            },
+            "nodeType": "Stmt_ClassMethod",
+            "params": [],
+            "returnType": null,
+            "stmts": [
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation cache-priming",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:cache prime",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel cache:wp-post prime",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "post_id",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "get_post",
+                      ],
+                    },
+                    "nodeType": "Expr_FuncCall",
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "post",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "attributes": {},
+                  "expr": {
+                    "attributes": {},
+                    "class": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "WP_Post",
+                      ],
+                    },
+                    "expr": {
+                      "attributes": {},
+                      "name": "post",
+                      "nodeType": "Expr_Variable",
+                    },
+                    "nodeType": "Expr_Instanceof",
+                  },
+                  "nodeType": "Expr_BooleanNot",
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "args": [
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "wpk_books_load_failed",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "Unable to load created Book.",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "items": [
+                              {
+                                "attributes": {},
+                                "byRef": false,
+                                "key": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_String",
+                                  "value": "status",
+                                },
+                                "nodeType": "Expr_ArrayItem",
+                                "unpack": false,
+                                "value": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_LNumber",
+                                  "value": 500,
+                                },
+                              },
+                            ],
+                            "nodeType": "Expr_Array",
+                          },
+                        },
+                      ],
+                      "attributes": {},
+                      "class": {
+                        "attributes": {},
+                        "nodeType": "Name",
+                        "parts": [
+                          "WP_Error",
+                        ],
+                      },
+                      "nodeType": "Expr_New",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "args": [
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "post",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "request",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                  ],
+                  "attributes": {},
+                  "name": {
+                    "attributes": {},
+                    "name": "prepareBooksResponse",
+                    "nodeType": "Identifier",
+                  },
+                  "nodeType": "Expr_MethodCall",
+                  "var": {
+                    "attributes": {},
+                    "name": "this",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Return",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:END AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+    ],
+  },
+]
+`;
+
+exports[`wp-post mutation macros syncs meta and taxonomies with metadata comments: sync-mutations-macro 1`] = `
+[
+  {
+    "attributes": {},
+    "declares": [
+      {
+        "attributes": {},
+        "key": {
+          "attributes": {},
+          "name": "strict_types",
+          "nodeType": "Identifier",
+        },
+        "nodeType": "DeclareItem",
+        "value": {
+          "attributes": {},
+          "nodeType": "Scalar_LNumber",
+          "value": 1,
+        },
+      },
+    ],
+    "nodeType": "Stmt_Declare",
+    "stmts": null,
+  },
+  {
+    "attributes": {},
+    "name": {
+      "attributes": {},
+      "nodeType": "Name",
+      "parts": [
+        "Demo",
+        "Rest",
+      ],
+    },
+    "nodeType": "Stmt_Namespace",
+    "stmts": [
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:BEGIN AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+      {
+        "attrGroups": [],
+        "attributes": {},
+        "extends": null,
+        "flags": 0,
+        "implements": [],
+        "name": {
+          "attributes": {},
+          "name": "MacroHarness",
+          "nodeType": "Identifier",
+        },
+        "namespacedName": null,
+        "nodeType": "Stmt_Class",
+        "stmts": [
+          {
+            "attrGroups": [],
+            "attributes": {},
+            "byRef": false,
+            "flags": 0,
+            "name": {
+              "attributes": {},
+              "name": "invoke",
+              "nodeType": "Identifier",
+            },
+            "nodeType": "Stmt_ClassMethod",
+            "params": [],
+            "returnType": null,
+            "stmts": [
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation sync-meta",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:meta update",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "args": [
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "post_id",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "request",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                  ],
+                  "attributes": {},
+                  "name": {
+                    "attributes": {},
+                    "name": "syncBooksMeta",
+                    "nodeType": "Identifier",
+                  },
+                  "nodeType": "Expr_MethodCall",
+                  "var": {
+                    "attributes": {},
+                    "name": "this",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation sync-taxonomies",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:taxonomies update",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "post_id",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "request",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "syncBooksTaxonomies",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "this",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "taxonomy_result",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "args": [
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "taxonomy_result",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                  ],
+                  "attributes": {},
+                  "name": {
+                    "attributes": {},
+                    "nodeType": "Name",
+                    "parts": [
+                      "is_wp_error",
+                    ],
+                  },
+                  "nodeType": "Expr_FuncCall",
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "attributes": {},
+                      "name": "taxonomy_result",
+                      "nodeType": "Expr_Variable",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:END AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+    ],
+  },
+]
+`;

--- a/packages/cli/src/next/builders/php/printers/__tests__/wpPostMutations.macros.test.ts
+++ b/packages/cli/src/next/builders/php/printers/__tests__/wpPostMutations.macros.test.ts
@@ -1,0 +1,309 @@
+import path from 'node:path';
+import type { Reporter } from '@wpkernel/core/reporter';
+import type {
+	BuilderInput,
+	BuilderOutput,
+	PipelineContext,
+} from '../../../runtime/types';
+import { createPhpProgramBuilder } from '../../ast/programBuilder';
+import { appendClassTemplate } from '../../ast/append';
+import {
+	createClassTemplate,
+	createMethodTemplate,
+	PHP_INDENT,
+	type PhpMethodBodyBuilder,
+} from '../../ast/templates';
+import {
+	appendCachePrimingMacro,
+	appendStatusValidationMacro,
+	appendSyncMetaMacro,
+	appendSyncTaxonomiesMacro,
+	createArrayDimExpression,
+	createVariableExpression,
+	WP_POST_MUTATION_CONTRACT,
+} from '../resource/wpPost/mutations';
+import { getPhpBuilderChannel, resetPhpBuilderChannel } from '../channel';
+import { resetPhpAstChannel } from '../../ast/context';
+
+const CONTRACT = WP_POST_MUTATION_CONTRACT;
+
+type ChannelEntry = ReturnType<
+	ReturnType<typeof getPhpBuilderChannel>['pending']
+>[number];
+
+function createReporter(): Reporter {
+	return {
+		debug: jest.fn(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		child: jest.fn().mockReturnThis(),
+	};
+}
+
+function createPipelineContext(): PipelineContext {
+	return {
+		workspace: {
+			root: '/workspace',
+			resolve: (...parts: string[]) => path.join('/workspace', ...parts),
+			cwd: () => '/workspace',
+			read: async () => null,
+			readText: async () => null,
+			write: jest.fn(async () => undefined),
+			writeJson: jest.fn(async () => undefined),
+			exists: async () => false,
+			rm: async () => undefined,
+			glob: async () => [],
+			threeWayMerge: async () => 'clean',
+			begin: () => undefined,
+			commit: async () => ({ writes: [], deletes: [] }),
+			rollback: async () => ({ writes: [], deletes: [] }),
+			dryRun: async (fn) => ({
+				result: await fn(),
+				manifest: { writes: [], deletes: [] },
+			}),
+			tmpDir: async () => '.tmp',
+		},
+		reporter: createReporter(),
+		phase: 'generate',
+	} as unknown as PipelineContext;
+}
+
+function createBuilderInput(): BuilderInput {
+	return {
+		phase: 'generate',
+		options: {
+			config: {} as never,
+			namespace: 'demo-plugin',
+			origin: 'kernel.config.ts',
+			sourcePath: 'kernel.config.ts',
+		},
+		ir: null,
+	};
+}
+
+async function queueMacroProgram(
+	macro: string,
+	build: (body: PhpMethodBodyBuilder) => void,
+	tags: Record<string, string>
+): Promise<{ entry: ChannelEntry; context: PipelineContext }> {
+	const context = createPipelineContext();
+	const input = createBuilderInput();
+	const output: BuilderOutput = { actions: [], queueWrite: jest.fn() };
+
+	resetPhpBuilderChannel(context);
+	resetPhpAstChannel(context);
+
+	const helper = createPhpProgramBuilder({
+		key: `macro.${macro}`,
+		filePath: context.workspace.resolve(
+			'.generated',
+			'php',
+			`${macro}.php`
+		),
+		namespace: 'Demo\\Rest',
+		metadata: {
+			kind: 'resource-macro',
+			macro,
+			tags,
+		},
+		async build(builder) {
+			const method = createMethodTemplate({
+				signature:
+					'public function invoke( WP_REST_Request $request ): void',
+				indentLevel: 1,
+				indentUnit: PHP_INDENT,
+				body: (body) => {
+					build(body);
+				},
+			});
+			const classTemplate = createClassTemplate({
+				name: 'MacroHarness',
+				methods: [method],
+			});
+			appendClassTemplate(builder, classTemplate);
+		},
+	});
+
+	await helper.apply(
+		{
+			context,
+			input,
+			output,
+			reporter: context.reporter,
+		},
+		undefined
+	);
+
+	const channel = getPhpBuilderChannel(context);
+	const entry = channel.pending()[0];
+	return { entry, context };
+}
+
+describe('wp-post mutation macros', () => {
+	it('appends status validation without guard', async () => {
+		const { entry } = await queueMacroProgram(
+			'status-validation',
+			(body) => {
+				appendStatusValidationMacro({
+					body,
+					indentLevel: 2,
+					metadataKeys: CONTRACT.metadataKeys,
+					pascalName: 'Books',
+					target: createVariableExpression('post_status'),
+				});
+			},
+			{
+				[CONTRACT.metadataKeys.channelTag]: 'status-validation',
+				[CONTRACT.metadataKeys.statusValidation]: 'normalise',
+			}
+		);
+
+		expect(entry.metadata).toMatchObject({
+			kind: 'resource-macro',
+			macro: 'status-validation',
+		});
+		expect(entry.statements).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining(
+					`// @wp-kernel ${CONTRACT.metadataKeys.channelTag} status-validation`
+				),
+				expect.stringContaining(
+					`// @wp-kernel ${CONTRACT.metadataKeys.statusValidation} normalise`
+				),
+				expect.stringContaining(
+					"$status = $request->get_param( 'status' );"
+				),
+				expect.stringContaining(
+					'$post_status = $this->normaliseBooksStatus( $status );'
+				),
+			])
+		);
+		expect(entry.program).toMatchSnapshot('status-validation-macro');
+	});
+
+	it('guards status validation when null checks are enabled', async () => {
+		const { entry } = await queueMacroProgram(
+			'status-validation-guarded',
+			(body) => {
+				appendStatusValidationMacro({
+					body,
+					indentLevel: 2,
+					metadataKeys: CONTRACT.metadataKeys,
+					pascalName: 'Books',
+					target: createArrayDimExpression(
+						'post_data',
+						'post_status'
+					),
+					guardWithNullCheck: true,
+				});
+			},
+			{
+				[CONTRACT.metadataKeys.channelTag]: 'status-validation',
+				[CONTRACT.metadataKeys.statusValidation]: 'normalise',
+			}
+		);
+
+		expect(entry.statements).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining(`if ( null !== $status ) {`),
+				expect.stringContaining(
+					"$post_data['post_status'] = $this->normaliseBooksStatus( $status );"
+				),
+			])
+		);
+		expect(entry.program).toMatchSnapshot(
+			'status-validation-guarded-macro'
+		);
+	});
+
+	it('syncs meta and taxonomies with metadata comments', async () => {
+		const { entry } = await queueMacroProgram(
+			'sync-mutations',
+			(body) => {
+				const postId = createVariableExpression('post_id');
+				appendSyncMetaMacro({
+					body,
+					indentLevel: 2,
+					metadataKeys: CONTRACT.metadataKeys,
+					pascalName: 'Books',
+					postId,
+				});
+				appendSyncTaxonomiesMacro({
+					body,
+					indentLevel: 2,
+					metadataKeys: CONTRACT.metadataKeys,
+					pascalName: 'Books',
+					postId,
+					resultVariable: createVariableExpression('taxonomy_result'),
+				});
+			},
+			{
+				[CONTRACT.metadataKeys.channelTag]: 'sync',
+				[CONTRACT.metadataKeys.syncMeta]: 'update',
+				[CONTRACT.metadataKeys.syncTaxonomies]: 'update',
+			}
+		);
+
+		expect(entry.statements).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining(
+					`// @wp-kernel ${CONTRACT.metadataKeys.syncMeta} update`
+				),
+				expect.stringContaining(
+					'$this->syncBooksMeta( $post_id, $request );'
+				),
+				expect.stringContaining(
+					`// @wp-kernel ${CONTRACT.metadataKeys.syncTaxonomies} update`
+				),
+				expect.stringContaining(
+					'$taxonomy_result = $this->syncBooksTaxonomies( $post_id, $request );'
+				),
+				expect.stringContaining(
+					'if ( is_wp_error( $taxonomy_result ) ) {'
+				),
+				expect.stringContaining('return $taxonomy_result;'),
+			])
+		);
+		expect(entry.program).toMatchSnapshot('sync-mutations-macro');
+	});
+
+	it('primes cache after mutations', async () => {
+		const { entry } = await queueMacroProgram(
+			'cache-priming',
+			(body) => {
+				appendCachePrimingMacro({
+					body,
+					indentLevel: 2,
+					metadataKeys: CONTRACT.metadataKeys,
+					pascalName: 'Books',
+					postId: createVariableExpression('post_id'),
+					errorCode: 'wpk_books_load_failed',
+					failureMessage: 'Unable to load created Book.',
+				});
+			},
+			{
+				[CONTRACT.metadataKeys.channelTag]: 'cache-priming',
+				[CONTRACT.metadataKeys.cachePriming]: 'prime',
+				[CONTRACT.metadataKeys.cacheSegment]: 'prime',
+			}
+		);
+
+		expect(entry.statements).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining(
+					`// @wp-kernel ${CONTRACT.metadataKeys.cacheSegment} prime`
+				),
+				expect.stringContaining('$post = get_post( $post_id );'),
+				expect.stringContaining('if ( ! $post instanceof WP_Post ) {'),
+				expect.stringContaining(
+					"return new WP_Error( 'wpk_books_load_failed', 'Unable to load created Book.', array( 'status' => 500 ) );"
+				),
+				expect.stringContaining(
+					'return $this->prepareBooksResponse( $post, $request );'
+				),
+			])
+		);
+		expect(entry.program).toMatchSnapshot('cache-priming-macro');
+	});
+});

--- a/packages/cli/src/next/builders/php/printers/resource/mutationContract.ts
+++ b/packages/cli/src/next/builders/php/printers/resource/mutationContract.ts
@@ -19,6 +19,10 @@ export interface ResourceMutationContract {
 	readonly metadataKeys: {
 		readonly cacheSegment: string;
 		readonly channelTag: string;
+		readonly statusValidation: string;
+		readonly syncMeta: string;
+		readonly syncTaxonomies: string;
+		readonly cachePriming: string;
 	};
 }
 
@@ -40,5 +44,9 @@ export const WP_POST_MUTATION_CONTRACT: ResourceMutationContract = {
 	metadataKeys: {
 		cacheSegment: 'cache:wp-post',
 		channelTag: 'resource.wpPost.mutation',
+		statusValidation: 'mutation:status',
+		syncMeta: 'mutation:meta',
+		syncTaxonomies: 'mutation:taxonomies',
+		cachePriming: 'mutation:cache',
 	},
 } as const;

--- a/packages/cli/src/next/builders/php/printers/resource/wpPost/mutations/index.ts
+++ b/packages/cli/src/next/builders/php/printers/resource/wpPost/mutations/index.ts
@@ -7,3 +7,13 @@
  */
 export { WP_POST_MUTATION_CONTRACT } from '../../mutationContract';
 export type { ResourceMutationContract } from '../../mutationContract';
+export {
+	appendStatusValidationMacro,
+	appendSyncMetaMacro,
+	appendSyncTaxonomiesMacro,
+	appendCachePrimingMacro,
+	createVariableExpression,
+	createArrayDimExpression,
+	createPropertyExpression,
+	type MacroExpression,
+} from './macros';

--- a/packages/cli/src/next/builders/php/printers/resource/wpPost/mutations/macros.ts
+++ b/packages/cli/src/next/builders/php/printers/resource/wpPost/mutations/macros.ts
@@ -1,0 +1,370 @@
+import {
+	createArg,
+	createArray,
+	createArrayItem,
+	createAssign,
+	createComment,
+	createExpressionStatement,
+	createFuncCall,
+	createIdentifier,
+	createMethodCall,
+	createName,
+	createNode,
+	createReturn,
+	createScalarInt,
+	createScalarString,
+	createStmtNop,
+	createVariable,
+	createNull,
+	type PhpExpr,
+	type PhpExprBooleanNot,
+	type PhpExprNew,
+} from '../../../../ast/nodes';
+import { createPrintable } from '../../../../ast/printables';
+import {
+	PHP_INDENT,
+	type PhpMethodBodyBuilder,
+} from '../../../../ast/templates';
+import { escapeSingleQuotes } from '../../../../ast/utils';
+import {
+	createArrayDimFetch,
+	createBinaryOperation,
+	createIfPrintable,
+	createInstanceof,
+	createPropertyFetch,
+} from '../../utils';
+import type { ResourceMutationContract } from '../../mutationContract';
+
+export interface MacroExpression {
+	readonly expression: PhpExpr;
+	readonly display: string;
+}
+
+export function createVariableExpression(name: string): MacroExpression {
+	return {
+		expression: createVariable(name),
+		display: `$${name}`,
+	};
+}
+
+export function createArrayDimExpression(
+	array: string,
+	key: string
+): MacroExpression {
+	const escapedKey = escapeSingleQuotes(key);
+	return {
+		expression: createArrayDimFetch(array, createScalarString(key)),
+		display: `$${array}['${escapedKey}']`,
+	};
+}
+
+export function createPropertyExpression(
+	object: string,
+	property: string
+): MacroExpression {
+	return {
+		expression: createPropertyFetch(object, property),
+		display: `$${object}->${property}`,
+	};
+}
+
+interface MacroOptionsBase {
+	readonly body: PhpMethodBodyBuilder;
+	readonly indentLevel: number;
+	readonly indentUnit?: string;
+	readonly metadataKeys: ResourceMutationContract['metadataKeys'];
+}
+
+export interface StatusValidationMacroOptions extends MacroOptionsBase {
+	readonly pascalName: string;
+	readonly target: MacroExpression;
+	readonly statusVariable?: MacroExpression;
+	readonly requestVariable?: MacroExpression;
+	readonly statusParam?: string;
+	readonly guardWithNullCheck?: boolean;
+}
+
+export interface SyncMetaMacroOptions extends MacroOptionsBase {
+	readonly pascalName: string;
+	readonly postId: MacroExpression;
+	readonly requestVariable?: MacroExpression;
+}
+
+export interface SyncTaxonomiesMacroOptions extends MacroOptionsBase {
+	readonly pascalName: string;
+	readonly postId: MacroExpression;
+	readonly resultVariable: MacroExpression;
+	readonly requestVariable?: MacroExpression;
+}
+
+export interface CachePrimingMacroOptions extends MacroOptionsBase {
+	readonly pascalName: string;
+	readonly postId: MacroExpression;
+	readonly errorCode: string;
+	readonly failureMessage: string;
+	readonly requestVariable?: MacroExpression;
+	readonly postVariableName?: string;
+}
+
+export function appendStatusValidationMacro(
+	options: StatusValidationMacroOptions
+): void {
+	const indentUnit = options.indentUnit ?? PHP_INDENT;
+	const indent = indentUnit.repeat(options.indentLevel);
+
+	appendMetadataComment(
+		options,
+		options.metadataKeys.channelTag,
+		'status-validation'
+	);
+	appendMetadataComment(
+		options,
+		options.metadataKeys.statusValidation,
+		'normalise'
+	);
+
+	const statusVariable =
+		options.statusVariable ?? createVariableExpression('status');
+	const requestVariable =
+		options.requestVariable ?? createVariableExpression('request');
+	const statusParam = options.statusParam ?? 'status';
+
+	const statusAssign = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				statusVariable.expression,
+				createMethodCall(
+					requestVariable.expression,
+					createIdentifier('get_param'),
+					[createArg(createScalarString(statusParam))]
+				)
+			)
+		),
+		[
+			`${indent}${statusVariable.display} = ${requestVariable.display}->get_param( '${escapeSingleQuotes(
+				statusParam
+			)}' );`,
+		]
+	);
+	options.body.statement(statusAssign);
+
+	const normalisedCall = createMethodCall(
+		createVariable('this'),
+		createIdentifier(`normalise${options.pascalName}Status`),
+		[createArg(statusVariable.expression)]
+	);
+
+	if (options.guardWithNullCheck) {
+		const childIndent = indentUnit.repeat(options.indentLevel + 1);
+		const guardedAssign = createPrintable(
+			createExpressionStatement(
+				createAssign(options.target.expression, normalisedCall)
+			),
+			[
+				`${childIndent}${options.target.display} = $this->normalise${options.pascalName}Status( ${statusVariable.display} );`,
+			]
+		);
+		const guard = createIfPrintable({
+			indentLevel: options.indentLevel,
+			condition: createBinaryOperation(
+				'NotIdentical',
+				createNull(),
+				statusVariable.expression
+			),
+			conditionText: `${indent}if ( null !== ${statusVariable.display} ) {`,
+			statements: [guardedAssign],
+		});
+		options.body.statement(guard);
+		return;
+	}
+
+	const directAssign = createPrintable(
+		createExpressionStatement(
+			createAssign(options.target.expression, normalisedCall)
+		),
+		[
+			`${indent}${options.target.display} = $this->normalise${options.pascalName}Status( ${statusVariable.display} );`,
+		]
+	);
+	options.body.statement(directAssign);
+}
+
+export function appendSyncMetaMacro(options: SyncMetaMacroOptions): void {
+	const indentUnit = options.indentUnit ?? PHP_INDENT;
+	const indent = indentUnit.repeat(options.indentLevel);
+
+	appendMetadataComment(
+		options,
+		options.metadataKeys.channelTag,
+		'sync-meta'
+	);
+	appendMetadataComment(options, options.metadataKeys.syncMeta, 'update');
+
+	const requestVariable =
+		options.requestVariable ?? createVariableExpression('request');
+	const call = createMethodCall(
+		createVariable('this'),
+		createIdentifier(`sync${options.pascalName}Meta`),
+		[
+			createArg(options.postId.expression),
+			createArg(requestVariable.expression),
+		]
+	);
+	const printable = createPrintable(createExpressionStatement(call), [
+		`${indent}$this->sync${options.pascalName}Meta( ${options.postId.display}, ${requestVariable.display} );`,
+	]);
+	options.body.statement(printable);
+}
+
+export function appendSyncTaxonomiesMacro(
+	options: SyncTaxonomiesMacroOptions
+): void {
+	const indentUnit = options.indentUnit ?? PHP_INDENT;
+	const indent = indentUnit.repeat(options.indentLevel);
+
+	appendMetadataComment(
+		options,
+		options.metadataKeys.channelTag,
+		'sync-taxonomies'
+	);
+	appendMetadataComment(
+		options,
+		options.metadataKeys.syncTaxonomies,
+		'update'
+	);
+
+	const requestVariable =
+		options.requestVariable ?? createVariableExpression('request');
+	const assign = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				options.resultVariable.expression,
+				createMethodCall(
+					createVariable('this'),
+					createIdentifier(`sync${options.pascalName}Taxonomies`),
+					[
+						createArg(options.postId.expression),
+						createArg(requestVariable.expression),
+					]
+				)
+			)
+		),
+		[
+			`${indent}${options.resultVariable.display} = $this->sync${options.pascalName}Taxonomies( ${options.postId.display}, ${requestVariable.display} );`,
+		]
+	);
+	options.body.statement(assign);
+
+	const childIndent = indentUnit.repeat(options.indentLevel + 1);
+	const returnPrintable = createPrintable(
+		createReturn(options.resultVariable.expression),
+		[`${childIndent}return ${options.resultVariable.display};`]
+	);
+	const guard = createIfPrintable({
+		indentLevel: options.indentLevel,
+		condition: createFuncCall(createName(['is_wp_error']), [
+			createArg(options.resultVariable.expression),
+		]),
+		conditionText: `${indent}if ( is_wp_error( ${options.resultVariable.display} ) ) {`,
+		statements: [returnPrintable],
+	});
+	options.body.statement(guard);
+}
+
+export function appendCachePrimingMacro(
+	options: CachePrimingMacroOptions
+): void {
+	const indentUnit = options.indentUnit ?? PHP_INDENT;
+	const indent = indentUnit.repeat(options.indentLevel);
+
+	appendMetadataComment(
+		options,
+		options.metadataKeys.channelTag,
+		'cache-priming'
+	);
+	appendMetadataComment(options, options.metadataKeys.cachePriming, 'prime');
+	appendMetadataComment(options, options.metadataKeys.cacheSegment, 'prime');
+
+	const requestVariable =
+		options.requestVariable ?? createVariableExpression('request');
+	const postVariableName = options.postVariableName ?? 'post';
+	const postVariable = createVariableExpression(postVariableName);
+
+	const loadPost = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				postVariable.expression,
+				createFuncCall(createName(['get_post']), [
+					createArg(options.postId.expression),
+				])
+			)
+		),
+		[
+			`${indent}${postVariable.display} = get_post( ${options.postId.display} );`,
+		]
+	);
+	options.body.statement(loadPost);
+
+	const childIndent = indentUnit.repeat(options.indentLevel + 1);
+	const failureExpr = createNode<PhpExprNew>('Expr_New', {
+		class: createName(['WP_Error']),
+		args: [
+			createArg(createScalarString(options.errorCode)),
+			createArg(
+				createScalarString(escapeSingleQuotes(options.failureMessage))
+			),
+			createArg(
+				createArray([
+					createArrayItem(createScalarInt(500), {
+						key: createScalarString('status'),
+					}),
+				])
+			),
+		],
+	});
+	const failureReturn = createPrintable(createReturn(failureExpr), [
+		`${childIndent}return new WP_Error( '${escapeSingleQuotes(
+			options.errorCode
+		)}', '${escapeSingleQuotes(
+			options.failureMessage
+		)}', array( 'status' => 500 ) );`,
+	]);
+	const notInstanceof = createNode<PhpExprBooleanNot>('Expr_BooleanNot', {
+		expr: createInstanceof(postVariableName, 'WP_Post'),
+	});
+	const guard = createIfPrintable({
+		indentLevel: options.indentLevel,
+		condition: notInstanceof,
+		conditionText: `${indent}if ( ! ${postVariable.display} instanceof WP_Post ) {`,
+		statements: [failureReturn],
+	});
+	options.body.statement(guard);
+
+	const responseCall = createMethodCall(
+		createVariable('this'),
+		createIdentifier(`prepare${options.pascalName}Response`),
+		[
+			createArg(postVariable.expression),
+			createArg(requestVariable.expression),
+		]
+	);
+	const responsePrintable = createPrintable(createReturn(responseCall), [
+		`${indent}return $this->prepare${options.pascalName}Response( ${postVariable.display}, ${requestVariable.display} );`,
+	]);
+	options.body.statement(responsePrintable);
+}
+
+function appendMetadataComment(
+	options: MacroOptionsBase,
+	key: string,
+	value: string
+): void {
+	const indentUnit = options.indentUnit ?? PHP_INDENT;
+	const indent = indentUnit.repeat(options.indentLevel);
+	const text = `// @wp-kernel ${key} ${value}`;
+	const printable = createPrintable(
+		createStmtNop({ comments: [createComment(text)] }),
+		[`${indent}${text}`]
+	);
+	options.body.statement(printable);
+}


### PR DESCRIPTION
## Summary
- add reusable wp-post mutation macros for status normalization, meta/taxonomy syncing, and cache priming, emitting @wp-kernel metadata tags
- extend the mutation contract metadata keys and expose the new macro helpers through the wpPost mutations index
- add focused Jest suites that snapshot the generated AST for each macro to lock down behaviour

## Testing
- pnpm --filter @wpkernel/cli test -- wpPostMutations.macros
- pnpm --filter @wpkernel/cli test:coverage
- jest --coverage --watchman=false

------
https://chatgpt.com/codex/tasks/task_e_68f6d40373b08325baa950c1c85b5aff