### PR TITLE
Add wp-post mutation route builders and helper factories

### DIFF
--- a/packages/cli/src/next/builders/php/printers/__tests__/__snapshots__/wpPostMutations.routes.test.ts.snap
+++ b/packages/cli/src/next/builders/php/printers/__tests__/__snapshots__/wpPostMutations.routes.test.ts.snap
@@ -1,0 +1,2839 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`wp-post mutation helpers queues helpers in contract order with stable output: helper-programs 1`] = `
+[
+  {
+    "helper": "sync-meta",
+    "statements": [
+      "class MutationHelpers",
+      "{",
+      "        private function syncBookMeta( int $post_id, WP_REST_Request $request ): void",
+      "        {",
+      "                $subtitleMeta = $request->get_param( 'subtitle' );",
+      "                if ( null !== $subtitleMeta ) {",
+      "                        $subtitleMeta = is_string( $subtitleMeta ) ? $subtitleMeta : (string) $subtitleMeta;",
+      "                        update_post_meta( $post_id, 'subtitle', $subtitleMeta );",
+      "                }",
+      "        }",
+      "}",
+    ],
+  },
+  {
+    "helper": "sync-taxonomies",
+    "statements": [
+      "class MutationHelpers",
+      "{",
+      "        private function syncBookTaxonomies( int $post_id, WP_REST_Request $request )",
+      "        {",
+      "                $result = true;",
+      "                $categoryTerms = $request->get_param( 'category' );",
+      "                if ( null !== $categoryTerms ) {",
+      "                        if ( ! is_array( $categoryTerms ) ) {",
+      "                                $categoryTerms = array( $categoryTerms );",
+      "                        }",
+      "                        $categoryTerms = array_filter( array_map( 'intval', (array) $categoryTerms ) );",
+      "                        $result = wp_set_object_terms(",
+      "                                $post_id,",
+      "                                $categoryTerms,",
+      "                                'category',",
+      "                                false",
+      "                        );",
+      "                        if ( is_wp_error( $result ) ) {",
+      "                                return $result;",
+      "                        }",
+      "                }",
+      "                return $result;",
+      "        }",
+      "}",
+    ],
+  },
+  {
+    "helper": "prepare-response",
+    "statements": [
+      "class MutationHelpers",
+      "{",
+      "        private function prepareBookResponse( WP_Post $post, WP_REST_Request $request ): array",
+      "        {",
+      "                $data = array(",
+      "                        'id' => (int) $post->ID,",
+      "                        'status' => (string) $post->post_status,",
+      "                );",
+      "                $data['title'] = (string) $post->post_title;",
+      "                $data['content'] = (string) $post->post_content;",
+      "                $subtitleMeta = get_post_meta( $post->ID, 'subtitle', true );",
+      "                        $subtitleMeta = is_string( $subtitleMeta ) ? $subtitleMeta : (string) $subtitleMeta;",
+      "                $data['subtitle'] = $subtitleMeta;",
+      "                $categoryTerms = wp_get_object_terms( $post->ID, 'category', array( 'fields' => 'ids' ) );",
+      "                if ( is_wp_error( $categoryTerms ) ) {",
+      "                        $categoryTerms = array();",
+      "                }",
+      "                $categoryTerms = array_map( 'intval', (array) $categoryTerms );",
+      "                $data['category'] = $categoryTerms;",
+      "                return $data;",
+      "        }",
+      "}",
+    ],
+  },
+]
+`;
+
+exports[`wp-post mutation route builders emits create route body with macros in expected order: create-route 1`] = `
+[
+  {
+    "attributes": {},
+    "declares": [
+      {
+        "attributes": {},
+        "key": {
+          "attributes": {},
+          "name": "strict_types",
+          "nodeType": "Identifier",
+        },
+        "nodeType": "DeclareItem",
+        "value": {
+          "attributes": {},
+          "nodeType": "Scalar_LNumber",
+          "value": 1,
+        },
+      },
+    ],
+    "nodeType": "Stmt_Declare",
+    "stmts": null,
+  },
+  {
+    "attributes": {},
+    "name": {
+      "attributes": {},
+      "nodeType": "Name",
+      "parts": [
+        "Demo",
+        "Rest",
+      ],
+    },
+    "nodeType": "Stmt_Namespace",
+    "stmts": [
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:BEGIN AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+      {
+        "attrGroups": [],
+        "attributes": {},
+        "extends": null,
+        "flags": 0,
+        "implements": [],
+        "name": {
+          "attributes": {},
+          "name": "MutationHarness",
+          "nodeType": "Identifier",
+        },
+        "namespacedName": null,
+        "nodeType": "Stmt_Class",
+        "stmts": [
+          {
+            "attrGroups": [],
+            "attributes": {},
+            "byRef": false,
+            "flags": 0,
+            "name": {
+              "attributes": {},
+              "name": "handle",
+              "nodeType": "Identifier",
+            },
+            "nodeType": "Stmt_ClassMethod",
+            "params": [],
+            "returnType": null,
+            "stmts": [
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "getBookPostType",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "this",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "post_type",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "attributes": {},
+                    "items": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "key": {
+                          "attributes": {},
+                          "nodeType": "Scalar_String",
+                          "value": "post_type",
+                        },
+                        "nodeType": "Expr_ArrayItem",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "post_type",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    ],
+                    "nodeType": "Expr_Array",
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "post_data",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation status-validation",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:status normalise",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "nodeType": "Scalar_String",
+                          "value": "status",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "get_param",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "request",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "status",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "status",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "normaliseBookStatus",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "this",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "dim": {
+                      "attributes": {},
+                      "nodeType": "Scalar_String",
+                      "value": "post_status",
+                    },
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "var": {
+                      "attributes": {},
+                      "name": "post_data",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "post_data",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": {
+                            "attributes": {},
+                            "nodeType": "Name",
+                            "parts": [
+                              "true",
+                            ],
+                          },
+                          "nodeType": "Expr_ConstFetch",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "wp_insert_post",
+                      ],
+                    },
+                    "nodeType": "Expr_FuncCall",
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "post_id",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "args": [
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "post_id",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                  ],
+                  "attributes": {},
+                  "name": {
+                    "attributes": {},
+                    "nodeType": "Name",
+                    "parts": [
+                      "is_wp_error",
+                    ],
+                  },
+                  "nodeType": "Expr_FuncCall",
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "attributes": {},
+                      "name": "post_id",
+                      "nodeType": "Expr_Variable",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation sync-meta",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:meta update",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "args": [
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "post_id",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "request",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                  ],
+                  "attributes": {},
+                  "name": {
+                    "attributes": {},
+                    "name": "syncBookMeta",
+                    "nodeType": "Identifier",
+                  },
+                  "nodeType": "Expr_MethodCall",
+                  "var": {
+                    "attributes": {},
+                    "name": "this",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation sync-taxonomies",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:taxonomies update",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "post_id",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "request",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "syncBookTaxonomies",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "this",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "taxonomy_result",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "args": [
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "taxonomy_result",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                  ],
+                  "attributes": {},
+                  "name": {
+                    "attributes": {},
+                    "nodeType": "Name",
+                    "parts": [
+                      "is_wp_error",
+                    ],
+                  },
+                  "nodeType": "Expr_FuncCall",
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "attributes": {},
+                      "name": "taxonomy_result",
+                      "nodeType": "Expr_Variable",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation cache-priming",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:cache prime",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel cache:wp-post prime",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "post_id",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "get_post",
+                      ],
+                    },
+                    "nodeType": "Expr_FuncCall",
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "post",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "attributes": {},
+                  "expr": {
+                    "attributes": {},
+                    "class": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "WP_Post",
+                      ],
+                    },
+                    "expr": {
+                      "attributes": {},
+                      "name": "post",
+                      "nodeType": "Expr_Variable",
+                    },
+                    "nodeType": "Expr_Instanceof",
+                  },
+                  "nodeType": "Expr_BooleanNot",
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "args": [
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "wpk_book_load_failed",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "Unable to load created Book.",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "items": [
+                              {
+                                "attributes": {},
+                                "byRef": false,
+                                "key": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_String",
+                                  "value": "status",
+                                },
+                                "nodeType": "Expr_ArrayItem",
+                                "unpack": false,
+                                "value": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_LNumber",
+                                  "value": 500,
+                                },
+                              },
+                            ],
+                            "nodeType": "Expr_Array",
+                          },
+                        },
+                      ],
+                      "attributes": {},
+                      "class": {
+                        "attributes": {},
+                        "nodeType": "Name",
+                        "parts": [
+                          "WP_Error",
+                        ],
+                      },
+                      "nodeType": "Expr_New",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "args": [
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "post",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "request",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                  ],
+                  "attributes": {},
+                  "name": {
+                    "attributes": {},
+                    "name": "prepareBookResponse",
+                    "nodeType": "Identifier",
+                  },
+                  "nodeType": "Expr_MethodCall",
+                  "var": {
+                    "attributes": {},
+                    "name": "this",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Return",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:END AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+    ],
+  },
+]
+`;
+
+exports[`wp-post mutation route builders emits delete route body with previous response payload: delete-route 1`] = `
+[
+  {
+    "attributes": {},
+    "declares": [
+      {
+        "attributes": {},
+        "key": {
+          "attributes": {},
+          "name": "strict_types",
+          "nodeType": "Identifier",
+        },
+        "nodeType": "DeclareItem",
+        "value": {
+          "attributes": {},
+          "nodeType": "Scalar_LNumber",
+          "value": 1,
+        },
+      },
+    ],
+    "nodeType": "Stmt_Declare",
+    "stmts": null,
+  },
+  {
+    "attributes": {},
+    "name": {
+      "attributes": {},
+      "nodeType": "Name",
+      "parts": [
+        "Demo",
+        "Rest",
+      ],
+    },
+    "nodeType": "Stmt_Namespace",
+    "stmts": [
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:BEGIN AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+      {
+        "attrGroups": [],
+        "attributes": {},
+        "extends": null,
+        "flags": 0,
+        "implements": [],
+        "name": {
+          "attributes": {},
+          "name": "MutationHarness",
+          "nodeType": "Identifier",
+        },
+        "namespacedName": null,
+        "nodeType": "Stmt_Class",
+        "stmts": [
+          {
+            "attrGroups": [],
+            "attributes": {},
+            "byRef": false,
+            "flags": 0,
+            "name": {
+              "attributes": {},
+              "name": "handle",
+              "nodeType": "Identifier",
+            },
+            "nodeType": "Stmt_ClassMethod",
+            "params": [],
+            "returnType": null,
+            "stmts": [
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "nodeType": "Scalar_String",
+                          "value": "id",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "get_param",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "request",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "id",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "attributes": {},
+                  "left": {
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "null",
+                      ],
+                    },
+                    "nodeType": "Expr_ConstFetch",
+                  },
+                  "nodeType": "Expr_BinaryOp_Identical",
+                  "right": {
+                    "attributes": {},
+                    "name": "id",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "args": [
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "wpk_book_missing_identifier",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "Missing identifier for Book.",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "items": [
+                              {
+                                "attributes": {},
+                                "byRef": false,
+                                "key": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_String",
+                                  "value": "status",
+                                },
+                                "nodeType": "Expr_ArrayItem",
+                                "unpack": false,
+                                "value": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_LNumber",
+                                  "value": 400,
+                                },
+                              },
+                            ],
+                            "nodeType": "Expr_Array",
+                          },
+                        },
+                      ],
+                      "attributes": {},
+                      "class": {
+                        "attributes": {},
+                        "nodeType": "Name",
+                        "parts": [
+                          "WP_Error",
+                        ],
+                      },
+                      "nodeType": "Expr_New",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "attributes": {},
+                    "expr": {
+                      "attributes": {},
+                      "name": "id",
+                      "nodeType": "Expr_Variable",
+                    },
+                    "nodeType": "Expr_Cast_Int",
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "id",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "attributes": {},
+                  "left": {
+                    "attributes": {},
+                    "name": "id",
+                    "nodeType": "Expr_Variable",
+                  },
+                  "nodeType": "Expr_BinaryOp_SmallerOrEqual",
+                  "right": {
+                    "attributes": {},
+                    "nodeType": "Scalar_LNumber",
+                    "value": 0,
+                  },
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "args": [
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "wpk_book_invalid_identifier",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "Invalid identifier for Book.",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "items": [
+                              {
+                                "attributes": {},
+                                "byRef": false,
+                                "key": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_String",
+                                  "value": "status",
+                                },
+                                "nodeType": "Expr_ArrayItem",
+                                "unpack": false,
+                                "value": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_LNumber",
+                                  "value": 400,
+                                },
+                              },
+                            ],
+                            "nodeType": "Expr_Array",
+                          },
+                        },
+                      ],
+                      "attributes": {},
+                      "class": {
+                        "attributes": {},
+                        "nodeType": "Name",
+                        "parts": [
+                          "WP_Error",
+                        ],
+                      },
+                      "nodeType": "Expr_New",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "id",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "resolveBookPost",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "this",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "post",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "attributes": {},
+                  "expr": {
+                    "attributes": {},
+                    "class": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "WP_Post",
+                      ],
+                    },
+                    "expr": {
+                      "attributes": {},
+                      "name": "post",
+                      "nodeType": "Expr_Variable",
+                    },
+                    "nodeType": "Expr_Instanceof",
+                  },
+                  "nodeType": "Expr_BooleanNot",
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "args": [
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "wpk_book_not_found",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "Book not found.",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "items": [
+                              {
+                                "attributes": {},
+                                "byRef": false,
+                                "key": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_String",
+                                  "value": "status",
+                                },
+                                "nodeType": "Expr_ArrayItem",
+                                "unpack": false,
+                                "value": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_LNumber",
+                                  "value": 404,
+                                },
+                              },
+                            ],
+                            "nodeType": "Expr_Array",
+                          },
+                        },
+                      ],
+                      "attributes": {},
+                      "class": {
+                        "attributes": {},
+                        "nodeType": "Name",
+                        "parts": [
+                          "WP_Error",
+                        ],
+                      },
+                      "nodeType": "Expr_New",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "post",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "request",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "prepareBookResponse",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "this",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "previous",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": {
+                            "attributes": {},
+                            "name": "ID",
+                            "nodeType": "Identifier",
+                          },
+                          "nodeType": "Expr_PropertyFetch",
+                          "var": {
+                            "attributes": {},
+                            "name": "post",
+                            "nodeType": "Expr_Variable",
+                          },
+                        },
+                      },
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": {
+                            "attributes": {},
+                            "nodeType": "Name",
+                            "parts": [
+                              "true",
+                            ],
+                          },
+                          "nodeType": "Expr_ConstFetch",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "wp_delete_post",
+                      ],
+                    },
+                    "nodeType": "Expr_FuncCall",
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "deleted",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "attributes": {},
+                  "left": {
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "false",
+                      ],
+                    },
+                    "nodeType": "Expr_ConstFetch",
+                  },
+                  "nodeType": "Expr_BinaryOp_Identical",
+                  "right": {
+                    "attributes": {},
+                    "name": "deleted",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "args": [
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "wpk_book_delete_failed",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "Unable to delete Book.",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "items": [
+                              {
+                                "attributes": {},
+                                "byRef": false,
+                                "key": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_String",
+                                  "value": "status",
+                                },
+                                "nodeType": "Expr_ArrayItem",
+                                "unpack": false,
+                                "value": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_LNumber",
+                                  "value": 500,
+                                },
+                              },
+                            ],
+                            "nodeType": "Expr_Array",
+                          },
+                        },
+                      ],
+                      "attributes": {},
+                      "class": {
+                        "attributes": {},
+                        "nodeType": "Name",
+                        "parts": [
+                          "WP_Error",
+                        ],
+                      },
+                      "nodeType": "Expr_New",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "items": [
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "key": {
+                        "attributes": {},
+                        "nodeType": "Scalar_String",
+                        "value": "deleted",
+                      },
+                      "nodeType": "Expr_ArrayItem",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": {
+                          "attributes": {},
+                          "nodeType": "Name",
+                          "parts": [
+                            "true",
+                          ],
+                        },
+                        "nodeType": "Expr_ConstFetch",
+                      },
+                    },
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "key": {
+                        "attributes": {},
+                        "nodeType": "Scalar_String",
+                        "value": "id",
+                      },
+                      "nodeType": "Expr_ArrayItem",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "expr": {
+                          "attributes": {},
+                          "name": {
+                            "attributes": {},
+                            "name": "ID",
+                            "nodeType": "Identifier",
+                          },
+                          "nodeType": "Expr_PropertyFetch",
+                          "var": {
+                            "attributes": {},
+                            "name": "post",
+                            "nodeType": "Expr_Variable",
+                          },
+                        },
+                        "nodeType": "Expr_Cast_Int",
+                      },
+                    },
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "key": {
+                        "attributes": {},
+                        "nodeType": "Scalar_String",
+                        "value": "previous",
+                      },
+                      "nodeType": "Expr_ArrayItem",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "previous",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                  ],
+                  "nodeType": "Expr_Array",
+                },
+                "nodeType": "Stmt_Return",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:END AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+    ],
+  },
+]
+`;
+
+exports[`wp-post mutation route builders emits update route body with guarded status macro: update-route 1`] = `
+[
+  {
+    "attributes": {},
+    "declares": [
+      {
+        "attributes": {},
+        "key": {
+          "attributes": {},
+          "name": "strict_types",
+          "nodeType": "Identifier",
+        },
+        "nodeType": "DeclareItem",
+        "value": {
+          "attributes": {},
+          "nodeType": "Scalar_LNumber",
+          "value": 1,
+        },
+      },
+    ],
+    "nodeType": "Stmt_Declare",
+    "stmts": null,
+  },
+  {
+    "attributes": {},
+    "name": {
+      "attributes": {},
+      "nodeType": "Name",
+      "parts": [
+        "Demo",
+        "Rest",
+      ],
+    },
+    "nodeType": "Stmt_Namespace",
+    "stmts": [
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:BEGIN AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+      {
+        "attrGroups": [],
+        "attributes": {},
+        "extends": null,
+        "flags": 0,
+        "implements": [],
+        "name": {
+          "attributes": {},
+          "name": "MutationHarness",
+          "nodeType": "Identifier",
+        },
+        "namespacedName": null,
+        "nodeType": "Stmt_Class",
+        "stmts": [
+          {
+            "attrGroups": [],
+            "attributes": {},
+            "byRef": false,
+            "flags": 0,
+            "name": {
+              "attributes": {},
+              "name": "handle",
+              "nodeType": "Identifier",
+            },
+            "nodeType": "Stmt_ClassMethod",
+            "params": [],
+            "returnType": null,
+            "stmts": [
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "nodeType": "Scalar_String",
+                          "value": "id",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "get_param",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "request",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "id",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "attributes": {},
+                  "left": {
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "null",
+                      ],
+                    },
+                    "nodeType": "Expr_ConstFetch",
+                  },
+                  "nodeType": "Expr_BinaryOp_Identical",
+                  "right": {
+                    "attributes": {},
+                    "name": "id",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "args": [
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "wpk_book_missing_identifier",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "Missing identifier for Book.",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "items": [
+                              {
+                                "attributes": {},
+                                "byRef": false,
+                                "key": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_String",
+                                  "value": "status",
+                                },
+                                "nodeType": "Expr_ArrayItem",
+                                "unpack": false,
+                                "value": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_LNumber",
+                                  "value": 400,
+                                },
+                              },
+                            ],
+                            "nodeType": "Expr_Array",
+                          },
+                        },
+                      ],
+                      "attributes": {},
+                      "class": {
+                        "attributes": {},
+                        "nodeType": "Name",
+                        "parts": [
+                          "WP_Error",
+                        ],
+                      },
+                      "nodeType": "Expr_New",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "attributes": {},
+                    "expr": {
+                      "attributes": {},
+                      "name": "id",
+                      "nodeType": "Expr_Variable",
+                    },
+                    "nodeType": "Expr_Cast_Int",
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "id",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "attributes": {},
+                  "left": {
+                    "attributes": {},
+                    "name": "id",
+                    "nodeType": "Expr_Variable",
+                  },
+                  "nodeType": "Expr_BinaryOp_SmallerOrEqual",
+                  "right": {
+                    "attributes": {},
+                    "nodeType": "Scalar_LNumber",
+                    "value": 0,
+                  },
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "args": [
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "wpk_book_invalid_identifier",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "Invalid identifier for Book.",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "items": [
+                              {
+                                "attributes": {},
+                                "byRef": false,
+                                "key": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_String",
+                                  "value": "status",
+                                },
+                                "nodeType": "Expr_ArrayItem",
+                                "unpack": false,
+                                "value": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_LNumber",
+                                  "value": 400,
+                                },
+                              },
+                            ],
+                            "nodeType": "Expr_Array",
+                          },
+                        },
+                      ],
+                      "attributes": {},
+                      "class": {
+                        "attributes": {},
+                        "nodeType": "Name",
+                        "parts": [
+                          "WP_Error",
+                        ],
+                      },
+                      "nodeType": "Expr_New",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "id",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "resolveBookPost",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "this",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "post",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "attributes": {},
+                  "expr": {
+                    "attributes": {},
+                    "class": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "WP_Post",
+                      ],
+                    },
+                    "expr": {
+                      "attributes": {},
+                      "name": "post",
+                      "nodeType": "Expr_Variable",
+                    },
+                    "nodeType": "Expr_Instanceof",
+                  },
+                  "nodeType": "Expr_BooleanNot",
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "args": [
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "wpk_book_not_found",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "Book not found.",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "items": [
+                              {
+                                "attributes": {},
+                                "byRef": false,
+                                "key": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_String",
+                                  "value": "status",
+                                },
+                                "nodeType": "Expr_ArrayItem",
+                                "unpack": false,
+                                "value": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_LNumber",
+                                  "value": 404,
+                                },
+                              },
+                            ],
+                            "nodeType": "Expr_Array",
+                          },
+                        },
+                      ],
+                      "attributes": {},
+                      "class": {
+                        "attributes": {},
+                        "nodeType": "Name",
+                        "parts": [
+                          "WP_Error",
+                        ],
+                      },
+                      "nodeType": "Expr_New",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "attributes": {},
+                    "items": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "key": {
+                          "attributes": {},
+                          "nodeType": "Scalar_String",
+                          "value": "ID",
+                        },
+                        "nodeType": "Expr_ArrayItem",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": {
+                            "attributes": {},
+                            "name": "ID",
+                            "nodeType": "Identifier",
+                          },
+                          "nodeType": "Expr_PropertyFetch",
+                          "var": {
+                            "attributes": {},
+                            "name": "post",
+                            "nodeType": "Expr_Variable",
+                          },
+                        },
+                      },
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "key": {
+                          "attributes": {},
+                          "nodeType": "Scalar_String",
+                          "value": "post_type",
+                        },
+                        "nodeType": "Expr_ArrayItem",
+                        "unpack": false,
+                        "value": {
+                          "args": [],
+                          "attributes": {},
+                          "name": {
+                            "attributes": {},
+                            "name": "getBookPostType",
+                            "nodeType": "Identifier",
+                          },
+                          "nodeType": "Expr_MethodCall",
+                          "var": {
+                            "attributes": {},
+                            "name": "this",
+                            "nodeType": "Expr_Variable",
+                          },
+                        },
+                      },
+                    ],
+                    "nodeType": "Expr_Array",
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "post_data",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation status-validation",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:status normalise",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "nodeType": "Scalar_String",
+                          "value": "status",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "get_param",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "request",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "status",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "attributes": {},
+                  "left": {
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "null",
+                      ],
+                    },
+                    "nodeType": "Expr_ConstFetch",
+                  },
+                  "nodeType": "Expr_BinaryOp_NotIdentical",
+                  "right": {
+                    "attributes": {},
+                    "name": "status",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "attributes": {},
+                      "expr": {
+                        "args": [
+                          {
+                            "attributes": {},
+                            "byRef": false,
+                            "name": null,
+                            "nodeType": "Arg",
+                            "unpack": false,
+                            "value": {
+                              "attributes": {},
+                              "name": "status",
+                              "nodeType": "Expr_Variable",
+                            },
+                          },
+                        ],
+                        "attributes": {},
+                        "name": {
+                          "attributes": {},
+                          "name": "normaliseBookStatus",
+                          "nodeType": "Identifier",
+                        },
+                        "nodeType": "Expr_MethodCall",
+                        "var": {
+                          "attributes": {},
+                          "name": "this",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                      "nodeType": "Expr_Assign",
+                      "var": {
+                        "attributes": {},
+                        "dim": {
+                          "attributes": {},
+                          "nodeType": "Scalar_String",
+                          "value": "post_status",
+                        },
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "var": {
+                          "attributes": {},
+                          "name": "post_data",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    },
+                    "nodeType": "Stmt_Expression",
+                  },
+                ],
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "post_data",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": {
+                            "attributes": {},
+                            "nodeType": "Name",
+                            "parts": [
+                              "true",
+                            ],
+                          },
+                          "nodeType": "Expr_ConstFetch",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "wp_update_post",
+                      ],
+                    },
+                    "nodeType": "Expr_FuncCall",
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "result",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "args": [
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "result",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                  ],
+                  "attributes": {},
+                  "name": {
+                    "attributes": {},
+                    "nodeType": "Name",
+                    "parts": [
+                      "is_wp_error",
+                    ],
+                  },
+                  "nodeType": "Expr_FuncCall",
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "attributes": {},
+                      "name": "result",
+                      "nodeType": "Expr_Variable",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation sync-meta",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:meta update",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "args": [
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": {
+                          "attributes": {},
+                          "name": "ID",
+                          "nodeType": "Identifier",
+                        },
+                        "nodeType": "Expr_PropertyFetch",
+                        "var": {
+                          "attributes": {},
+                          "name": "post",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    },
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "request",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                  ],
+                  "attributes": {},
+                  "name": {
+                    "attributes": {},
+                    "name": "syncBookMeta",
+                    "nodeType": "Identifier",
+                  },
+                  "nodeType": "Expr_MethodCall",
+                  "var": {
+                    "attributes": {},
+                    "name": "this",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation sync-taxonomies",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:taxonomies update",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": {
+                            "attributes": {},
+                            "name": "ID",
+                            "nodeType": "Identifier",
+                          },
+                          "nodeType": "Expr_PropertyFetch",
+                          "var": {
+                            "attributes": {},
+                            "name": "post",
+                            "nodeType": "Expr_Variable",
+                          },
+                        },
+                      },
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": "request",
+                          "nodeType": "Expr_Variable",
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "name": "syncBookTaxonomies",
+                      "nodeType": "Identifier",
+                    },
+                    "nodeType": "Expr_MethodCall",
+                    "var": {
+                      "attributes": {},
+                      "name": "this",
+                      "nodeType": "Expr_Variable",
+                    },
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "taxonomy_result",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "args": [
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "taxonomy_result",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                  ],
+                  "attributes": {},
+                  "name": {
+                    "attributes": {},
+                    "nodeType": "Name",
+                    "parts": [
+                      "is_wp_error",
+                    ],
+                  },
+                  "nodeType": "Expr_FuncCall",
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "attributes": {},
+                      "name": "taxonomy_result",
+                      "nodeType": "Expr_Variable",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel resource.wpPost.mutation cache-priming",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel mutation:cache prime",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {
+                  "comments": [
+                    {
+                      "nodeType": "Comment",
+                      "text": "// @wp-kernel cache:wp-post prime",
+                    },
+                  ],
+                },
+                "nodeType": "Stmt_Nop",
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "attributes": {},
+                  "expr": {
+                    "args": [
+                      {
+                        "attributes": {},
+                        "byRef": false,
+                        "name": null,
+                        "nodeType": "Arg",
+                        "unpack": false,
+                        "value": {
+                          "attributes": {},
+                          "name": {
+                            "attributes": {},
+                            "name": "ID",
+                            "nodeType": "Identifier",
+                          },
+                          "nodeType": "Expr_PropertyFetch",
+                          "var": {
+                            "attributes": {},
+                            "name": "post",
+                            "nodeType": "Expr_Variable",
+                          },
+                        },
+                      },
+                    ],
+                    "attributes": {},
+                    "name": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "get_post",
+                      ],
+                    },
+                    "nodeType": "Expr_FuncCall",
+                  },
+                  "nodeType": "Expr_Assign",
+                  "var": {
+                    "attributes": {},
+                    "name": "updated",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Expression",
+              },
+              {
+                "attributes": {},
+                "cond": {
+                  "attributes": {},
+                  "expr": {
+                    "attributes": {},
+                    "class": {
+                      "attributes": {},
+                      "nodeType": "Name",
+                      "parts": [
+                        "WP_Post",
+                      ],
+                    },
+                    "expr": {
+                      "attributes": {},
+                      "name": "updated",
+                      "nodeType": "Expr_Variable",
+                    },
+                    "nodeType": "Expr_Instanceof",
+                  },
+                  "nodeType": "Expr_BooleanNot",
+                },
+                "else": null,
+                "elseifs": [],
+                "nodeType": "Stmt_If",
+                "stmts": [
+                  {
+                    "attributes": {},
+                    "expr": {
+                      "args": [
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "wpk_book_load_failed",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "nodeType": "Scalar_String",
+                            "value": "Unable to load updated Book.",
+                          },
+                        },
+                        {
+                          "attributes": {},
+                          "byRef": false,
+                          "name": null,
+                          "nodeType": "Arg",
+                          "unpack": false,
+                          "value": {
+                            "attributes": {},
+                            "items": [
+                              {
+                                "attributes": {},
+                                "byRef": false,
+                                "key": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_String",
+                                  "value": "status",
+                                },
+                                "nodeType": "Expr_ArrayItem",
+                                "unpack": false,
+                                "value": {
+                                  "attributes": {},
+                                  "nodeType": "Scalar_LNumber",
+                                  "value": 500,
+                                },
+                              },
+                            ],
+                            "nodeType": "Expr_Array",
+                          },
+                        },
+                      ],
+                      "attributes": {},
+                      "class": {
+                        "attributes": {},
+                        "nodeType": "Name",
+                        "parts": [
+                          "WP_Error",
+                        ],
+                      },
+                      "nodeType": "Expr_New",
+                    },
+                    "nodeType": "Stmt_Return",
+                  },
+                ],
+              },
+              {
+                "attributes": {},
+                "expr": {
+                  "args": [
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "updated",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                    {
+                      "attributes": {},
+                      "byRef": false,
+                      "name": null,
+                      "nodeType": "Arg",
+                      "unpack": false,
+                      "value": {
+                        "attributes": {},
+                        "name": "request",
+                        "nodeType": "Expr_Variable",
+                      },
+                    },
+                  ],
+                  "attributes": {},
+                  "name": {
+                    "attributes": {},
+                    "name": "prepareBookResponse",
+                    "nodeType": "Identifier",
+                  },
+                  "nodeType": "Expr_MethodCall",
+                  "var": {
+                    "attributes": {},
+                    "name": "this",
+                    "nodeType": "Expr_Variable",
+                  },
+                },
+                "nodeType": "Stmt_Return",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        "attributes": {
+          "comments": [
+            {
+              "nodeType": "Comment",
+              "text": "// WPK:END AUTO",
+            },
+          ],
+        },
+        "nodeType": "Stmt_Nop",
+      },
+    ],
+  },
+]
+`;

--- a/packages/cli/src/next/builders/php/printers/__tests__/wpPostMutations.routes.test.ts
+++ b/packages/cli/src/next/builders/php/printers/__tests__/wpPostMutations.routes.test.ts
@@ -1,0 +1,319 @@
+import path from 'node:path';
+import type { Reporter } from '@wpkernel/core/reporter';
+import type {
+	BuilderInput,
+	BuilderOutput,
+	PipelineContext,
+} from '../../../runtime/types';
+import { createPhpProgramBuilder } from '../../ast/programBuilder';
+import { appendClassTemplate } from '../../ast/append';
+import {
+	createClassTemplate,
+	createMethodTemplate,
+	PHP_INDENT,
+	type PhpMethodBodyBuilder,
+} from '../../ast/templates';
+import {
+	WP_POST_MUTATION_CONTRACT,
+	buildCreateRouteBody,
+	buildUpdateRouteBody,
+	buildDeleteRouteBody,
+	prepareWpPostResponse,
+	syncWpPostMeta,
+	syncWpPostTaxonomies,
+} from '../resource/wpPost/mutations';
+import { getPhpBuilderChannel, resetPhpBuilderChannel } from '../channel';
+import { resetPhpAstChannel } from '../../ast/context';
+import type { IRResource } from '../../../../ir/types';
+
+const CONTRACT = WP_POST_MUTATION_CONTRACT;
+
+type ChannelEntry = ReturnType<
+	ReturnType<typeof getPhpBuilderChannel>['pending']
+>[number];
+
+function createReporter(): Reporter {
+	return {
+		debug: jest.fn(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		child: jest.fn().mockReturnThis(),
+	} as Reporter;
+}
+
+function createPipelineContext(): PipelineContext {
+	return {
+		workspace: {
+			root: '/workspace',
+			resolve: (...parts: string[]) => path.join('/workspace', ...parts),
+			cwd: () => '/workspace',
+			read: async () => null,
+			readText: async () => null,
+			write: jest.fn(async () => undefined),
+			writeJson: jest.fn(async () => undefined),
+			exists: async () => false,
+			rm: async () => undefined,
+			glob: async () => [],
+			threeWayMerge: async () => 'clean',
+			begin: () => undefined,
+			commit: async () => ({ writes: [], deletes: [] }),
+			rollback: async () => ({ writes: [], deletes: [] }),
+			dryRun: async (fn) => ({
+				result: await fn(),
+				manifest: { writes: [], deletes: [] },
+			}),
+			tmpDir: async () => '.tmp',
+		},
+		reporter: createReporter(),
+		phase: 'generate',
+	} as unknown as PipelineContext;
+}
+
+function createBuilderInput(): BuilderInput {
+	return {
+		phase: 'generate',
+		options: {
+			config: {} as never,
+			namespace: 'demo-plugin',
+			origin: 'kernel.config.ts',
+			sourcePath: 'kernel.config.ts',
+		},
+		ir: null,
+	};
+}
+
+const RESOURCE: IRResource = {
+	name: 'book',
+	schemaKey: 'book',
+	schemaProvenance: 'manual',
+	routes: [],
+	cacheKeys: {
+		list: { segments: ['book', 'list'], source: 'default' },
+		get: { segments: ['book', 'get'], source: 'default' },
+		create: { segments: ['book', 'create'], source: 'default' },
+		update: { segments: ['book', 'update'], source: 'default' },
+		remove: { segments: ['book', 'remove'], source: 'default' },
+	},
+	identity: { type: 'number', param: 'id' },
+	storage: {
+		mode: 'wp-post',
+		postType: 'book',
+		statuses: ['draft', 'publish'],
+		supports: ['title', 'editor'],
+		meta: {
+			subtitle: { type: 'string' },
+		},
+		taxonomies: {
+			category: { taxonomy: 'category' },
+		},
+	},
+	queryParams: {},
+	ui: undefined,
+	hash: 'book-hash',
+	warnings: [],
+};
+
+const PASCALE_NAME = 'Book';
+const IDENTITY = { type: 'number', param: 'id' } as const;
+
+async function queueRouteProgram(
+	buildMethod: (body: PhpMethodBodyBuilder) => void,
+	metadata: Record<string, string>
+): Promise<{ entry: ChannelEntry; context: PipelineContext }> {
+	const context = createPipelineContext();
+	const input = createBuilderInput();
+	const output: BuilderOutput = { actions: [], queueWrite: jest.fn() };
+
+	resetPhpBuilderChannel(context);
+	resetPhpAstChannel(context);
+
+	const helper = createPhpProgramBuilder({
+		key: `mutation.route.${metadata.kind}`,
+		filePath: context.workspace.resolve(
+			'.generated',
+			'php',
+			`mutation-${metadata.kind}.php`
+		),
+		namespace: 'Demo\\Rest',
+		metadata: {
+			kind: 'resource-mutation',
+			name: metadata.kind,
+			tags: metadata,
+		},
+		async build(builder) {
+			const method = createMethodTemplate({
+				signature: 'public function handle( WP_REST_Request $request )',
+				indentLevel: 1,
+				indentUnit: PHP_INDENT,
+				body: buildMethod,
+			});
+			const classTemplate = createClassTemplate({
+				name: 'MutationHarness',
+				methods: [method],
+			});
+			appendClassTemplate(builder, classTemplate);
+		},
+	});
+
+	await helper.apply(
+		{ context, input, output, reporter: context.reporter },
+		undefined
+	);
+
+	const channel = getPhpBuilderChannel(context);
+	const entry = channel.pending()[0];
+	return { entry, context };
+}
+
+async function queueHelperPrograms(): Promise<{
+	entries: ChannelEntry[];
+	context: PipelineContext;
+}> {
+	const context = createPipelineContext();
+	const input = createBuilderInput();
+	const output: BuilderOutput = { actions: [], queueWrite: jest.fn() };
+
+	resetPhpBuilderChannel(context);
+	resetPhpAstChannel(context);
+
+	const helpers = [
+		{ key: 'sync-meta', factory: syncWpPostMeta },
+		{ key: 'sync-taxonomies', factory: syncWpPostTaxonomies },
+		{ key: 'prepare-response', factory: prepareWpPostResponse },
+	];
+
+	for (const helperFactory of helpers) {
+		const builderHelper = createPhpProgramBuilder({
+			key: `mutation.helper.${helperFactory.key}`,
+			filePath: context.workspace.resolve(
+				'.generated',
+				'php',
+				`${helperFactory.key}.php`
+			),
+			namespace: 'Demo\\Rest',
+			metadata: {
+				kind: 'resource-helper',
+				helper: helperFactory.key,
+			},
+			async build(builder) {
+				const method = helperFactory.factory({
+					resource: RESOURCE,
+					pascalName: PASCALE_NAME,
+					identity: IDENTITY,
+				});
+				const classTemplate = createClassTemplate({
+					name: 'MutationHelpers',
+					methods: [method],
+				});
+				appendClassTemplate(builder, classTemplate);
+			},
+		});
+
+		await builderHelper.apply(
+			{ context, input, output, reporter: context.reporter },
+			undefined
+		);
+	}
+
+	const channel = getPhpBuilderChannel(context);
+	return { entries: channel.pending(), context };
+}
+
+describe('wp-post mutation route builders', () => {
+	it('emits create route body with macros in expected order', async () => {
+		const { entry } = await queueRouteProgram(
+			(body) => {
+				const built = buildCreateRouteBody({
+					body,
+					indentLevel: 2,
+					resource: RESOURCE,
+					pascalName: PASCALE_NAME,
+					metadataKeys: CONTRACT.metadataKeys,
+				});
+
+				expect(built).toBe(true);
+			},
+			{ kind: 'create' }
+		);
+
+		const source = entry.statements.join('\n');
+		expect(
+			source.indexOf(CONTRACT.metadataKeys.statusValidation)
+		).toBeLessThan(source.indexOf(CONTRACT.metadataKeys.syncMeta));
+		expect(source.indexOf(CONTRACT.metadataKeys.syncMeta)).toBeLessThan(
+			source.indexOf(CONTRACT.metadataKeys.syncTaxonomies)
+		);
+		expect(
+			source.indexOf(CONTRACT.metadataKeys.syncTaxonomies)
+		).toBeLessThan(source.indexOf(CONTRACT.metadataKeys.cachePriming));
+		expect(entry.program).toMatchSnapshot('create-route');
+	});
+
+	it('emits update route body with guarded status macro', async () => {
+		const { entry } = await queueRouteProgram(
+			(body) => {
+				const built = buildUpdateRouteBody({
+					body,
+					indentLevel: 2,
+					resource: RESOURCE,
+					pascalName: PASCALE_NAME,
+					metadataKeys: CONTRACT.metadataKeys,
+					identity: IDENTITY,
+				});
+
+				expect(built).toBe(true);
+			},
+			{ kind: 'update' }
+		);
+
+		const statements = entry.statements.join('\n');
+		expect(statements).toContain('if ( null !== $status ) {');
+		expect(statements.indexOf(CONTRACT.metadataKeys.syncMeta)).toBeLessThan(
+			statements.indexOf(CONTRACT.metadataKeys.cachePriming)
+		);
+		expect(entry.program).toMatchSnapshot('update-route');
+	});
+
+	it('emits delete route body with previous response payload', async () => {
+		const { entry } = await queueRouteProgram(
+			(body) => {
+				const built = buildDeleteRouteBody({
+					body,
+					indentLevel: 2,
+					resource: RESOURCE,
+					pascalName: PASCALE_NAME,
+					metadataKeys: CONTRACT.metadataKeys,
+					identity: IDENTITY,
+				});
+
+				expect(built).toBe(true);
+			},
+			{ kind: 'delete' }
+		);
+
+		const statements = entry.statements.join('\n');
+		expect(statements).toContain("'previous' => $previous");
+		expect(entry.program).toMatchSnapshot('delete-route');
+	});
+});
+
+describe('wp-post mutation helpers', () => {
+	it('queues helpers in contract order with stable output', async () => {
+		const { entries } = await queueHelperPrograms();
+
+		const helpers = entries.map((entry) => entry.metadata.helper);
+		expect(helpers).toEqual([
+			'sync-meta',
+			'sync-taxonomies',
+			'prepare-response',
+		]);
+
+		const snapshotPayload = entries.map((entry) => ({
+			helper: entry.metadata.helper,
+			statements: entry.statements,
+		}));
+
+		expect(snapshotPayload).toMatchSnapshot('helper-programs');
+	});
+});

--- a/packages/cli/src/next/builders/php/printers/resource/wpPost/mutations/helpers.ts
+++ b/packages/cli/src/next/builders/php/printers/resource/wpPost/mutations/helpers.ts
@@ -1,0 +1,329 @@
+import { KernelError } from '@wpkernel/core/contracts';
+import {
+	createIdentifier,
+	createName,
+	createParam,
+	createVariable,
+} from '../../../../ast/nodes';
+import {
+	createMethodTemplate,
+	PHP_INDENT,
+	type PhpMethodBodyBuilder,
+	type PhpMethodTemplate,
+} from '../../../../ast/templates';
+import { PHP_METHOD_MODIFIER_PRIVATE } from '../../../../ast/modifiers';
+import { escapeSingleQuotes, toSnakeCase } from '../../../../ast/utils';
+import type { IRResource } from '../../../../../../../ir/types';
+import type { ResolvedIdentity } from '../../../identity';
+
+type WpPostStorage = Extract<
+	NonNullable<IRResource['storage']>,
+	{ mode: 'wp-post' }
+>;
+
+type WpPostMetaDescriptor = NonNullable<WpPostStorage['meta']>[string];
+type WpPostTaxonomyDescriptor = NonNullable<
+	WpPostStorage['taxonomies']
+>[string];
+
+export interface MutationHelperOptions {
+	readonly resource: IRResource;
+	readonly pascalName: string;
+	readonly identity: ResolvedIdentity;
+}
+
+export function syncWpPostMeta(
+	options: MutationHelperOptions
+): PhpMethodTemplate {
+	const storage = ensureStorage(options.resource);
+	const metaEntries = Object.entries(storage.meta ?? {}) as Array<
+		[string, WpPostMetaDescriptor]
+	>;
+
+	return createMethodTemplate({
+		signature: `private function sync${options.pascalName}Meta( int $post_id, WP_REST_Request $request ): void`,
+		indentLevel: 1,
+		indentUnit: PHP_INDENT,
+		body: (body) => {
+			if (metaEntries.length === 0) {
+				body.line('unset( $post_id, $request );');
+				body.line('return;');
+				return;
+			}
+
+			for (const [key, descriptor] of metaEntries) {
+				const variable = `$${toSnakeCase(key)}Meta`;
+				const escapedKey = escapeSingleQuotes(key);
+				body.line(
+					`${variable} = $request->get_param( '${escapedKey}' );`
+				);
+				body.line(`if ( null !== ${variable} ) {`);
+				appendMetaSanitizer(body, variable, descriptor);
+
+				if (descriptor?.single === false) {
+					body.line(
+						`        delete_post_meta( $post_id, '${escapedKey}' );`
+					);
+					body.line(
+						`        foreach ( (array) ${variable} as $value ) {`
+					);
+					body.line(
+						`                add_post_meta( $post_id, '${escapedKey}', $value );`
+					);
+					body.line('        }');
+				} else {
+					body.line(
+						`        update_post_meta( $post_id, '${escapedKey}', ${variable} );`
+					);
+				}
+
+				body.line('}');
+			}
+		},
+		ast: {
+			flags: PHP_METHOD_MODIFIER_PRIVATE,
+			params: [
+				createParam(createVariable('post_id'), {
+					type: createIdentifier('int'),
+				}),
+				createParam(createVariable('request'), {
+					type: createName(['WP_REST_Request']),
+				}),
+			],
+			returnType: createIdentifier('void'),
+		},
+	});
+}
+
+export function syncWpPostTaxonomies(
+	options: MutationHelperOptions
+): PhpMethodTemplate {
+	const storage = ensureStorage(options.resource);
+	const taxonomyEntries = Object.entries(storage.taxonomies ?? {}) as Array<
+		[string, WpPostTaxonomyDescriptor]
+	>;
+
+	return createMethodTemplate({
+		signature: `private function sync${options.pascalName}Taxonomies( int $post_id, WP_REST_Request $request )`,
+		indentLevel: 1,
+		indentUnit: PHP_INDENT,
+		body: (body) => {
+			if (taxonomyEntries.length === 0) {
+				body.line('unset( $post_id, $request );');
+				body.line('return true;');
+				return;
+			}
+
+			body.line('$result = true;');
+
+			for (const [key, descriptor] of taxonomyEntries) {
+				const variable = `$${toSnakeCase(key)}Terms`;
+				const escapedKey = escapeSingleQuotes(key);
+				const taxonomy = escapeSingleQuotes(descriptor.taxonomy);
+				body.line(
+					`${variable} = $request->get_param( '${escapedKey}' );`
+				);
+				body.line(`if ( null !== ${variable} ) {`);
+				body.line(`        if ( ! is_array( ${variable} ) ) {`);
+				body.line(
+					`                ${variable} = array( ${variable} );`
+				);
+				body.line('        }');
+				body.line(
+					`        ${variable} = array_filter( array_map( 'intval', (array) ${variable} ) );`
+				);
+				body.line('        $result = wp_set_object_terms(');
+				body.line('                $post_id,');
+				body.line(`                ${variable},`);
+				body.line(`                '${taxonomy}',`);
+				body.line('                false');
+				body.line('        );');
+				body.line('        if ( is_wp_error( $result ) ) {');
+				body.line('                return $result;');
+				body.line('        }');
+				body.line('}');
+			}
+
+			body.line('return $result;');
+		},
+		ast: {
+			flags: PHP_METHOD_MODIFIER_PRIVATE,
+			params: [
+				createParam(createVariable('post_id'), {
+					type: createIdentifier('int'),
+				}),
+				createParam(createVariable('request'), {
+					type: createName(['WP_REST_Request']),
+				}),
+			],
+		},
+	});
+}
+
+export function prepareWpPostResponse(
+	options: MutationHelperOptions
+): PhpMethodTemplate {
+	const storage = ensureStorage(options.resource);
+	const metaEntries = Object.entries(storage.meta ?? {}) as Array<
+		[string, WpPostMetaDescriptor]
+	>;
+	const taxonomyEntries = Object.entries(storage.taxonomies ?? {}) as Array<
+		[string, WpPostTaxonomyDescriptor]
+	>;
+	const supports = new Set(storage.supports ?? []);
+
+	return createMethodTemplate({
+		signature: `private function prepare${options.pascalName}Response( WP_Post $post, WP_REST_Request $request ): array`,
+		indentLevel: 1,
+		indentUnit: PHP_INDENT,
+		body: (body) => {
+			body.line('$data = array(');
+			body.line("        'id' => (int) $post->ID,");
+			if (options.identity.param === 'slug') {
+				body.line("        'slug' => (string) $post->post_name,");
+			}
+			body.line("        'status' => (string) $post->post_status,");
+			body.line(');');
+
+			if (supports.has('title')) {
+				body.line("$data['title'] = (string) $post->post_title;");
+			}
+
+			if (supports.has('editor')) {
+				body.line("$data['content'] = (string) $post->post_content;");
+			}
+
+			if (supports.has('excerpt')) {
+				body.line("$data['excerpt'] = (string) $post->post_excerpt;");
+			}
+
+			for (const [key, descriptor] of metaEntries) {
+				const variable = `$${toSnakeCase(key)}Meta`;
+				const escapedKey = escapeSingleQuotes(key);
+				const fetchFlag =
+					descriptor?.single === false ? 'false' : 'true';
+				body.line(
+					`${variable} = get_post_meta( $post->ID, '${escapedKey}', ${fetchFlag} );`
+				);
+				if (descriptor) {
+					appendMetaSanitizer(body, variable, descriptor);
+				}
+				body.line(`$data['${escapedKey}'] = ${variable};`);
+			}
+
+			for (const [key, descriptor] of taxonomyEntries) {
+				const variable = `$${toSnakeCase(key)}Terms`;
+				const escapedKey = escapeSingleQuotes(key);
+				const taxonomy = escapeSingleQuotes(descriptor.taxonomy);
+				body.line(
+					`${variable} = wp_get_object_terms( $post->ID, '${taxonomy}', array( 'fields' => 'ids' ) );`
+				);
+				body.line(`if ( is_wp_error( ${variable} ) ) {`);
+				body.line(`        ${variable} = array();`);
+				body.line('}');
+				body.line(
+					`${variable} = array_map( 'intval', (array) ${variable} );`
+				);
+				body.line(`$data['${escapedKey}'] = ${variable};`);
+			}
+
+			body.line('return $data;');
+		},
+		ast: {
+			flags: PHP_METHOD_MODIFIER_PRIVATE,
+			params: [
+				createParam(createVariable('post'), {
+					type: createName(['WP_Post']),
+				}),
+				createParam(createVariable('request'), {
+					type: createName(['WP_REST_Request']),
+				}),
+			],
+			returnType: createIdentifier('array'),
+		},
+	});
+}
+
+function ensureStorage(resource: IRResource): WpPostStorage {
+	const storage = resource.storage;
+	if (!storage || storage.mode !== 'wp-post') {
+		throw new KernelError('DeveloperError', {
+			message: 'Resource must use wp-post storage.',
+			context: { name: resource.name },
+		});
+	}
+
+	return storage;
+}
+
+function appendMetaSanitizer(
+	body: PhpMethodBodyBuilder,
+	variable: string,
+	descriptor: WpPostMetaDescriptor
+): void {
+	if (descriptor?.single === false && descriptor.type !== 'array') {
+		body.line(`        if ( ! is_array( ${variable} ) ) {`);
+		body.line(`                ${variable} = array( ${variable} );`);
+		body.line('        }');
+		body.line(`        ${variable} = array_values( (array) ${variable} );`);
+		body.line(
+			`        foreach ( ${variable} as $meta_index => $meta_value ) {`
+		);
+		appendMetaSanitizerValue(
+			body,
+			'$meta_value',
+			descriptor,
+			'                '
+		);
+		body.line(`                ${variable}[ $meta_index ] = $meta_value;`);
+		body.line('        }');
+		return;
+	}
+
+	appendMetaSanitizerValue(body, variable, descriptor, '        ');
+}
+
+function appendMetaSanitizerValue(
+	body: PhpMethodBodyBuilder,
+	variable: string,
+	descriptor: WpPostMetaDescriptor,
+	indent: string
+): void {
+	switch (descriptor.type) {
+		case 'integer': {
+			body.line(
+				`${indent}${variable} = is_numeric( ${variable} ) ? (int) ${variable} : 0;`
+			);
+			break;
+		}
+		case 'number': {
+			body.line(
+				`${indent}${variable} = is_numeric( ${variable} ) ? (float) ${variable} : 0.0;`
+			);
+			break;
+		}
+		case 'boolean': {
+			body.line(
+				`${indent}${variable} = rest_sanitize_boolean( ${variable} );`
+			);
+			break;
+		}
+		case 'array': {
+			body.line(
+				`${indent}${variable} = array_values( (array) ${variable} );`
+			);
+			break;
+		}
+		case 'object': {
+			body.line(
+				`${indent}${variable} = is_array( ${variable} ) ? ${variable} : array();`
+			);
+			break;
+		}
+		default: {
+			body.line(
+				`${indent}${variable} = is_string( ${variable} ) ? ${variable} : (string) ${variable};`
+			);
+		}
+	}
+}

--- a/packages/cli/src/next/builders/php/printers/resource/wpPost/mutations/index.ts
+++ b/packages/cli/src/next/builders/php/printers/resource/wpPost/mutations/index.ts
@@ -17,3 +17,14 @@ export {
 	createPropertyExpression,
 	type MacroExpression,
 } from './macros';
+export {
+	buildCreateRouteBody,
+	buildUpdateRouteBody,
+	buildDeleteRouteBody,
+} from './routes';
+export {
+	syncWpPostMeta,
+	syncWpPostTaxonomies,
+	prepareWpPostResponse,
+	type MutationHelperOptions,
+} from './helpers';

--- a/packages/cli/src/next/builders/php/printers/resource/wpPost/mutations/routes.ts
+++ b/packages/cli/src/next/builders/php/printers/resource/wpPost/mutations/routes.ts
@@ -1,0 +1,517 @@
+import {
+	createArg,
+	createArray,
+	createArrayItem,
+	createAssign,
+	createExpressionStatement,
+	createFuncCall,
+	createIdentifier,
+	createMethodCall,
+	createName,
+	createNode,
+	createReturn,
+	createScalarBool,
+	createScalarString,
+	createVariable,
+	type PhpExprBooleanNot,
+} from '../../../../ast/nodes';
+import { createPrintable } from '../../../../ast/printables';
+import {
+	PHP_INDENT,
+	type PhpMethodBodyBuilder,
+} from '../../../../ast/templates';
+import { createErrorCodeFactory } from '../../../../ast/utils';
+import type { IRResource } from '../../../../../../../ir/types';
+import type { ResolvedIdentity } from '../../../identity';
+import { createIdentityValidationPrintables } from '../../wpPost/identity';
+import {
+	appendCachePrimingMacro,
+	appendStatusValidationMacro,
+	appendSyncMetaMacro,
+	appendSyncTaxonomiesMacro,
+	createArrayDimExpression,
+	createPropertyExpression,
+	createVariableExpression,
+} from './macros';
+import {
+	createIfPrintable,
+	createInstanceof,
+	createBinaryOperation,
+	createScalarCast,
+	createPropertyFetch,
+} from '../../utils';
+import { createWpErrorReturn } from '../../errors';
+import type { ResourceMutationContract } from '../../mutationContract';
+
+export interface BuildMutationRouteBodyBaseOptions {
+	readonly body: PhpMethodBodyBuilder;
+	readonly indentLevel: number;
+	readonly resource: IRResource;
+	readonly pascalName: string;
+	readonly metadataKeys: ResourceMutationContract['metadataKeys'];
+}
+
+export type BuildCreateRouteBodyOptions = BuildMutationRouteBodyBaseOptions;
+
+export function buildCreateRouteBody(
+	options: BuildCreateRouteBodyOptions
+): boolean {
+	const storage = options.resource.storage;
+	if (!storage || storage.mode !== 'wp-post') {
+		return false;
+	}
+
+	const indentLevel = options.indentLevel;
+	const indent = PHP_INDENT.repeat(indentLevel);
+	const errorCodeFactory = createErrorCodeFactory(options.resource.name);
+
+	const postTypePrintable = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				createVariable('post_type'),
+				createMethodCall(
+					createVariable('this'),
+					createIdentifier(`get${options.pascalName}PostType`),
+					[]
+				)
+			)
+		),
+		[`${indent}$post_type = $this->get${options.pascalName}PostType();`]
+	);
+	options.body.statement(postTypePrintable);
+	options.body.blank();
+
+	const postDataPrintable = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				createVariable('post_data'),
+				createArray([
+					createArrayItem(createVariable('post_type'), {
+						key: createScalarString('post_type'),
+					}),
+				])
+			)
+		),
+		[
+			`${indent}$post_data = array(`,
+			`${indent}${PHP_INDENT}'post_type' => $post_type,`,
+			`${indent});`,
+		]
+	);
+	options.body.statement(postDataPrintable);
+
+	appendStatusValidationMacro({
+		body: options.body,
+		indentLevel,
+		metadataKeys: options.metadataKeys,
+		pascalName: options.pascalName,
+		target: createArrayDimExpression('post_data', 'post_status'),
+	});
+	options.body.blank();
+
+	const insertPrintable = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				createVariable('post_id'),
+				createFuncCall(createName(['wp_insert_post']), [
+					createArg(createVariable('post_data')),
+					createArg(createScalarBool(true)),
+				])
+			)
+		),
+		[`${indent}$post_id = wp_insert_post( $post_data, true );`]
+	);
+	options.body.statement(insertPrintable);
+
+	const insertReturn = createPrintable(
+		createReturn(createVariable('post_id')),
+		[`${indent}${PHP_INDENT}return $post_id;`]
+	);
+	const insertGuard = createIfPrintable({
+		indentLevel,
+		condition: createFuncCall(createName(['is_wp_error']), [
+			createArg(createVariable('post_id')),
+		]),
+		conditionText: `${indent}if ( is_wp_error( $post_id ) ) {`,
+		statements: [insertReturn],
+	});
+	options.body.statement(insertGuard);
+	options.body.blank();
+
+	appendSyncMetaMacro({
+		body: options.body,
+		indentLevel,
+		metadataKeys: options.metadataKeys,
+		pascalName: options.pascalName,
+		postId: createVariableExpression('post_id'),
+	});
+
+	appendSyncTaxonomiesMacro({
+		body: options.body,
+		indentLevel,
+		metadataKeys: options.metadataKeys,
+		pascalName: options.pascalName,
+		postId: createVariableExpression('post_id'),
+		resultVariable: createVariableExpression('taxonomy_result'),
+	});
+
+	appendCachePrimingMacro({
+		body: options.body,
+		indentLevel,
+		metadataKeys: options.metadataKeys,
+		pascalName: options.pascalName,
+		postId: createVariableExpression('post_id'),
+		errorCode: errorCodeFactory('load_failed'),
+		failureMessage: `Unable to load created ${options.pascalName}.`,
+	});
+
+	return true;
+}
+
+export interface BuildUpdateRouteBodyOptions
+	extends BuildMutationRouteBodyBaseOptions {
+	readonly identity: ResolvedIdentity;
+}
+
+export function buildUpdateRouteBody(
+	options: BuildUpdateRouteBodyOptions
+): boolean {
+	const storage = options.resource.storage;
+	if (!storage || storage.mode !== 'wp-post') {
+		return false;
+	}
+
+	const indentLevel = options.indentLevel;
+	const indent = PHP_INDENT.repeat(indentLevel);
+	const identityVar = options.identity.param;
+	const errorCodeFactory = createErrorCodeFactory(options.resource.name);
+
+	const identityPrintable = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				createVariable(identityVar),
+				createMethodCall(
+					createVariable('request'),
+					createIdentifier('get_param'),
+					[createArg(createScalarString(identityVar))]
+				)
+			)
+		),
+		[`${indent}$${identityVar} = $request->get_param( '${identityVar}' );`]
+	);
+	options.body.statement(identityPrintable);
+
+	const validationStatements = createIdentityValidationPrintables({
+		identity: options.identity,
+		indentLevel,
+		pascalName: options.pascalName,
+		errorCodeFactory,
+	});
+
+	for (const statement of validationStatements) {
+		options.body.statement(statement);
+	}
+
+	if (validationStatements.length > 0) {
+		options.body.blank();
+	}
+
+	const resolvePrintable = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				createVariable('post'),
+				createMethodCall(
+					createVariable('this'),
+					createIdentifier(`resolve${options.pascalName}Post`),
+					[createArg(createVariable(identityVar))]
+				)
+			)
+		),
+		[
+			`${indent}$post = $this->resolve${options.pascalName}Post( $${identityVar} );`,
+		]
+	);
+	options.body.statement(resolvePrintable);
+
+	const notFoundReturn = createWpErrorReturn({
+		indentLevel: indentLevel + 1,
+		code: errorCodeFactory('not_found'),
+		message: `${options.pascalName} not found.`,
+		status: 404,
+	});
+
+	const notFoundGuard = createIfPrintable({
+		indentLevel,
+		condition: createBooleanNot(createInstanceof('post', 'WP_Post')),
+		conditionText: `${indent}if ( ! $post instanceof WP_Post ) {`,
+		statements: [notFoundReturn],
+	});
+	options.body.statement(notFoundGuard);
+	options.body.blank();
+
+	const postDataPrintable = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				createVariable('post_data'),
+				createArray([
+					createArrayItem(createPropertyFetch('post', 'ID'), {
+						key: createScalarString('ID'),
+					}),
+					createArrayItem(
+						createMethodCall(
+							createVariable('this'),
+							createIdentifier(
+								`get${options.pascalName}PostType`
+							),
+							[]
+						),
+						{ key: createScalarString('post_type') }
+					),
+				])
+			)
+		),
+		[
+			`${indent}$post_data = array(`,
+			`${indent}${PHP_INDENT}'ID' => $post->ID,`,
+			`${indent}${PHP_INDENT}'post_type' => $this->get${options.pascalName}PostType(),`,
+			`${indent});`,
+		]
+	);
+	options.body.statement(postDataPrintable);
+
+	appendStatusValidationMacro({
+		body: options.body,
+		indentLevel,
+		metadataKeys: options.metadataKeys,
+		pascalName: options.pascalName,
+		target: createArrayDimExpression('post_data', 'post_status'),
+		guardWithNullCheck: true,
+	});
+	options.body.blank();
+
+	const updatePrintable = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				createVariable('result'),
+				createFuncCall(createName(['wp_update_post']), [
+					createArg(createVariable('post_data')),
+					createArg(createScalarBool(true)),
+				])
+			)
+		),
+		[`${indent}$result = wp_update_post( $post_data, true );`]
+	);
+	options.body.statement(updatePrintable);
+
+	const resultReturn = createPrintable(
+		createReturn(createVariable('result')),
+		[`${indent}${PHP_INDENT}return $result;`]
+	);
+	const resultGuard = createIfPrintable({
+		indentLevel,
+		condition: createFuncCall(createName(['is_wp_error']), [
+			createArg(createVariable('result')),
+		]),
+		conditionText: `${indent}if ( is_wp_error( $result ) ) {`,
+		statements: [resultReturn],
+	});
+	options.body.statement(resultGuard);
+	options.body.blank();
+
+	appendSyncMetaMacro({
+		body: options.body,
+		indentLevel,
+		metadataKeys: options.metadataKeys,
+		pascalName: options.pascalName,
+		postId: createPropertyExpression('post', 'ID'),
+	});
+
+	appendSyncTaxonomiesMacro({
+		body: options.body,
+		indentLevel,
+		metadataKeys: options.metadataKeys,
+		pascalName: options.pascalName,
+		postId: createPropertyExpression('post', 'ID'),
+		resultVariable: createVariableExpression('taxonomy_result'),
+	});
+
+	appendCachePrimingMacro({
+		body: options.body,
+		indentLevel,
+		metadataKeys: options.metadataKeys,
+		pascalName: options.pascalName,
+		postId: createPropertyExpression('post', 'ID'),
+		errorCode: errorCodeFactory('load_failed'),
+		failureMessage: `Unable to load updated ${options.pascalName}.`,
+		postVariableName: 'updated',
+	});
+
+	return true;
+}
+
+export interface BuildDeleteRouteBodyOptions
+	extends BuildMutationRouteBodyBaseOptions {
+	readonly identity: ResolvedIdentity;
+}
+
+export function buildDeleteRouteBody(
+	options: BuildDeleteRouteBodyOptions
+): boolean {
+	const storage = options.resource.storage;
+	if (!storage || storage.mode !== 'wp-post') {
+		return false;
+	}
+
+	const indentLevel = options.indentLevel;
+	const indent = PHP_INDENT.repeat(indentLevel);
+	const identityVar = options.identity.param;
+	const errorCodeFactory = createErrorCodeFactory(options.resource.name);
+
+	const identityPrintable = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				createVariable(identityVar),
+				createMethodCall(
+					createVariable('request'),
+					createIdentifier('get_param'),
+					[createArg(createScalarString(identityVar))]
+				)
+			)
+		),
+		[`${indent}$${identityVar} = $request->get_param( '${identityVar}' );`]
+	);
+	options.body.statement(identityPrintable);
+
+	const validationStatements = createIdentityValidationPrintables({
+		identity: options.identity,
+		indentLevel,
+		pascalName: options.pascalName,
+		errorCodeFactory,
+	});
+
+	for (const statement of validationStatements) {
+		options.body.statement(statement);
+	}
+
+	if (validationStatements.length > 0) {
+		options.body.blank();
+	}
+
+	const resolvePrintable = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				createVariable('post'),
+				createMethodCall(
+					createVariable('this'),
+					createIdentifier(`resolve${options.pascalName}Post`),
+					[createArg(createVariable(identityVar))]
+				)
+			)
+		),
+		[
+			`${indent}$post = $this->resolve${options.pascalName}Post( $${identityVar} );`,
+		]
+	);
+	options.body.statement(resolvePrintable);
+
+	const notFoundReturn = createWpErrorReturn({
+		indentLevel: indentLevel + 1,
+		code: errorCodeFactory('not_found'),
+		message: `${options.pascalName} not found.`,
+		status: 404,
+	});
+
+	const notFoundGuard = createIfPrintable({
+		indentLevel,
+		condition: createBooleanNot(createInstanceof('post', 'WP_Post')),
+		conditionText: `${indent}if ( ! $post instanceof WP_Post ) {`,
+		statements: [notFoundReturn],
+	});
+	options.body.statement(notFoundGuard);
+	options.body.blank();
+
+	const previousPrintable = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				createVariable('previous'),
+				createMethodCall(
+					createVariable('this'),
+					createIdentifier(`prepare${options.pascalName}Response`),
+					[
+						createArg(createVariable('post')),
+						createArg(createVariable('request')),
+					]
+				)
+			)
+		),
+		[
+			`${indent}$previous = $this->prepare${options.pascalName}Response( $post, $request );`,
+		]
+	);
+	options.body.statement(previousPrintable);
+
+	const deletePrintable = createPrintable(
+		createExpressionStatement(
+			createAssign(
+				createVariable('deleted'),
+				createFuncCall(createName(['wp_delete_post']), [
+					createArg(createPropertyFetch('post', 'ID')),
+					createArg(createScalarBool(true)),
+				])
+			)
+		),
+		[`${indent}$deleted = wp_delete_post( $post->ID, true );`]
+	);
+	options.body.statement(deletePrintable);
+
+	const deleteReturn = createWpErrorReturn({
+		indentLevel: indentLevel + 1,
+		code: errorCodeFactory('delete_failed'),
+		message: `Unable to delete ${options.pascalName}.`,
+		status: 500,
+	});
+
+	const deleteGuard = createIfPrintable({
+		indentLevel,
+		condition: createBinaryOperation(
+			'Identical',
+			createScalarBool(false),
+			createVariable('deleted')
+		),
+		conditionText: `${indent}if ( false === $deleted ) {`,
+		statements: [deleteReturn],
+	});
+	options.body.statement(deleteGuard);
+	options.body.blank();
+
+	const responsePrintable = createPrintable(
+		createReturn(
+			createArray([
+				createArrayItem(createScalarBool(true), {
+					key: createScalarString('deleted'),
+				}),
+				createArrayItem(
+					createScalarCast('int', createPropertyFetch('post', 'ID')),
+					{ key: createScalarString('id') }
+				),
+				createArrayItem(createVariable('previous'), {
+					key: createScalarString('previous'),
+				}),
+			])
+		),
+		[
+			`${indent}return array(`,
+			`${indent}${PHP_INDENT}'deleted' => true,`,
+			`${indent}${PHP_INDENT}'id' => (int) $post->ID,`,
+			`${indent}${PHP_INDENT}'previous' => $previous,`,
+			`${indent});`,
+		]
+	);
+	options.body.statement(responsePrintable);
+
+	return true;
+}
+
+function createBooleanNot(expr: ReturnType<typeof createInstanceof>) {
+	return createNode<PhpExprBooleanNot>('Expr_BooleanNot', { expr });
+}


### PR DESCRIPTION
## Summary
- add AST-backed builders for wp-post create, update, and delete routes that reuse the shared mutation macros
- implement wp-post mutation helper factories for meta syncing, taxonomy syncing, and response preparation
- add unit coverage that snapshots the generated programs and verifies macro/helper invocation order

## Testing
- pnpm --filter @wpkernel/cli test -- --runTestsByPath packages/cli/src/next/builders/php/printers/__tests__/wpPostMutations.routes.test.ts packages/cli/src/next/builders/php/printers/__tests__/wpPostMutations.macros.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68f6eb3a407483259a7f67596cad1265