### PR TITLE
Add wp-post mutation routing support

### DIFF
--- a/packages/cli/src/next/builders/php/ast/types.ts
+++ b/packages/cli/src/next/builders/php/ast/types.ts
@@ -4,6 +4,8 @@ export interface ResourceControllerRouteMetadata {
 	readonly method: string;
 	readonly path: string;
 	readonly kind: 'list' | 'get' | 'create' | 'update' | 'remove' | 'custom';
+	readonly cacheSegments?: readonly unknown[];
+	readonly tags?: Readonly<Record<string, string>>;
 }
 
 export interface ResourceControllerMetadata {

--- a/packages/cli/src/next/builders/php/printers/resourceController/metadata.ts
+++ b/packages/cli/src/next/builders/php/printers/resourceController/metadata.ts
@@ -1,15 +1,20 @@
 import { determineRouteKind, type ResourceRouteKind } from '../routes';
+import {
+	WP_POST_MUTATION_CONTRACT,
+	type ResourceMutationContract,
+} from '../resource/wpPost/mutations';
 import type {
 	ResourceControllerMetadata,
 	ResourceControllerRouteMetadata,
 } from '../../ast/types';
-import type { IRRoute } from '../../../../../ir/types';
+import type { IRResource, IRRoute } from '../../../../../ir/types';
 import type { ResolvedIdentity } from '../identity';
 
 export interface CreateRouteMetadataOptions {
 	readonly routes: readonly IRRoute[];
 	readonly identity: ResolvedIdentity;
 	readonly canonicalBasePaths: Set<string>;
+	readonly resource: IRResource;
 }
 
 export type RouteMetadataKind = ResourceRouteKind | 'custom';
@@ -17,17 +22,87 @@ export type RouteMetadataKind = ResourceRouteKind | 'custom';
 export function createRouteMetadata(
 	options: CreateRouteMetadataOptions
 ): ResourceControllerMetadata['routes'] {
-	const { routes, identity, canonicalBasePaths } = options;
+	const { routes, identity, canonicalBasePaths, resource } = options;
+	const mutationContract = resolveMutationContract(resource);
 
 	return routes.map<ResourceControllerRouteMetadata>((route) => {
 		const kind =
 			determineRouteKind(route, identity.param, canonicalBasePaths) ??
 			'custom';
 
-		return {
+		const metadata: ResourceControllerRouteMetadata = {
 			method: route.method,
 			path: route.path,
 			kind,
 		};
+
+		if (!mutationContract) {
+			return metadata;
+		}
+
+		const mutationKind = mapToMutationKind(kind);
+		if (!mutationKind) {
+			return metadata;
+		}
+
+		const cacheSegments = resolveMutationCacheSegments(resource, kind);
+		const tags = createMutationTags(mutationContract, mutationKind);
+
+		return {
+			...metadata,
+			cacheSegments,
+			tags,
+		};
 	});
+}
+
+function resolveMutationContract(
+	resource: IRResource
+): ResourceMutationContract | undefined {
+	if (resource.storage?.mode === 'wp-post') {
+		return WP_POST_MUTATION_CONTRACT;
+	}
+
+	return undefined;
+}
+
+type MutationContract = typeof WP_POST_MUTATION_CONTRACT;
+type MutationKind = MutationContract['mutationKinds'][number];
+
+function mapToMutationKind(kind: RouteMetadataKind): MutationKind | undefined {
+	switch (kind) {
+		case 'create':
+			return 'create';
+		case 'update':
+			return 'update';
+		case 'remove':
+			return 'delete';
+		default:
+			return undefined;
+	}
+}
+
+function resolveMutationCacheSegments(
+	resource: IRResource,
+	kind: RouteMetadataKind
+): readonly unknown[] {
+	switch (kind) {
+		case 'create':
+			return resource.cacheKeys.create?.segments ?? [];
+		case 'update':
+			return resource.cacheKeys.update?.segments ?? [];
+		case 'remove':
+			return resource.cacheKeys.remove?.segments ?? [];
+		default:
+			return [];
+	}
+}
+
+function createMutationTags(
+	contract: MutationContract,
+	kind: MutationKind
+): Readonly<Record<string, string>> {
+	return {
+		[contract.metadataKeys.channelTag]: kind,
+	} as const;
 }

--- a/packages/cli/src/next/builders/php/printers/resourceController/routes/__tests__/handleRouteKind.test.ts
+++ b/packages/cli/src/next/builders/php/printers/resourceController/routes/__tests__/handleRouteKind.test.ts
@@ -1,0 +1,104 @@
+import { PHP_INDENT, PhpMethodBodyBuilder } from '../../../../ast/templates';
+import type { ResourceMetadataHost } from '../../../../ast/factories/cacheMetadata';
+import type { IRResource } from '../../../../../../../ir/types';
+import { handleRouteKind } from '../handleRouteKind';
+
+function createMetadataHost(): ResourceMetadataHost {
+	return {
+		getMetadata: () => ({
+			kind: 'resource-controller',
+			name: 'book',
+			identity: { type: 'number', param: 'id' },
+			routes: [],
+		}),
+		setMetadata: jest.fn(),
+	};
+}
+
+function createResource(storage: IRResource['storage']): IRResource {
+	return {
+		name: 'book',
+		schemaKey: 'book',
+		schemaProvenance: 'manual',
+		routes: [],
+		cacheKeys: {
+			list: { segments: [], source: 'default' },
+			get: { segments: [], source: 'default' },
+			create: { segments: [], source: 'default' },
+			update: { segments: [], source: 'default' },
+			remove: { segments: [], source: 'default' },
+		},
+		identity: { type: 'number', param: 'id' },
+		storage,
+		queryParams: undefined,
+		ui: undefined,
+		hash: 'resource-hash',
+		warnings: [],
+	};
+}
+
+describe('handleRouteKind', () => {
+	it('delegates to mutation builders for wp-post resources', () => {
+		const options = {
+			body: new PhpMethodBodyBuilder(PHP_INDENT, 1),
+			indentLevel: 1,
+			resource: createResource({
+				mode: 'wp-post',
+				postType: 'book',
+				statuses: [],
+				supports: [],
+				meta: {},
+				taxonomies: {},
+			} as IRResource['storage']),
+			identity: { type: 'number', param: 'id' } as const,
+			pascalName: 'Book',
+			errorCodeFactory: (suffix: string) => `book_${suffix}`,
+			metadataHost: createMetadataHost(),
+			cacheSegments: [],
+		} as const;
+
+		expect(handleRouteKind({ ...options, routeKind: 'create' })).toBe(true);
+		expect(handleRouteKind({ ...options, routeKind: 'update' })).toBe(true);
+		expect(handleRouteKind({ ...options, routeKind: 'remove' })).toBe(true);
+	});
+
+	it('returns false for mutation kinds when storage is unsupported', () => {
+		const options = {
+			body: new PhpMethodBodyBuilder(PHP_INDENT, 1),
+			indentLevel: 1,
+			resource: createResource(undefined),
+			identity: { type: 'number', param: 'id' } as const,
+			pascalName: 'Book',
+			errorCodeFactory: (suffix: string) => `book_${suffix}`,
+			metadataHost: createMetadataHost(),
+			cacheSegments: [],
+		} as const;
+
+		expect(handleRouteKind({ ...options, routeKind: 'create' })).toBe(
+			false
+		);
+		expect(handleRouteKind({ ...options, routeKind: 'update' })).toBe(
+			false
+		);
+		expect(handleRouteKind({ ...options, routeKind: 'remove' })).toBe(
+			false
+		);
+	});
+
+	it('returns false for unsupported kinds', () => {
+		const options = {
+			body: new PhpMethodBodyBuilder(PHP_INDENT, 1),
+			indentLevel: 1,
+			resource: createResource(undefined),
+			identity: { type: 'number', param: 'id' } as const,
+			pascalName: 'Book',
+			errorCodeFactory: (suffix: string) => `book_${suffix}`,
+			metadataHost: createMetadataHost(),
+			cacheSegments: [],
+		} as const;
+
+		expect(handleRouteKind({ ...options, routeKind: 'custom' })).toBe(
+			false
+		);
+	});
+});

--- a/packages/cli/src/next/builders/php/printers/resourceController/routes/handleRouteKind.ts
+++ b/packages/cli/src/next/builders/php/printers/resourceController/routes/handleRouteKind.ts
@@ -3,6 +3,17 @@ import type { ResolvedIdentity } from '../../identity';
 import type { RouteMetadataKind } from '../metadata';
 import type { ResourceMetadataHost } from '../../../ast/factories/cacheMetadata';
 import type { IRResource } from '../../../../../../ir/types';
+import {
+	buildCreateRouteBody,
+	buildUpdateRouteBody,
+	buildDeleteRouteBody as buildRemoveRouteBody,
+	WP_POST_MUTATION_CONTRACT,
+} from '../../resource/wpPost/mutations';
+import type {
+	BuildCreateRouteBodyOptions,
+	BuildUpdateRouteBodyOptions,
+	BuildDeleteRouteBodyOptions as BuildRemoveRouteBodyOptions,
+} from '../../resource/wpPost/mutations/routes';
 import type { BuildGetRouteBodyOptions } from './get';
 import { buildGetRouteBody } from './get';
 import type { BuildListRouteBodyOptions } from './list';
@@ -27,6 +38,15 @@ export function handleRouteKind(options: HandleRouteKindOptions): boolean {
 		}
 		case 'get': {
 			return buildGetRouteBody(createGetOptions(options));
+		}
+		case 'create': {
+			return buildCreateRouteBody(createCreateOptions(options));
+		}
+		case 'update': {
+			return buildUpdateRouteBody(createUpdateOptions(options));
+		}
+		case 'remove': {
+			return buildRemoveRouteBody(createRemoveOptions(options));
 		}
 		default:
 			return false;
@@ -58,5 +78,43 @@ function createGetOptions(
 		errorCodeFactory: options.errorCodeFactory,
 		metadataHost: options.metadataHost,
 		cacheSegments: options.cacheSegments,
+	};
+}
+
+function createCreateOptions(
+	options: HandleRouteKindOptions
+): BuildCreateRouteBodyOptions {
+	return {
+		body: options.body,
+		indentLevel: options.indentLevel,
+		resource: options.resource,
+		pascalName: options.pascalName,
+		metadataKeys: WP_POST_MUTATION_CONTRACT.metadataKeys,
+	};
+}
+
+function createUpdateOptions(
+	options: HandleRouteKindOptions
+): BuildUpdateRouteBodyOptions {
+	return {
+		body: options.body,
+		indentLevel: options.indentLevel,
+		resource: options.resource,
+		pascalName: options.pascalName,
+		metadataKeys: WP_POST_MUTATION_CONTRACT.metadataKeys,
+		identity: options.identity,
+	};
+}
+
+function createRemoveOptions(
+	options: HandleRouteKindOptions
+): BuildRemoveRouteBodyOptions {
+	return {
+		body: options.body,
+		indentLevel: options.indentLevel,
+		resource: options.resource,
+		pascalName: options.pascalName,
+		metadataKeys: WP_POST_MUTATION_CONTRACT.metadataKeys,
+		identity: options.identity,
 	};
 }


### PR DESCRIPTION
## Summary
- add cache segment and tag support to resource controller route metadata and populate them from the wp-post mutation contract
- emit mutation channel tags in generated controller docblocks and reuse stored cache segments when delegating route builds
- delegate create, update, and remove kinds through the wp-post mutation builders and cover the new paths with unit tests

## Testing
- pnpm --filter @wpkernel/cli test
- pnpm --filter @wpkernel/cli test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68f6f107f6148325a21bf9c602b40750