### PR TITLE
Ensure CLI packages install PHP driver

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -89,7 +89,6 @@
 	"peerDependencies": {
 		"@prettier/plugin-php": ">=0.24.0",
 		"@wpkernel/core": "workspace:*",
-		"@wpkernel/php-driver": "workspace:*",
 		"@wpkernel/php-json-ast": "workspace:*",
 		"@wpkernel/test-utils": "workspace:*",
 		"json-schema-to-typescript": ">=15.0.4",
@@ -98,6 +97,7 @@
 		"typescript": ">=5.0.0"
 	},
 	"dependencies": {
+		"@wpkernel/php-driver": "workspace:*",
 		"chokidar": "^4.0.3",
 		"clipanion": "4.0.0-rc.4",
 		"cosmiconfig": "^9.0.0",

--- a/packages/cli/src/next/builders/__tests__/phpBridge.test.ts
+++ b/packages/cli/src/next/builders/__tests__/phpBridge.test.ts
@@ -1,6 +1,11 @@
+import fs from 'node:fs';
 import { EventEmitter } from 'node:events';
 import path from 'node:path';
 import type { Workspace } from '../../workspace/types';
+import {
+	createPhpPrettyPrinter,
+	resolvePrettyPrintScriptPath,
+} from '../php/bridge';
 
 const spawnMock = jest.fn();
 
@@ -60,7 +65,6 @@ describe('createPhpPrettyPrinter', () => {
 
 	beforeEach(() => {
 		spawnMock.mockReset();
-		jest.resetModules();
 		delete process.env.PHP_MEMORY_LIMIT;
 	});
 
@@ -90,7 +94,6 @@ describe('createPhpPrettyPrinter', () => {
 			})
 		);
 
-		const { createPhpPrettyPrinter } = await import('../php/bridge');
 		const prettyPrinter = createPhpPrettyPrinter({ workspace });
 		process.env.PHP_MEMORY_LIMIT = '768M';
 
@@ -127,6 +130,27 @@ describe('createPhpPrettyPrinter', () => {
 		);
 	});
 
+	it('resolves the PHP bridge script relative to the package root', async () => {
+		const scriptPath = resolvePrettyPrintScriptPath();
+		const packagesRoot = path.resolve(
+			__dirname,
+			'..',
+			'..',
+			'..',
+			'..',
+			'..'
+		);
+		const expectedPath = path.join(
+			packagesRoot,
+			'php-driver',
+			'php',
+			'pretty-print.php'
+		);
+
+		expect(scriptPath).toBe(expectedPath);
+		expect(fs.existsSync(scriptPath)).toBe(true);
+	});
+
 	it('raises a DeveloperError error when PHP binary or bridge is not available', async () => {
 		spawnMock.mockImplementation(() =>
 			createMockChildProcess({
@@ -142,7 +166,6 @@ describe('createPhpPrettyPrinter', () => {
 			})
 		);
 
-		const { createPhpPrettyPrinter } = await import('../php/bridge');
 		const prettyPrinter = createPhpPrettyPrinter({ workspace });
 
 		await expect(
@@ -159,7 +182,6 @@ describe('createPhpPrettyPrinter', () => {
 	});
 
 	it('validates the AST payload shape', async () => {
-		const { createPhpPrettyPrinter } = await import('../php/bridge');
 		const prettyPrinter = createPhpPrettyPrinter({ workspace });
 
 		await expect(
@@ -228,7 +250,6 @@ describe('createPhpPrettyPrinter', () => {
 			})
 		);
 
-		const { createPhpPrettyPrinter } = await import('../php/bridge');
 		const prettyPrinter = createPhpPrettyPrinter({ workspace });
 
 		await prettyPrinter.prettyPrint({
@@ -271,7 +292,6 @@ describe('createPhpPrettyPrinter', () => {
 			})
 		);
 
-		const { createPhpPrettyPrinter } = await import('../php/bridge');
 		const prettyPrinter = createPhpPrettyPrinter({ workspace });
 
 		await expect(
@@ -309,7 +329,6 @@ describe('createPhpPrettyPrinter', () => {
 			})
 		);
 
-		const { createPhpPrettyPrinter } = await import('../php/bridge');
 		const prettyPrinter = createPhpPrettyPrinter({ workspace });
 
 		await expect(
@@ -337,7 +356,6 @@ describe('createPhpPrettyPrinter', () => {
 			})
 		);
 
-		const { createPhpPrettyPrinter } = await import('../php/bridge');
 		const prettyPrinter = createPhpPrettyPrinter({ workspace });
 
 		await expect(
@@ -375,7 +393,6 @@ describe('createPhpPrettyPrinter', () => {
 			})
 		);
 
-		const { createPhpPrettyPrinter } = await import('../php/bridge');
 		const prettyPrinter = createPhpPrettyPrinter({ workspace });
 
 		await expect(
@@ -402,7 +419,6 @@ describe('createPhpPrettyPrinter', () => {
 			})
 		);
 
-		const { createPhpPrettyPrinter } = await import('../php/bridge');
 		const prettyPrinter = createPhpPrettyPrinter({ workspace });
 
 		await expect(
@@ -431,7 +447,6 @@ describe('createPhpPrettyPrinter', () => {
 			})
 		);
 
-		const { createPhpPrettyPrinter } = await import('../php/bridge');
 		const prettyPrinter = createPhpPrettyPrinter({ workspace });
 
 		await expect(

--- a/packages/php-driver/src/__tests__/createPhpPrettyPrinter.test.ts
+++ b/packages/php-driver/src/__tests__/createPhpPrettyPrinter.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import type { WorkspaceLike } from '../workspace';
 import {
@@ -66,7 +68,6 @@ describe('createPhpPrettyPrinter', () => {
 
 	beforeEach(() => {
 		spawnMock.mockReset();
-		jest.resetModules();
 		delete process.env.PHP_MEMORY_LIMIT;
 	});
 
@@ -80,7 +81,11 @@ describe('createPhpPrettyPrinter', () => {
 
 	it('resolves the default pretty print script path', () => {
 		const scriptPath = resolvePrettyPrintScriptPath();
-		expect(scriptPath.endsWith('php/pretty-print.php')).toBe(true);
+		const packageRoot = path.resolve(__dirname, '..', '..');
+		const expectedPath = path.join(packageRoot, 'php', 'pretty-print.php');
+
+		expect(scriptPath).toBe(expectedPath);
+		expect(fs.existsSync(scriptPath)).toBe(true);
 	});
 
 	it('invokes the PHP bridge and returns formatted code and AST payloads', async () => {

--- a/packages/php-driver/src/prettyPrinter/createPhpPrettyPrinter.ts
+++ b/packages/php-driver/src/prettyPrinter/createPhpPrettyPrinter.ts
@@ -33,16 +33,32 @@ interface CreatePhpPrettyPrinterOptions {
 }
 
 export function resolvePrettyPrintScriptPath(): string {
-	if (typeof __dirname === 'string') {
-		return path.resolve(__dirname, '../php/pretty-print.php');
-	}
+	const packageRoot =
+		resolvePackageRootFromDirname() ?? resolvePackageRootFromModuleUrl();
 
-	const moduleUrl = getImportMetaUrl();
-	if (moduleUrl) {
-		return fileURLToPath(new URL('../php/pretty-print.php', moduleUrl));
+	if (packageRoot) {
+		return path.resolve(packageRoot, 'php', 'pretty-print.php');
 	}
 
 	return path.resolve(process.cwd(), 'php', 'pretty-print.php');
+}
+
+function resolvePackageRootFromDirname(): string | null {
+	if (typeof __dirname !== 'string') {
+		return null;
+	}
+
+	return path.resolve(__dirname, '..', '..');
+}
+
+function resolvePackageRootFromModuleUrl(): string | null {
+	const moduleUrl = getImportMetaUrl();
+	if (!moduleUrl) {
+		return null;
+	}
+
+	const modulePath = fileURLToPath(moduleUrl);
+	return path.resolve(path.dirname(modulePath), '..', '..');
 }
 
 function getImportMetaUrl(): string | null {

--- a/packages/php-json-ast/package.json
+++ b/packages/php-json-ast/package.json
@@ -96,8 +96,9 @@
 	},
 	"peerDependencies": {
 		"@wpkernel/core": "workspace:*",
-		"@wpkernel/test-utils": "workspace:*",
-		"@wpkernel/php-driver": "workspace:*"
+		"@wpkernel/test-utils": "workspace:*"
 	},
-	"dependencies": {}
+	"dependencies": {
+		"@wpkernel/php-driver": "workspace:*"
+	}
 }


### PR DESCRIPTION
## Summary
- add @wpkernel/php-driver as a runtime dependency for the CLI package so installations include the PHP bridge
- ensure @wpkernel/php-json-ast also installs @wpkernel/php-driver since it uses the bridge at runtime

## Testing
- pnpm test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68f98f351cb883259eb153c25ba132db