### PR TITLE
Update PHP AST builders to use build-prefixed helpers

### DIFF
--- a/packages/cli/src/next/builders/php/__tests__/wpPostMutations.macros.test.ts
+++ b/packages/cli/src/next/builders/php/__tests__/wpPostMutations.macros.test.ts
@@ -11,8 +11,8 @@ import {
 	resetPhpAstChannel,
 } from '@wpkernel/php-json-ast';
 import {
-	createClassTemplate,
-	createMethodTemplate,
+	assembleClassTemplate,
+	assembleMethodTemplate,
 	PHP_INDENT,
 	type PhpMethodBodyBuilder,
 } from '@wpkernel/php-json-ast';
@@ -142,7 +142,7 @@ async function queueMacroProgram(
 			tags,
 		},
 		async build(builder) {
-			const method = createMethodTemplate({
+			const method = assembleMethodTemplate({
 				signature:
 					'public function invoke( WP_REST_Request $request ): void',
 				indentLevel: 1,
@@ -151,7 +151,7 @@ async function queueMacroProgram(
 					build(body);
 				},
 			});
-			const classTemplate = createClassTemplate({
+			const classTemplate = assembleClassTemplate({
 				name: 'MacroHarness',
 				methods: [method],
 			});

--- a/packages/cli/src/next/builders/php/__tests__/wpPostMutations.routes.test.ts
+++ b/packages/cli/src/next/builders/php/__tests__/wpPostMutations.routes.test.ts
@@ -11,8 +11,8 @@ import {
 	resetPhpAstChannel,
 } from '@wpkernel/php-json-ast';
 import {
-	createClassTemplate,
-	createMethodTemplate,
+	assembleClassTemplate,
+	assembleMethodTemplate,
 	PHP_INDENT,
 	type PhpMethodBodyBuilder,
 } from '@wpkernel/php-json-ast';
@@ -148,13 +148,13 @@ async function queueRouteProgram(
 			tags: metadata,
 		},
 		async build(builder) {
-			const method = createMethodTemplate({
+			const method = assembleMethodTemplate({
 				signature: 'public function handle( WP_REST_Request $request )',
 				indentLevel: 1,
 				indentUnit: PHP_INDENT,
 				body: buildMethod,
 			});
-			const classTemplate = createClassTemplate({
+			const classTemplate = assembleClassTemplate({
 				name: 'MutationHarness',
 				methods: [method],
 			});
@@ -212,7 +212,7 @@ async function queueHelperPrograms(): Promise<{
 					pascalName: PASCALE_NAME,
 					identity: IDENTITY,
 				});
-				const classTemplate = createClassTemplate({
+				const classTemplate = assembleClassTemplate({
 					name: 'MutationHelpers',
 					methods: [method],
 				});

--- a/packages/cli/src/next/builders/php/__tests__/writer.test.ts
+++ b/packages/cli/src/next/builders/php/__tests__/writer.test.ts
@@ -7,7 +7,7 @@ import type {
 } from '../../../runtime/types';
 import { createPhpProgramWriterHelper } from '../writer';
 import { getPhpBuilderChannel, resetPhpBuilderChannel } from '../channel';
-import { resetPhpAstChannel, createStmtNop } from '@wpkernel/php-json-ast';
+import { resetPhpAstChannel, buildStmtNop } from '@wpkernel/php-json-ast';
 import { buildPhpPrettyPrinter } from '@wpkernel/php-driver';
 
 jest.mock('@wpkernel/php-driver', () => ({
@@ -85,7 +85,7 @@ describe('createPhpProgramWriterHelper', () => {
 		resetPhpAstChannel(context);
 
 		const channel = getPhpBuilderChannel(context);
-		const program = [createStmtNop(), createStmtNop()];
+		const program = [buildStmtNop(), buildStmtNop()];
 		channel.queue({
 			file: '/workspace/.generated/php/Writer.php',
 			metadata: { kind: 'policy-helper' },

--- a/packages/cli/src/next/builders/php/baseController.ts
+++ b/packages/cli/src/next/builders/php/baseController.ts
@@ -10,9 +10,9 @@ import type {
 import {
 	appendClassTemplate,
 	appendGeneratedFileDocblock,
-	createClassTemplate,
-	createIdentifier,
-	createMethodTemplate,
+	assembleClassTemplate,
+	buildIdentifier,
+	assembleMethodTemplate,
 	createPhpFileBuilder,
 	escapeSingleQuotes,
 	PHP_CLASS_MODIFIER_ABSTRACT,
@@ -53,7 +53,7 @@ export function createPhpBaseControllerHelper(): BuilderHelper {
 						`Source: ${ir.meta.origin} → resources (namespace: ${ir.meta.sanitizedNamespace})`,
 					]);
 
-					const getNamespaceMethod = createMethodTemplate({
+					const getNamespaceMethod = assembleMethodTemplate({
 						signature: 'public function get_namespace(): string',
 						indentLevel: 1,
 						indentUnit: PHP_INDENT,
@@ -66,11 +66,11 @@ export function createPhpBaseControllerHelper(): BuilderHelper {
 						},
 						ast: {
 							flags: PHP_METHOD_MODIFIER_PUBLIC,
-							returnType: createIdentifier('string'),
+							returnType: buildIdentifier('string'),
 						},
 					});
 
-					const classTemplate = createClassTemplate({
+					const classTemplate = assembleClassTemplate({
 						name: 'BaseController',
 						flags: PHP_CLASS_MODIFIER_ABSTRACT,
 						methods: [getNamespaceMethod],

--- a/packages/cli/src/next/builders/php/indexFile.ts
+++ b/packages/cli/src/next/builders/php/indexFile.ts
@@ -10,7 +10,7 @@ import type {
 import {
 	appendGeneratedFileDocblock,
 	createPhpFileBuilder,
-	createPhpReturn,
+	buildPhpReturnPrintable,
 	toPascalCase,
 	type PhpAstBuilderAdapter,
 } from '@wpkernel/php-json-ast';
@@ -56,7 +56,7 @@ function buildIndexFile(builder: PhpAstBuilderAdapter, ir: IRv1): void {
 	]);
 
 	const entries = createIndexEntries(ir);
-	const printable = createPhpReturn(entries, 1);
+	const printable = buildPhpReturnPrintable(entries, 1);
 	printable.lines.forEach((line) => builder.appendStatement(line));
 	builder.appendProgramStatement(printable.node);
 }

--- a/packages/cli/src/next/builders/php/persistenceRegistry.ts
+++ b/packages/cli/src/next/builders/php/persistenceRegistry.ts
@@ -10,11 +10,11 @@ import type {
 import {
 	appendClassTemplate,
 	appendGeneratedFileDocblock,
-	createClassTemplate,
-	createIdentifier,
-	createMethodTemplate,
+	assembleClassTemplate,
+	buildIdentifier,
+	assembleMethodTemplate,
 	createPhpFileBuilder,
-	createPhpReturn,
+	buildPhpReturnPrintable,
 	PHP_CLASS_MODIFIER_FINAL,
 	PHP_INDENT,
 	PHP_METHOD_MODIFIER_PUBLIC,
@@ -72,22 +72,22 @@ function buildPersistenceRegistry(
 	const payload = buildPersistencePayload(ir.resources);
 
 	const methods = [
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: 'public static function get_config(): array',
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
 			body: (body) => {
-				const printable = createPhpReturn(payload, 2);
+				const printable = buildPhpReturnPrintable(payload, 2);
 				body.statement(printable);
 			},
 			ast: {
 				flags: PHP_METHOD_MODIFIER_PUBLIC + PHP_METHOD_MODIFIER_STATIC,
-				returnType: createIdentifier('array'),
+				returnType: buildIdentifier('array'),
 			},
 		}),
 	];
 
-	const classTemplate = createClassTemplate({
+	const classTemplate = assembleClassTemplate({
 		name: 'PersistenceRegistry',
 		flags: PHP_CLASS_MODIFIER_FINAL,
 		methods,

--- a/packages/cli/src/next/builders/php/policy.ts
+++ b/packages/cli/src/next/builders/php/policy.ts
@@ -10,19 +10,19 @@ import type {
 import {
 	appendClassTemplate,
 	appendGeneratedFileDocblock,
-	createArg,
-	createClassTemplate,
-	createComment,
-	createIdentifier,
-	createMethodTemplate,
-	createName,
-	createNode,
+	buildArg,
+	assembleClassTemplate,
+	buildComment,
+	buildIdentifier,
+	assembleMethodTemplate,
+	buildName,
+	buildNode,
 	createPhpFileBuilder,
-	createPhpReturn,
-	createPrintable,
-	createReturn,
-	createScalarString,
-	createStmtNop,
+	buildPhpReturnPrintable,
+	buildPrintable,
+	buildReturn,
+	buildScalarString,
+	buildStmtNop,
 	PHP_CLASS_MODIFIER_FINAL,
 	PHP_INDENT,
 	PHP_METHOD_MODIFIER_PUBLIC,
@@ -83,33 +83,33 @@ function buildPolicyHelper(builder: PhpAstBuilderAdapter, ir: IRv1): void {
 	const fallback = sanitizeJson(ir.policyMap.fallback);
 
 	const methods = [
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: 'public static function policy_map(): array',
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
 			body: (body) => {
-				const printable = createPhpReturn(policyMap, 2);
+				const printable = buildPhpReturnPrintable(policyMap, 2);
 				body.statement(printable);
 			},
 			ast: {
 				flags: PHP_METHOD_MODIFIER_PUBLIC + PHP_METHOD_MODIFIER_STATIC,
-				returnType: createIdentifier('array'),
+				returnType: buildIdentifier('array'),
 			},
 		}),
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: 'public static function fallback(): array',
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
 			body: (body) => {
-				const printable = createPhpReturn(fallback, 2);
+				const printable = buildPhpReturnPrintable(fallback, 2);
 				body.statement(printable);
 			},
 			ast: {
 				flags: PHP_METHOD_MODIFIER_PUBLIC + PHP_METHOD_MODIFIER_STATIC,
-				returnType: createIdentifier('array'),
+				returnType: buildIdentifier('array'),
 			},
 		}),
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature:
 				'public static function callback( string $policy_key ): callable',
 			indentLevel: 1,
@@ -119,15 +119,15 @@ function buildPolicyHelper(builder: PhpAstBuilderAdapter, ir: IRv1): void {
 				'@todo Return a closure once enforcement is implemented.',
 			],
 			body: (body) => {
-				const printable = createPhpReturn('Policy::enforce', 2);
+				const printable = buildPhpReturnPrintable('Policy::enforce', 2);
 				body.statement(printable);
 			},
 			ast: {
 				flags: PHP_METHOD_MODIFIER_PUBLIC + PHP_METHOD_MODIFIER_STATIC,
-				returnType: createIdentifier('callable'),
+				returnType: buildIdentifier('callable'),
 			},
 		}),
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature:
 				'public static function enforce( string $policy_key, WP_REST_Request $request )',
 			indentLevel: 1,
@@ -137,32 +137,32 @@ function buildPolicyHelper(builder: PhpAstBuilderAdapter, ir: IRv1): void {
 				'@todo Wire kernel policy enforcement.',
 			],
 			body: (body) => {
-				const todo = createStmtNop({
+				const todo = buildStmtNop({
 					comments: [
-						createComment(
+						buildComment(
 							'// TODO: Implement policy enforcement logic.'
 						),
 					],
 				});
 				body.statement(
-					createPrintable(todo, [
+					buildPrintable(todo, [
 						`${PHP_INDENT.repeat(2)}// TODO: Implement policy enforcement logic.`,
 					])
 				);
 
-				const errorExpr = createNode<PhpExprNew>('Expr_New', {
-					class: createName(['WP_Error']),
+				const errorExpr = buildNode<PhpExprNew>('Expr_New', {
+					class: buildName(['WP_Error']),
 					args: [
-						createArg(createScalarString('wpk_policy_stub')),
-						createArg(
-							createScalarString(
+						buildArg(buildScalarString('wpk_policy_stub')),
+						buildArg(
+							buildScalarString(
 								'Policy enforcement is not yet implemented.'
 							)
 						),
 					],
 				});
 				body.statement(
-					createPrintable(createReturn(errorExpr), [
+					buildPrintable(buildReturn(errorExpr), [
 						`${PHP_INDENT.repeat(2)}return new WP_Error( 'wpk_policy_stub', 'Policy enforcement is not yet implemented.' );`,
 					])
 				);
@@ -174,7 +174,7 @@ function buildPolicyHelper(builder: PhpAstBuilderAdapter, ir: IRv1): void {
 		}),
 	];
 
-	const classTemplate = createClassTemplate({
+	const classTemplate = assembleClassTemplate({
 		name: 'Policy',
 		flags: PHP_CLASS_MODIFIER_FINAL,
 		methods,

--- a/packages/cli/src/next/builders/php/resource/__tests__/phpValue.test.ts
+++ b/packages/cli/src/next/builders/php/resource/__tests__/phpValue.test.ts
@@ -1,4 +1,4 @@
-import { createPrintable, createScalarInt } from '@wpkernel/php-json-ast';
+import { buildPrintable, buildScalarInt } from '@wpkernel/php-json-ast';
 import { expression, renderPhpValue, variable } from '../phpValue';
 
 describe('phpValue', () => {
@@ -9,7 +9,7 @@ describe('phpValue', () => {
 	});
 
 	it('renders expression descriptors with indentation', () => {
-		const printable = createPrintable(createScalarInt(5), ['5']);
+		const printable = buildPrintable(buildScalarInt(5), ['5']);
 		const rendered = renderPhpValue(expression(printable), 2);
 		expect(rendered.lines).toEqual(['                5']);
 	});

--- a/packages/cli/src/next/builders/php/resource/__tests__/utils.test.ts
+++ b/packages/cli/src/next/builders/php/resource/__tests__/utils.test.ts
@@ -5,7 +5,7 @@ import {
 	indentLines,
 	normaliseVariableReference,
 } from '../utils';
-import { createVariable, createScalarInt } from '@wpkernel/php-json-ast';
+import { buildVariable, buildScalarInt } from '@wpkernel/php-json-ast';
 
 describe('resource utils', () => {
 	describe('normaliseVariableReference', () => {
@@ -31,15 +31,15 @@ describe('resource utils', () => {
 	});
 
 	it('creates scalar casts', () => {
-		const cast = buildScalarCast('int', createVariable('value'));
+		const cast = buildScalarCast('int', buildVariable('value'));
 		expect(cast).toMatchObject({ nodeType: 'Expr_Cast_Int' });
 	});
 
 	it('creates binary operations', () => {
 		const operation = buildBinaryOperation(
 			'Greater',
-			createVariable('left'),
-			createScalarInt(10)
+			buildVariable('left'),
+			buildScalarInt(10)
 		);
 		expect(operation).toMatchObject({
 			nodeType: 'Expr_BinaryOp_Greater',

--- a/packages/cli/src/next/builders/php/resource/errors.ts
+++ b/packages/cli/src/next/builders/php/resource/errors.ts
@@ -1,15 +1,15 @@
 import {
-	createArg,
-	createArray,
-	createArrayItem,
-	createName,
-	createNode,
-	createReturn,
-	createScalarInt,
-	createScalarString,
+	buildArg,
+	buildArray,
+	buildArrayItem,
+	buildName,
+	buildNode,
+	buildReturn,
+	buildScalarInt,
+	buildScalarString,
 	type PhpExprNew,
 	type PhpStmtReturn,
-	createPrintable,
+	buildPrintable,
 	type PhpPrintable,
 } from '@wpkernel/php-json-ast';
 import { PHP_INDENT, escapeSingleQuotes } from '@wpkernel/php-json-ast';
@@ -27,25 +27,25 @@ export function createWpErrorReturn(
 	const { indentLevel, code, message, status = 400 } = options;
 	const indent = PHP_INDENT.repeat(indentLevel);
 
-	const errorExpr = createNode<PhpExprNew>('Expr_New', {
-		class: createName(['WP_Error']),
+	const errorExpr = buildNode<PhpExprNew>('Expr_New', {
+		class: buildName(['WP_Error']),
 		args: [
-			createArg(createScalarString(code)),
-			createArg(createScalarString(message)),
-			createArg(
-				createArray([
-					createArrayItem(createScalarInt(status), {
-						key: createScalarString('status'),
+			buildArg(buildScalarString(code)),
+			buildArg(buildScalarString(message)),
+			buildArg(
+				buildArray([
+					buildArrayItem(buildScalarInt(status), {
+						key: buildScalarString('status'),
 					}),
 				])
 			),
 		],
 	});
 
-	const returnNode = createReturn(errorExpr);
+	const returnNode = buildReturn(errorExpr);
 	const line = `${indent}return new WP_Error( '${escapeSingleQuotes(
 		code
 	)}', '${escapeSingleQuotes(message)}', [ 'status' => ${status} ] );`;
 
-	return createPrintable(returnNode, [line]);
+	return buildPrintable(returnNode, [line]);
 }

--- a/packages/cli/src/next/builders/php/resource/phpValue.ts
+++ b/packages/cli/src/next/builders/php/resource/phpValue.ts
@@ -1,10 +1,13 @@
 import {
-	createVariable,
+	buildVariable,
 	type PhpExpr,
-	createPrintable,
+	buildPrintable,
 	type PhpPrintable,
 } from '@wpkernel/php-json-ast';
-import { PHP_INDENT, createPhpExpression } from '@wpkernel/php-json-ast';
+import {
+	PHP_INDENT,
+	buildPhpExpressionPrintable,
+} from '@wpkernel/php-json-ast';
 import { indentLines, normaliseVariableReference } from './utils';
 
 type PhpPrintableExpr = PhpPrintable<PhpExpr>;
@@ -55,7 +58,7 @@ export function renderPhpValue(
 		return renderExpression(value, indentLevel, indentUnit);
 	}
 
-	return createPhpExpression(value, indentLevel);
+	return buildPhpExpressionPrintable(value, indentLevel);
 }
 
 function isVariableDescriptor(
@@ -87,7 +90,7 @@ function renderVariable(
 ): PhpPrintableExpr {
 	const reference = normaliseVariableReference(descriptor.name);
 	const indent = indentUnit.repeat(indentLevel);
-	return createPrintable(createVariable(reference.raw), [
+	return buildPrintable(buildVariable(reference.raw), [
 		`${indent}${reference.display}`,
 	]);
 }
@@ -99,5 +102,5 @@ function renderExpression(
 ): PhpPrintableExpr {
 	const indent = indentUnit.repeat(indentLevel);
 	const lines = indentLines(descriptor.printable.lines, indent);
-	return createPrintable(descriptor.printable.node, lines);
+	return buildPrintable(descriptor.printable.node, lines);
 }

--- a/packages/cli/src/next/builders/php/resource/query.ts
+++ b/packages/cli/src/next/builders/php/resource/query.ts
@@ -1,21 +1,21 @@
 import {
-	createArg,
-	createAssign,
-	createArray,
-	createArrayItem,
-	createExpressionStatement,
-	createFuncCall,
-	createIdentifier,
-	createMethodCall,
-	createName,
-	createNode,
-	createScalarInt,
-	createScalarString,
-	createVariable,
+	buildArg,
+	buildAssign,
+	buildArray,
+	buildArrayItem,
+	buildExpressionStatement,
+	buildFuncCall,
+	buildIdentifier,
+	buildMethodCall,
+	buildName,
+	buildNode,
+	buildScalarInt,
+	buildScalarString,
+	buildVariable,
 	type PhpExprBinaryOp,
 	type PhpStmtExpression,
 	type PhpStmtIf,
-	createPrintable,
+	buildPrintable,
 	type PhpPrintable,
 	type ResourceControllerCacheOperation,
 	type ResourceControllerCacheScope,
@@ -23,7 +23,7 @@ import {
 } from '@wpkernel/php-json-ast';
 import {
 	PHP_INDENT,
-	createWpQueryInstantiation,
+	buildWpQueryInstantiation,
 	escapeSingleQuotes,
 } from '@wpkernel/php-json-ast';
 import { appendResourceCacheEvent } from './cache';
@@ -64,7 +64,7 @@ export function createQueryArgsAssignment(
 	const indent = indentUnit.repeat(indentLevel);
 	const childIndent = indentUnit.repeat(indentLevel + 1);
 
-	const items: ReturnType<typeof createArrayItem>[] = [];
+	const items: ReturnType<typeof buildArrayItem>[] = [];
 	const lines: string[] = [`${indent}${target.display} = [`];
 
 	for (const entry of entries) {
@@ -81,18 +81,18 @@ export function createQueryArgsAssignment(
 		childLines[lastIndex] = `${childLines[lastIndex]},`;
 		lines.push(...childLines);
 		items.push(
-			createArrayItem(rendered.node, {
-				key: createScalarString(entry.key),
+			buildArrayItem(rendered.node, {
+				key: buildScalarString(entry.key),
 			})
 		);
 	}
 
 	lines.push(`${indent}];`);
 
-	const assign = createAssign(createVariable(target.raw), createArray(items));
-	const statement = createExpressionStatement(assign);
+	const assign = buildAssign(buildVariable(target.raw), buildArray(items));
+	const statement = buildExpressionStatement(assign);
 
-	return createPrintable(statement, lines);
+	return buildPrintable(statement, lines);
 }
 
 export interface PaginationNormalisationOptions {
@@ -180,16 +180,16 @@ function createConditionalAssignment(
 
 	const condition = buildBinaryOperation(
 		operator,
-		createVariable(variable.raw),
-		createScalarInt(comparison)
+		buildVariable(variable.raw),
+		buildScalarInt(comparison)
 	);
 
-	const assign = createAssign(
-		createVariable(variable.raw),
-		createScalarInt(assignment)
+	const assign = buildAssign(
+		buildVariable(variable.raw),
+		buildScalarInt(assignment)
 	);
-	const statement = createExpressionStatement(assign);
-	const ifNode = createNode<PhpStmtIf>('Stmt_If', {
+	const statement = buildExpressionStatement(assign);
+	const ifNode = buildNode<PhpStmtIf>('Stmt_If', {
 		cond: condition as PhpExprBinaryOp,
 		stmts: [statement],
 		elseifs: [],
@@ -203,7 +203,7 @@ function createConditionalAssignment(
 		`${indent}}`,
 	];
 
-	return createPrintable(ifNode, lines);
+	return buildPrintable(ifNode, lines);
 }
 
 export interface PageExpressionOptions {
@@ -218,20 +218,20 @@ export function createPageExpression(
 	const { requestVariable, param = 'page', minimum = 1 } = options;
 	const request = normaliseVariableReference(requestVariable);
 
-	const methodCall = createMethodCall(
-		createVariable(request.raw),
-		createIdentifier('get_param'),
-		[createArg(createScalarString(param))]
+	const methodCall = buildMethodCall(
+		buildVariable(request.raw),
+		buildIdentifier('get_param'),
+		[buildArg(buildScalarString(param))]
 	);
 
 	const cast = buildScalarCast('int', methodCall);
-	const funcCall = createFuncCall(createName(['max']), [
-		createArg(createScalarInt(minimum)),
-		createArg(cast),
+	const funcCall = buildFuncCall(buildName(['max']), [
+		buildArg(buildScalarInt(minimum)),
+		buildArg(cast),
 	]);
 
 	const line = `max( ${minimum}, (int) ${request.display}->get_param( '${param}' ) )`;
-	return expression(createPrintable(funcCall, [line]));
+	return expression(buildPrintable(funcCall, [line]));
 }
 
 export interface ExecuteWpQueryOptions {
@@ -263,7 +263,7 @@ export function createWpQueryExecution(
 		});
 	}
 
-	return createWpQueryInstantiation({
+	return buildWpQueryInstantiation({
 		target,
 		argsVariable,
 		indentLevel,

--- a/packages/cli/src/next/builders/php/resource/request.ts
+++ b/packages/cli/src/next/builders/php/resource/request.ts
@@ -1,15 +1,15 @@
 import { KernelError } from '@wpkernel/core/contracts';
 import {
-	createArg,
-	createAssign,
-	createExpressionStatement,
-	createIdentifier,
-	createMethodCall,
-	createScalarString,
-	createVariable,
+	buildArg,
+	buildAssign,
+	buildExpressionStatement,
+	buildIdentifier,
+	buildMethodCall,
+	buildScalarString,
+	buildVariable,
 	type PhpExpr,
 	type PhpStmtExpression,
-	createPrintable,
+	buildPrintable,
 	type PhpPrintable,
 } from '@wpkernel/php-json-ast';
 import { PHP_INDENT } from '@wpkernel/php-json-ast';
@@ -44,23 +44,23 @@ export function createRequestParamAssignment(
 	const target = normaliseVariableReference(targetVariable);
 	const indent = indentUnit.repeat(indentLevel);
 
-	const methodCall = createMethodCall(
-		createVariable(request.raw),
-		createIdentifier('get_param'),
-		[createArg(createScalarString(param))]
+	const methodCall = buildMethodCall(
+		buildVariable(request.raw),
+		buildIdentifier('get_param'),
+		[buildArg(buildScalarString(param))]
 	);
 
 	const expression: PhpExpr = cast
 		? buildScalarCast(cast, methodCall)
 		: methodCall;
 
-	const assignment = createAssign(createVariable(target.raw), expression);
-	const statement = createExpressionStatement(assignment);
+	const assignment = buildAssign(buildVariable(target.raw), expression);
+	const statement = buildExpressionStatement(assignment);
 
 	const castPrefix = cast ? getCastPrefix(cast) : '';
 	const line = `${indent}${target.display} = ${castPrefix}${request.display}->get_param( '${param}' );`;
 
-	return createPrintable(statement, [line]);
+	return buildPrintable(statement, [line]);
 }
 
 function getCastPrefix(cast: ScalarCastKind): string {

--- a/packages/cli/src/next/builders/php/resource/utils.ts
+++ b/packages/cli/src/next/builders/php/resource/utils.ts
@@ -1,24 +1,24 @@
 import { KernelError } from '@wpkernel/core/contracts';
 import {
-	createArray,
-	createArrayDimFetch,
-	createAssign,
-	createBooleanNot,
-	createIdentifier,
-	createIfStatement,
-	createInstanceof,
-	createName,
-	createNode,
-	createExpressionStatement,
-	createPropertyFetch,
-	createScalarCast,
-	createVariable,
+	buildArray,
+	buildArrayDimFetch as buildArrayDimFetchNode,
+	buildAssign,
+	buildBooleanNot as buildBooleanNotExpr,
+	buildIdentifier,
+	buildIfStatement,
+	buildInstanceof as buildInstanceofExpr,
+	buildName,
+	buildNode,
+	buildExpressionStatement,
+	buildPropertyFetch as buildPropertyFetchNode,
+	buildScalarCast as buildScalarCastNode,
+	buildVariable,
 	type PhpExpr,
 	type PhpExprBinaryOp,
 	type PhpExprBooleanNot,
 	type PhpStmt,
 	type PhpStmtIf,
-	createPrintable,
+	buildPrintable,
 	type PhpPrintable,
 } from '@wpkernel/php-json-ast';
 import { PHP_INDENT } from '@wpkernel/php-json-ast';
@@ -57,7 +57,7 @@ export function normaliseVariableReference(
 export type ScalarCastKind = 'int' | 'float' | 'string' | 'bool';
 
 export function buildScalarCast(kind: ScalarCastKind, expr: PhpExpr): PhpExpr {
-	return createScalarCast(kind, expr);
+	return buildScalarCastNode(kind, expr);
 }
 
 export type BinaryOperator =
@@ -83,7 +83,7 @@ export function buildBinaryOperation(
 	right: PhpExpr
 ): PhpExprBinaryOp {
 	const nodeType = `Expr_BinaryOp_${operator}` as PhpExprBinaryOp['nodeType'];
-	return createNode<PhpExprBinaryOp>(nodeType, { left, right });
+	return buildNode<PhpExprBinaryOp>(nodeType, { left, right });
 }
 
 export function indentLines(
@@ -119,31 +119,31 @@ export function buildIfPrintable(
 
 	lines.push(`${indent}}`);
 
-	const node = createIfStatement(options.condition, stmts);
+	const node = buildIfStatement(options.condition, stmts);
 
-	return createPrintable(node, lines);
+	return buildPrintable(node, lines);
 }
 
 export function buildArrayDimFetch(
 	target: string,
 	dim: PhpExpr | null
 ): PhpExpr {
-	return createArrayDimFetch(createVariable(target), dim);
+	return buildArrayDimFetchNode(buildVariable(target), dim);
 }
 
 export function buildPropertyFetch(target: string, property: string): PhpExpr {
-	return createPropertyFetch(
-		createVariable(target),
-		createIdentifier(property)
+	return buildPropertyFetchNode(
+		buildVariable(target),
+		buildIdentifier(property)
 	);
 }
 
 export function buildInstanceof(subject: string, className: string): PhpExpr {
-	return createInstanceof(createVariable(subject), createName([className]));
+	return buildInstanceofExpr(buildVariable(subject), buildName([className]));
 }
 
 export function buildBooleanNot(expr: PhpExpr): PhpExprBooleanNot {
-	return createBooleanNot(expr);
+	return buildBooleanNotExpr(expr);
 }
 
 export interface ArrayInitialiserOptions {
@@ -157,9 +157,9 @@ export function buildArrayInitialiser(
 	const reference = normaliseVariableReference(options.variable);
 	const indent = PHP_INDENT.repeat(options.indentLevel);
 
-	return createPrintable(
-		createExpressionStatement(
-			createAssign(createVariable(reference.raw), createArray([]))
+	return buildPrintable(
+		buildExpressionStatement(
+			buildAssign(buildVariable(reference.raw), buildArray([]))
 		),
 		[`${indent}${reference.display} = [];`]
 	);

--- a/packages/cli/src/next/builders/php/resource/wpPost/identity.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/identity.ts
@@ -1,15 +1,15 @@
 import {
-	createArg,
-	createAssign,
-	createExpressionStatement,
-	createFuncCall,
-	createName,
-	createNull,
-	createScalarInt,
-	createScalarString,
-	createVariable,
+	buildArg,
+	buildAssign,
+	buildExpressionStatement,
+	buildFuncCall,
+	buildName,
+	buildNull,
+	buildScalarInt,
+	buildScalarString,
+	buildVariable,
 	type PhpStmt,
-	createPrintable,
+	buildPrintable,
 	type PhpPrintable,
 } from '@wpkernel/php-json-ast';
 import { PHP_INDENT } from '@wpkernel/php-json-ast';
@@ -50,8 +50,8 @@ export function createIdentityValidationPrintables(
 				indentLevel,
 				condition: buildBinaryOperation(
 					'Identical',
-					createNull(),
-					createVariable(variable.raw)
+					buildNull(),
+					buildVariable(variable.raw)
 				),
 				conditionText: `${indent}if ( null === ${variable.display} ) {`,
 				statements: [missingReturn],
@@ -59,11 +59,11 @@ export function createIdentityValidationPrintables(
 		);
 
 		statements.push(
-			createPrintable(
-				createExpressionStatement(
-					createAssign(
-						createVariable(variable.raw),
-						buildScalarCast('int', createVariable(variable.raw))
+			buildPrintable(
+				buildExpressionStatement(
+					buildAssign(
+						buildVariable(variable.raw),
+						buildScalarCast('int', buildVariable(variable.raw))
 					)
 				),
 				[`${indent}${variable.display} = (int) ${variable.display};`]
@@ -81,8 +81,8 @@ export function createIdentityValidationPrintables(
 				indentLevel,
 				condition: buildBinaryOperation(
 					'SmallerOrEqual',
-					createVariable(variable.raw),
-					createScalarInt(0)
+					buildVariable(variable.raw),
+					buildScalarInt(0)
 				),
 				conditionText: `${indent}if ( ${variable.display} <= 0 ) {`,
 				statements: [invalidReturn],
@@ -102,15 +102,15 @@ export function createIdentityValidationPrintables(
 	const condition = buildBinaryOperation(
 		'BooleanOr',
 		buildBooleanNot(
-			createFuncCall(createName(['is_string']), [
-				createArg(createVariable(variable.raw)),
+			buildFuncCall(buildName(['is_string']), [
+				buildArg(buildVariable(variable.raw)),
 			])
 		),
 		buildBinaryOperation(
 			'Identical',
-			createScalarString(''),
-			createFuncCall(createName(['trim']), [
-				createArg(createVariable(variable.raw)),
+			buildScalarString(''),
+			buildFuncCall(buildName(['trim']), [
+				buildArg(buildVariable(variable.raw)),
 			])
 		)
 	);
@@ -125,15 +125,15 @@ export function createIdentityValidationPrintables(
 	);
 
 	statements.push(
-		createPrintable(
-			createExpressionStatement(
-				createAssign(
-					createVariable(variable.raw),
-					createFuncCall(createName(['trim']), [
-						createArg(
+		buildPrintable(
+			buildExpressionStatement(
+				buildAssign(
+					buildVariable(variable.raw),
+					buildFuncCall(buildName(['trim']), [
+						buildArg(
 							buildScalarCast(
 								'string',
-								createVariable(variable.raw)
+								buildVariable(variable.raw)
 							)
 						),
 					])

--- a/packages/cli/src/next/builders/php/resource/wpPost/list.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/list.ts
@@ -1,18 +1,18 @@
 import {
-	createArg,
-	createAssign,
-	createExpressionStatement,
-	createFuncCall,
-	createIdentifier,
-	createMethodCall,
-	createName,
-	createNode,
-	createVariable,
+	buildArg,
+	buildAssign,
+	buildExpressionStatement,
+	buildFuncCall,
+	buildIdentifier,
+	buildMethodCall,
+	buildName,
+	buildNode,
+	buildVariable,
 	type PhpStmt,
 	type PhpStmtContinue,
 	type PhpStmtForeach,
 	type PhpStmtIf,
-	createPrintable,
+	buildPrintable,
 	type PhpPrintable,
 } from '@wpkernel/php-json-ast';
 import { PHP_INDENT } from '@wpkernel/php-json-ast';
@@ -49,25 +49,25 @@ export function createListForeachPrintable(
 	const childIndent = PHP_INDENT.repeat(options.indentLevel + 1);
 	const nestedIndent = PHP_INDENT.repeat(options.indentLevel + 2);
 
-	const assignment = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('post'),
-				createFuncCall(createName(['get_post']), [
-					createArg(createVariable('post_id')),
+	const assignment = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('post'),
+				buildFuncCall(buildName(['get_post']), [
+					buildArg(buildVariable('post_id')),
 				])
 			)
 		),
 		[`${childIndent}$post = get_post( $post_id );`]
 	);
 
-	const continuePrintable = createPrintable(
-		createNode<PhpStmtContinue>('Stmt_Continue', { num: null }),
+	const continuePrintable = buildPrintable(
+		buildNode<PhpStmtContinue>('Stmt_Continue', { num: null }),
 		[`${nestedIndent}continue;`]
 	);
 
-	const guard = createPrintable(
-		createNode<PhpStmtIf>('Stmt_If', {
+	const guard = buildPrintable(
+		buildNode<PhpStmtIf>('Stmt_If', {
 			cond: buildBooleanNot(buildInstanceof('post', 'WP_Post')),
 			stmts: [continuePrintable.node],
 			elseifs: [],
@@ -80,16 +80,16 @@ export function createListForeachPrintable(
 		]
 	);
 
-	const pushPrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
+	const pushPrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
 				buildArrayDimFetch('items', null),
-				createMethodCall(
-					createVariable('this'),
-					createIdentifier(`prepare${options.pascalName}Response`),
+				buildMethodCall(
+					buildVariable('this'),
+					buildIdentifier(`prepare${options.pascalName}Response`),
 					[
-						createArg(createVariable('post')),
-						createArg(createVariable('request')),
+						buildArg(buildVariable('post')),
+						buildArg(buildVariable('request')),
 					]
 				)
 			)
@@ -99,9 +99,9 @@ export function createListForeachPrintable(
 		]
 	);
 
-	const foreachNode = createNode<PhpStmtForeach>('Stmt_Foreach', {
+	const foreachNode = buildNode<PhpStmtForeach>('Stmt_Foreach', {
 		expr: buildPropertyFetch('query', 'posts'),
-		valueVar: createVariable('post_id'),
+		valueVar: buildVariable('post_id'),
 		keyVar: null,
 		byRef: false,
 		stmts: [assignment.node, guard.node, pushPrintable.node],
@@ -116,5 +116,5 @@ export function createListForeachPrintable(
 		`${indent}}`,
 	];
 
-	return createPrintable(foreachNode, lines);
+	return buildPrintable(foreachNode, lines);
 }

--- a/packages/cli/src/next/builders/php/resource/wpPost/metaQuery.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/metaQuery.ts
@@ -1,26 +1,26 @@
 import {
-	createArg,
-	createArray,
-	createArrayItem,
-	createArrayCast as createArrayCastNode,
-	createAssign,
-	createArrowFunction,
-	createExpressionStatement,
-	createFuncCall,
-	createIdentifier,
-	createMatch,
-	createMatchArm,
-	createMethodCall,
-	createName,
-	createNull,
-	createParam,
-	createScalarBool,
-	createScalarInt,
-	createScalarString,
-	createVariable,
+	buildArg,
+	buildArray,
+	buildArrayItem,
+	buildArrayCast as buildArrayCastNode,
+	buildAssign,
+	buildArrowFunction,
+	buildExpressionStatement,
+	buildFuncCall,
+	buildIdentifier,
+	buildMatch,
+	buildMatchArm,
+	buildMethodCall,
+	buildName,
+	buildNull,
+	buildParam,
+	buildScalarBool,
+	buildScalarInt,
+	buildScalarString,
+	buildVariable,
 	type PhpExpr,
 	type PhpStmt,
-	createPrintable,
+	buildPrintable,
 	type PhpPrintable,
 	type PhpMethodBodyBuilder,
 } from '@wpkernel/php-json-ast';
@@ -91,14 +91,14 @@ export function appendMetaQueryBuilder(
 
 	for (const [key, descriptor] of options.entries) {
 		const variableName = `${toSnakeCase(key)}Meta`;
-		const requestPrintable = createPrintable(
-			createExpressionStatement(
-				createAssign(
-					createVariable(variableName),
-					createMethodCall(
-						createVariable('request'),
-						createIdentifier('get_param'),
-						[createArg(createScalarString(key))]
+		const requestPrintable = buildPrintable(
+			buildExpressionStatement(
+				buildAssign(
+					buildVariable(variableName),
+					buildMethodCall(
+						buildVariable('request'),
+						buildIdentifier('get_param'),
+						[buildArg(buildScalarString(key))]
 					)
 				)
 			),
@@ -117,19 +117,19 @@ export function appendMetaQueryBuilder(
 				buildIfPrintable({
 					indentLevel: childIndentLevel,
 					condition: buildBooleanNot(
-						createFuncCall(createName(['is_array']), [
-							createArg(createVariable(variableName)),
+						buildFuncCall(buildName(['is_array']), [
+							buildArg(buildVariable(variableName)),
 						])
 					),
 					conditionText: `${childIndent}if ( ! is_array( $${variableName} ) ) {`,
 					statements: [
-						createPrintable(
-							createExpressionStatement(
-								createAssign(
-									createVariable(variableName),
-									createArray([
-										createArrayItem(
-											createVariable(variableName)
+						buildPrintable(
+							buildExpressionStatement(
+								buildAssign(
+									buildVariable(variableName),
+									buildArray([
+										buildArrayItem(
+											buildVariable(variableName)
 										),
 									])
 								)
@@ -142,15 +142,13 @@ export function appendMetaQueryBuilder(
 				})
 			);
 
-			const normalisePrintable = createPrintable(
-				createExpressionStatement(
-					createAssign(
-						createVariable(variableName),
-						createFuncCall(createName(['array_values']), [
-							createArg(
-								createArrayCastNode(
-									createVariable(variableName)
-								)
+			const normalisePrintable = buildPrintable(
+				buildExpressionStatement(
+					buildAssign(
+						buildVariable(variableName),
+						buildFuncCall(buildName(['array_values']), [
+							buildArg(
+								buildArrayCastNode(buildVariable(variableName))
 							),
 						])
 					)
@@ -160,13 +158,13 @@ export function appendMetaQueryBuilder(
 				]
 			);
 
-			const filterPrintable = createPrintable(
-				createExpressionStatement(
-					createAssign(
-						createVariable(variableName),
-						createFuncCall(createName(['array_filter']), [
-							createArg(createVariable(variableName)),
-							createArg(createStaticTrimFilterClosure()),
+			const filterPrintable = buildPrintable(
+				buildExpressionStatement(
+					buildAssign(
+						buildVariable(variableName),
+						buildFuncCall(buildName(['array_filter']), [
+							buildArg(buildVariable(variableName)),
+							buildArg(createStaticTrimFilterClosure()),
 						])
 					)
 				),
@@ -181,19 +179,19 @@ export function appendMetaQueryBuilder(
 			innerStatements.push(normalisePrintable, filterPrintable);
 
 			const nestedIndent = PHP_INDENT.repeat(childIndentLevel + 1);
-			const pushPrintable = createPrintable(
-				createExpressionStatement(
-					createAssign(
+			const pushPrintable = buildPrintable(
+				buildExpressionStatement(
+					buildAssign(
 						buildArrayDimFetch('meta_query', null),
-						createArray([
-							createArrayItem(createScalarString(key), {
-								key: createScalarString('key'),
+						buildArray([
+							buildArrayItem(buildScalarString(key), {
+								key: buildScalarString('key'),
 							}),
-							createArrayItem(createScalarString('IN'), {
-								key: createScalarString('compare'),
+							buildArrayItem(buildScalarString('IN'), {
+								key: buildScalarString('compare'),
 							}),
-							createArrayItem(createVariable(variableName), {
-								key: createScalarString('value'),
+							buildArrayItem(buildVariable(variableName), {
+								key: buildScalarString('value'),
 							}),
 						])
 					)
@@ -212,37 +210,37 @@ export function appendMetaQueryBuilder(
 					indentLevel: childIndentLevel,
 					condition: buildBinaryOperation(
 						'Greater',
-						createFuncCall(createName(['count']), [
-							createArg(createVariable(variableName)),
+						buildFuncCall(buildName(['count']), [
+							buildArg(buildVariable(variableName)),
 						]),
-						createScalarInt(0)
+						buildScalarInt(0)
 					),
 					conditionText: `${childIndent}if ( count( $${variableName} ) > 0 ) {`,
 					statements: [pushPrintable],
 				})
 			);
 		} else {
-			const sanitisePrintable = createPrintable(
-				createExpressionStatement(
-					createAssign(
-						createVariable(variableName),
-						createMatch(
-							createFuncCall(createName(['is_scalar']), [
-								createArg(createVariable(variableName)),
+			const sanitisePrintable = buildPrintable(
+				buildExpressionStatement(
+					buildAssign(
+						buildVariable(variableName),
+						buildMatch(
+							buildFuncCall(buildName(['is_scalar']), [
+								buildArg(buildVariable(variableName)),
 							]),
 							[
-								createMatchArm(
-									[createScalarBool(true)],
-									createFuncCall(createName(['trim']), [
-										createArg(
+								buildMatchArm(
+									[buildScalarBool(true)],
+									buildFuncCall(buildName(['trim']), [
+										buildArg(
 											buildScalarCast(
 												'string',
-												createVariable(variableName)
+												buildVariable(variableName)
 											)
 										),
 									])
 								),
-								createMatchArm(null, createNull()),
+								buildMatchArm(null, buildNull()),
 							]
 						)
 					)
@@ -255,19 +253,19 @@ export function appendMetaQueryBuilder(
 				]
 			);
 
-			const pushPrintable = createPrintable(
-				createExpressionStatement(
-					createAssign(
+			const pushPrintable = buildPrintable(
+				buildExpressionStatement(
+					buildAssign(
 						buildArrayDimFetch('meta_query', null),
-						createArray([
-							createArrayItem(createScalarString(key), {
-								key: createScalarString('key'),
+						buildArray([
+							buildArrayItem(buildScalarString(key), {
+								key: buildScalarString('key'),
 							}),
-							createArrayItem(createScalarString('='), {
-								key: createScalarString('compare'),
+							buildArrayItem(buildScalarString('='), {
+								key: buildScalarString('compare'),
 							}),
-							createArrayItem(createVariable(variableName), {
-								key: createScalarString('value'),
+							buildArrayItem(buildVariable(variableName), {
+								key: buildScalarString('value'),
 							}),
 						])
 					)
@@ -289,13 +287,13 @@ export function appendMetaQueryBuilder(
 						'BooleanAnd',
 						buildBinaryOperation(
 							'NotIdentical',
-							createVariable(variableName),
-							createNull()
+							buildVariable(variableName),
+							buildNull()
 						),
 						buildBinaryOperation(
 							'NotIdentical',
-							createVariable(variableName),
-							createScalarString('')
+							buildVariable(variableName),
+							buildScalarString('')
 						)
 					),
 					conditionText: `${childIndent}if ( null !== $${variableName} && '' !== $${variableName} ) {`,
@@ -309,8 +307,8 @@ export function appendMetaQueryBuilder(
 				indentLevel,
 				condition: buildBinaryOperation(
 					'NotIdentical',
-					createVariable(variableName),
-					createNull()
+					buildVariable(variableName),
+					buildNull()
 				),
 				conditionText: `${indent}if ( null !== $${variableName} ) {`,
 				statements: innerStatements,
@@ -318,14 +316,14 @@ export function appendMetaQueryBuilder(
 		);
 	}
 
-	const assignPrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
+	const assignPrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
 				buildArrayDimFetch(
 					'query_args',
-					createScalarString('meta_query')
+					buildScalarString('meta_query')
 				),
-				createVariable('meta_query')
+				buildVariable('meta_query')
 			)
 		),
 		[`${indent}${PHP_INDENT}$query_args['meta_query'] = $meta_query;`]
@@ -336,10 +334,10 @@ export function appendMetaQueryBuilder(
 			indentLevel,
 			condition: buildBinaryOperation(
 				'Greater',
-				createFuncCall(createName(['count']), [
-					createArg(createVariable('meta_query')),
+				buildFuncCall(buildName(['count']), [
+					buildArg(buildVariable('meta_query')),
 				]),
-				createScalarInt(0)
+				buildScalarInt(0)
 			),
 			conditionText: `${indent}if ( count( $meta_query ) > 0 ) {`,
 			statements: [assignPrintable],
@@ -349,17 +347,17 @@ export function appendMetaQueryBuilder(
 }
 
 function createStaticTrimFilterClosure(): PhpExpr {
-	const parameter = createParam(createVariable('value'));
-	const trimmedValue = createFuncCall(createName(['trim']), [
-		createArg(buildScalarCast('string', createVariable('value'))),
+	const parameter = buildParam(buildVariable('value'));
+	const trimmedValue = buildFuncCall(buildName(['trim']), [
+		buildArg(buildScalarCast('string', buildVariable('value'))),
 	]);
 
-	return createArrowFunction({
+	return buildArrowFunction({
 		static: true,
 		params: [parameter],
-		expr: createMatch(trimmedValue, [
-			createMatchArm([createScalarString('')], createScalarBool(false)),
-			createMatchArm(null, createScalarBool(true)),
+		expr: buildMatch(trimmedValue, [
+			buildMatchArm([buildScalarString('')], buildScalarBool(false)),
+			buildMatchArm(null, buildScalarBool(true)),
 		]),
 	});
 }

--- a/packages/cli/src/next/builders/php/resource/wpPost/mutations/helpers.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/mutations/helpers.ts
@@ -1,15 +1,15 @@
 import { KernelError } from '@wpkernel/core/contracts';
 import {
-	createIdentifier,
-	createName,
-	createParam,
-	createVariable,
+	buildIdentifier,
+	buildName,
+	buildParam,
+	buildVariable,
 	PHP_METHOD_MODIFIER_PRIVATE,
 	escapeSingleQuotes,
 	toSnakeCase,
 } from '@wpkernel/php-json-ast';
 import {
-	createMethodTemplate,
+	assembleMethodTemplate,
 	PHP_INDENT,
 	type PhpMethodBodyBuilder,
 	type PhpMethodTemplate,
@@ -41,7 +41,7 @@ export function syncWpPostMeta(
 		[string, WpPostMetaDescriptor]
 	>;
 
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `private function sync${options.pascalName}Meta( int $post_id, WP_REST_Request $request ): void`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,
@@ -84,14 +84,14 @@ export function syncWpPostMeta(
 		ast: {
 			flags: PHP_METHOD_MODIFIER_PRIVATE,
 			params: [
-				createParam(createVariable('post_id'), {
-					type: createIdentifier('int'),
+				buildParam(buildVariable('post_id'), {
+					type: buildIdentifier('int'),
 				}),
-				createParam(createVariable('request'), {
-					type: createName(['WP_REST_Request']),
+				buildParam(buildVariable('request'), {
+					type: buildName(['WP_REST_Request']),
 				}),
 			],
-			returnType: createIdentifier('void'),
+			returnType: buildIdentifier('void'),
 		},
 	});
 }
@@ -104,7 +104,7 @@ export function syncWpPostTaxonomies(
 		[string, WpPostTaxonomyDescriptor]
 	>;
 
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `private function sync${options.pascalName}Taxonomies( int $post_id, WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,
@@ -150,11 +150,11 @@ export function syncWpPostTaxonomies(
 		ast: {
 			flags: PHP_METHOD_MODIFIER_PRIVATE,
 			params: [
-				createParam(createVariable('post_id'), {
-					type: createIdentifier('int'),
+				buildParam(buildVariable('post_id'), {
+					type: buildIdentifier('int'),
 				}),
-				createParam(createVariable('request'), {
-					type: createName(['WP_REST_Request']),
+				buildParam(buildVariable('request'), {
+					type: buildName(['WP_REST_Request']),
 				}),
 			],
 		},
@@ -173,7 +173,7 @@ export function prepareWpPostResponse(
 	>;
 	const supports = new Set(storage.supports ?? []);
 
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `private function prepare${options.pascalName}Response( WP_Post $post, WP_REST_Request $request ): array`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,
@@ -233,14 +233,14 @@ export function prepareWpPostResponse(
 		ast: {
 			flags: PHP_METHOD_MODIFIER_PRIVATE,
 			params: [
-				createParam(createVariable('post'), {
-					type: createName(['WP_Post']),
+				buildParam(buildVariable('post'), {
+					type: buildName(['WP_Post']),
 				}),
-				createParam(createVariable('request'), {
-					type: createName(['WP_REST_Request']),
+				buildParam(buildVariable('request'), {
+					type: buildName(['WP_REST_Request']),
 				}),
 			],
-			returnType: createIdentifier('array'),
+			returnType: buildIdentifier('array'),
 		},
 	});
 }

--- a/packages/cli/src/next/builders/php/resource/wpPost/mutations/macros.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/mutations/macros.ts
@@ -1,27 +1,27 @@
 import {
-	createArg,
-	createArray,
-	createArrayItem,
-	createAssign,
-	createComment,
-	createExpressionStatement,
-	createFuncCall,
-	createIdentifier,
-	createMethodCall,
-	createName,
-	createNode,
-	createReturn,
-	createScalarInt,
-	createScalarString,
-	createStmtNop,
-	createVariable,
-	createNull,
+	buildArg,
+	buildArray,
+	buildArrayItem,
+	buildAssign,
+	buildComment,
+	buildExpressionStatement,
+	buildFuncCall,
+	buildIdentifier,
+	buildMethodCall,
+	buildName,
+	buildNode,
+	buildReturn,
+	buildScalarInt,
+	buildScalarString,
+	buildStmtNop,
+	buildVariable,
+	buildNull,
 	type PhpExpr,
 	type PhpExprNew,
 	PHP_INDENT,
 	type PhpMethodBodyBuilder,
 } from '@wpkernel/php-json-ast';
-import { createPrintable, escapeSingleQuotes } from '@wpkernel/php-json-ast';
+import { buildPrintable, escapeSingleQuotes } from '@wpkernel/php-json-ast';
 import {
 	buildArrayDimFetch,
 	buildBinaryOperation,
@@ -39,7 +39,7 @@ export interface MacroExpression {
 
 export function buildVariableExpression(name: string): MacroExpression {
 	return {
-		expression: createVariable(name),
+		expression: buildVariable(name),
 		display: `$${name}`,
 	};
 }
@@ -50,7 +50,7 @@ export function buildArrayDimExpression(
 ): MacroExpression {
 	const escapedKey = escapeSingleQuotes(key);
 	return {
-		expression: buildArrayDimFetch(array, createScalarString(key)),
+		expression: buildArrayDimFetch(array, buildScalarString(key)),
 		display: `$${array}['${escapedKey}']`,
 	};
 }
@@ -126,14 +126,14 @@ export function appendStatusValidationMacro(
 		options.requestVariable ?? buildVariableExpression('request');
 	const statusParam = options.statusParam ?? 'status';
 
-	const statusAssign = createPrintable(
-		createExpressionStatement(
-			createAssign(
+	const statusAssign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
 				statusVariable.expression,
-				createMethodCall(
+				buildMethodCall(
 					requestVariable.expression,
-					createIdentifier('get_param'),
-					[createArg(createScalarString(statusParam))]
+					buildIdentifier('get_param'),
+					[buildArg(buildScalarString(statusParam))]
 				)
 			)
 		),
@@ -145,17 +145,17 @@ export function appendStatusValidationMacro(
 	);
 	options.body.statement(statusAssign);
 
-	const normalisedCall = createMethodCall(
-		createVariable('this'),
-		createIdentifier(`normalise${options.pascalName}Status`),
-		[createArg(statusVariable.expression)]
+	const normalisedCall = buildMethodCall(
+		buildVariable('this'),
+		buildIdentifier(`normalise${options.pascalName}Status`),
+		[buildArg(statusVariable.expression)]
 	);
 
 	if (options.guardWithNullCheck) {
 		const childIndent = indentUnit.repeat(options.indentLevel + 1);
-		const guardedAssign = createPrintable(
-			createExpressionStatement(
-				createAssign(options.target.expression, normalisedCall)
+		const guardedAssign = buildPrintable(
+			buildExpressionStatement(
+				buildAssign(options.target.expression, normalisedCall)
 			),
 			[
 				`${childIndent}${options.target.display} = $this->normalise${options.pascalName}Status( ${statusVariable.display} );`,
@@ -165,7 +165,7 @@ export function appendStatusValidationMacro(
 			indentLevel: options.indentLevel,
 			condition: buildBinaryOperation(
 				'NotIdentical',
-				createNull(),
+				buildNull(),
 				statusVariable.expression
 			),
 			conditionText: `${indent}if ( null !== ${statusVariable.display} ) {`,
@@ -175,9 +175,9 @@ export function appendStatusValidationMacro(
 		return;
 	}
 
-	const directAssign = createPrintable(
-		createExpressionStatement(
-			createAssign(options.target.expression, normalisedCall)
+	const directAssign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(options.target.expression, normalisedCall)
 		),
 		[
 			`${indent}${options.target.display} = $this->normalise${options.pascalName}Status( ${statusVariable.display} );`,
@@ -199,15 +199,15 @@ export function appendSyncMetaMacro(options: SyncMetaMacroOptions): void {
 
 	const requestVariable =
 		options.requestVariable ?? buildVariableExpression('request');
-	const call = createMethodCall(
-		createVariable('this'),
-		createIdentifier(`sync${options.pascalName}Meta`),
+	const call = buildMethodCall(
+		buildVariable('this'),
+		buildIdentifier(`sync${options.pascalName}Meta`),
 		[
-			createArg(options.postId.expression),
-			createArg(requestVariable.expression),
+			buildArg(options.postId.expression),
+			buildArg(requestVariable.expression),
 		]
 	);
-	const printable = createPrintable(createExpressionStatement(call), [
+	const printable = buildPrintable(buildExpressionStatement(call), [
 		`${indent}$this->sync${options.pascalName}Meta( ${options.postId.display}, ${requestVariable.display} );`,
 	]);
 	options.body.statement(printable);
@@ -232,16 +232,16 @@ export function appendSyncTaxonomiesMacro(
 
 	const requestVariable =
 		options.requestVariable ?? buildVariableExpression('request');
-	const assign = createPrintable(
-		createExpressionStatement(
-			createAssign(
+	const assign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
 				options.resultVariable.expression,
-				createMethodCall(
-					createVariable('this'),
-					createIdentifier(`sync${options.pascalName}Taxonomies`),
+				buildMethodCall(
+					buildVariable('this'),
+					buildIdentifier(`sync${options.pascalName}Taxonomies`),
 					[
-						createArg(options.postId.expression),
-						createArg(requestVariable.expression),
+						buildArg(options.postId.expression),
+						buildArg(requestVariable.expression),
 					]
 				)
 			)
@@ -253,14 +253,14 @@ export function appendSyncTaxonomiesMacro(
 	options.body.statement(assign);
 
 	const childIndent = indentUnit.repeat(options.indentLevel + 1);
-	const returnPrintable = createPrintable(
-		createReturn(options.resultVariable.expression),
+	const returnPrintable = buildPrintable(
+		buildReturn(options.resultVariable.expression),
 		[`${childIndent}return ${options.resultVariable.display};`]
 	);
 	const guard = buildIfPrintable({
 		indentLevel: options.indentLevel,
-		condition: createFuncCall(createName(['is_wp_error']), [
-			createArg(options.resultVariable.expression),
+		condition: buildFuncCall(buildName(['is_wp_error']), [
+			buildArg(options.resultVariable.expression),
 		]),
 		conditionText: `${indent}if ( is_wp_error( ${options.resultVariable.display} ) ) {`,
 		statements: [returnPrintable],
@@ -287,12 +287,12 @@ export function appendCachePrimingMacro(
 	const postVariableName = options.postVariableName ?? 'post';
 	const postVariable = buildVariableExpression(postVariableName);
 
-	const loadPost = createPrintable(
-		createExpressionStatement(
-			createAssign(
+	const loadPost = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
 				postVariable.expression,
-				createFuncCall(createName(['get_post']), [
-					createArg(options.postId.expression),
+				buildFuncCall(buildName(['get_post']), [
+					buildArg(options.postId.expression),
 				])
 			)
 		),
@@ -303,23 +303,23 @@ export function appendCachePrimingMacro(
 	options.body.statement(loadPost);
 
 	const childIndent = indentUnit.repeat(options.indentLevel + 1);
-	const failureExpr = createNode<PhpExprNew>('Expr_New', {
-		class: createName(['WP_Error']),
+	const failureExpr = buildNode<PhpExprNew>('Expr_New', {
+		class: buildName(['WP_Error']),
 		args: [
-			createArg(createScalarString(options.errorCode)),
-			createArg(
-				createScalarString(escapeSingleQuotes(options.failureMessage))
+			buildArg(buildScalarString(options.errorCode)),
+			buildArg(
+				buildScalarString(escapeSingleQuotes(options.failureMessage))
 			),
-			createArg(
-				createArray([
-					createArrayItem(createScalarInt(500), {
-						key: createScalarString('status'),
+			buildArg(
+				buildArray([
+					buildArrayItem(buildScalarInt(500), {
+						key: buildScalarString('status'),
 					}),
 				])
 			),
 		],
 	});
-	const failureReturn = createPrintable(createReturn(failureExpr), [
+	const failureReturn = buildPrintable(buildReturn(failureExpr), [
 		`${childIndent}return new WP_Error( '${escapeSingleQuotes(
 			options.errorCode
 		)}', '${escapeSingleQuotes(
@@ -336,15 +336,15 @@ export function appendCachePrimingMacro(
 	});
 	options.body.statement(guard);
 
-	const responseCall = createMethodCall(
-		createVariable('this'),
-		createIdentifier(`prepare${options.pascalName}Response`),
+	const responseCall = buildMethodCall(
+		buildVariable('this'),
+		buildIdentifier(`prepare${options.pascalName}Response`),
 		[
-			createArg(postVariable.expression),
-			createArg(requestVariable.expression),
+			buildArg(postVariable.expression),
+			buildArg(requestVariable.expression),
 		]
 	);
-	const responsePrintable = createPrintable(createReturn(responseCall), [
+	const responsePrintable = buildPrintable(buildReturn(responseCall), [
 		`${indent}return $this->prepare${options.pascalName}Response( ${postVariable.display}, ${requestVariable.display} );`,
 	]);
 	options.body.statement(responsePrintable);
@@ -358,8 +358,8 @@ function appendMetadataComment(
 	const indentUnit = options.indentUnit ?? PHP_INDENT;
 	const indent = indentUnit.repeat(options.indentLevel);
 	const text = `// @wp-kernel ${key} ${value}`;
-	const printable = createPrintable(
-		createStmtNop({ comments: [createComment(text)] }),
+	const printable = buildPrintable(
+		buildStmtNop({ comments: [buildComment(text)] }),
 		[`${indent}${text}`]
 	);
 	options.body.statement(printable);

--- a/packages/cli/src/next/builders/php/resource/wpPost/mutations/routes/create.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/mutations/routes/create.ts
@@ -1,21 +1,21 @@
 import {
-	createArg,
-	createArray,
-	createArrayItem,
-	createAssign,
-	createExpressionStatement,
-	createFuncCall,
-	createIdentifier,
-	createMethodCall,
-	createName,
-	createReturn,
-	createScalarBool,
-	createScalarInt,
-	createScalarString,
-	createVariable,
-	createPrintable,
+	buildArg,
+	buildArray,
+	buildArrayItem,
+	buildAssign,
+	buildExpressionStatement,
+	buildFuncCall,
+	buildIdentifier,
+	buildMethodCall,
+	buildName,
+	buildReturn,
+	buildScalarBool,
+	buildScalarInt,
+	buildScalarString,
+	buildVariable,
+	buildPrintable,
 	PHP_INDENT,
-	createErrorCodeFactory,
+	makeErrorCodeFactory,
 } from '@wpkernel/php-json-ast';
 import {
 	appendCachePrimingMacro,
@@ -39,15 +39,15 @@ export function buildCreateRouteBody(
 
 	const indentLevel = options.indentLevel;
 	const indent = PHP_INDENT.repeat(indentLevel);
-	const errorCodeFactory = createErrorCodeFactory(options.resource.name);
+	const errorCodeFactory = makeErrorCodeFactory(options.resource.name);
 
-	const postTypePrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('post_type'),
-				createMethodCall(
-					createVariable('this'),
-					createIdentifier(`get${options.pascalName}PostType`),
+	const postTypePrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('post_type'),
+				buildMethodCall(
+					buildVariable('this'),
+					buildIdentifier(`get${options.pascalName}PostType`),
 					[]
 				)
 			)
@@ -57,13 +57,13 @@ export function buildCreateRouteBody(
 	options.body.statement(postTypePrintable);
 	options.body.blank();
 
-	const postDataPrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('post_data'),
-				createArray([
-					createArrayItem(createVariable('post_type'), {
-						key: createScalarString('post_type'),
+	const postDataPrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('post_data'),
+				buildArray([
+					buildArrayItem(buildVariable('post_type'), {
+						key: buildScalarString('post_type'),
 					}),
 				])
 			)
@@ -85,13 +85,13 @@ export function buildCreateRouteBody(
 	});
 	options.body.blank();
 
-	const insertPrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('post_id'),
-				createFuncCall(createName(['wp_insert_post']), [
-					createArg(createVariable('post_data')),
-					createArg(createScalarBool(true)),
+	const insertPrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('post_id'),
+				buildFuncCall(buildName(['wp_insert_post']), [
+					buildArg(buildVariable('post_data')),
+					buildArg(buildScalarBool(true)),
 				])
 			)
 		),
@@ -99,14 +99,13 @@ export function buildCreateRouteBody(
 	);
 	options.body.statement(insertPrintable);
 
-	const insertReturn = createPrintable(
-		createReturn(createVariable('post_id')),
-		[`${indent}${PHP_INDENT}return $post_id;`]
-	);
+	const insertReturn = buildPrintable(buildReturn(buildVariable('post_id')), [
+		`${indent}${PHP_INDENT}return $post_id;`,
+	]);
 	const insertGuard = buildIfPrintable({
 		indentLevel,
-		condition: createFuncCall(createName(['is_wp_error']), [
-			createArg(createVariable('post_id')),
+		condition: buildFuncCall(buildName(['is_wp_error']), [
+			buildArg(buildVariable('post_id')),
 		]),
 		conditionText: `${indent}if ( is_wp_error( $post_id ) ) {`,
 		statements: [insertReturn],
@@ -124,8 +123,8 @@ export function buildCreateRouteBody(
 		indentLevel,
 		condition: buildBinaryOperation(
 			'Identical',
-			createScalarInt(0),
-			createVariable('post_id')
+			buildScalarInt(0),
+			buildVariable('post_id')
 		),
 		conditionText: `${indent}if ( 0 === $post_id ) {`,
 		statements: [insertFailedReturn],

--- a/packages/cli/src/next/builders/php/resource/wpPost/mutations/routes/remove.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/mutations/routes/remove.ts
@@ -1,20 +1,20 @@
 import {
-	createArg,
-	createAssign,
-	createArray,
-	createArrayItem,
-	createExpressionStatement,
-	createFuncCall,
-	createIdentifier,
-	createMethodCall,
-	createName,
-	createReturn,
-	createScalarBool,
-	createScalarString,
-	createVariable,
-	createPrintable,
+	buildArg,
+	buildAssign,
+	buildArray,
+	buildArrayItem,
+	buildExpressionStatement,
+	buildFuncCall,
+	buildIdentifier,
+	buildMethodCall,
+	buildName,
+	buildReturn,
+	buildScalarBool,
+	buildScalarString,
+	buildVariable,
+	buildPrintable,
 	PHP_INDENT,
-	createErrorCodeFactory,
+	makeErrorCodeFactory,
 } from '@wpkernel/php-json-ast';
 import { createIdentityValidationPrintables } from '../../identity';
 import {
@@ -39,16 +39,16 @@ export function buildDeleteRouteBody(
 	const indentLevel = options.indentLevel;
 	const indent = PHP_INDENT.repeat(indentLevel);
 	const identityVar = options.identity.param;
-	const errorCodeFactory = createErrorCodeFactory(options.resource.name);
+	const errorCodeFactory = makeErrorCodeFactory(options.resource.name);
 
-	const identityPrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable(identityVar),
-				createMethodCall(
-					createVariable('request'),
-					createIdentifier('get_param'),
-					[createArg(createScalarString(identityVar))]
+	const identityPrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable(identityVar),
+				buildMethodCall(
+					buildVariable('request'),
+					buildIdentifier('get_param'),
+					[buildArg(buildScalarString(identityVar))]
 				)
 			)
 		),
@@ -71,14 +71,14 @@ export function buildDeleteRouteBody(
 		options.body.blank();
 	}
 
-	const resolvePrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('post'),
-				createMethodCall(
-					createVariable('this'),
-					createIdentifier(`resolve${options.pascalName}Post`),
-					[createArg(createVariable(identityVar))]
+	const resolvePrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('post'),
+				buildMethodCall(
+					buildVariable('this'),
+					buildIdentifier(`resolve${options.pascalName}Post`),
+					[buildArg(buildVariable(identityVar))]
 				)
 			)
 		),
@@ -104,16 +104,16 @@ export function buildDeleteRouteBody(
 	options.body.statement(notFoundGuard);
 	options.body.blank();
 
-	const previousPrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('previous'),
-				createMethodCall(
-					createVariable('this'),
-					createIdentifier(`prepare${options.pascalName}Response`),
+	const previousPrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('previous'),
+				buildMethodCall(
+					buildVariable('this'),
+					buildIdentifier(`prepare${options.pascalName}Response`),
 					[
-						createArg(createVariable('post')),
-						createArg(createVariable('request')),
+						buildArg(buildVariable('post')),
+						buildArg(buildVariable('request')),
 					]
 				)
 			)
@@ -124,13 +124,13 @@ export function buildDeleteRouteBody(
 	);
 	options.body.statement(previousPrintable);
 
-	const deletePrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('deleted'),
-				createFuncCall(createName(['wp_delete_post']), [
-					createArg(buildPropertyFetch('post', 'ID')),
-					createArg(createScalarBool(true)),
+	const deletePrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('deleted'),
+				buildFuncCall(buildName(['wp_delete_post']), [
+					buildArg(buildPropertyFetch('post', 'ID')),
+					buildArg(buildScalarBool(true)),
 				])
 			)
 		),
@@ -149,8 +149,8 @@ export function buildDeleteRouteBody(
 		indentLevel,
 		condition: buildBinaryOperation(
 			'Identical',
-			createScalarBool(false),
-			createVariable('deleted')
+			buildScalarBool(false),
+			buildVariable('deleted')
 		),
 		conditionText: `${indent}if ( false === $deleted ) {`,
 		statements: [deleteReturn],
@@ -158,18 +158,18 @@ export function buildDeleteRouteBody(
 	options.body.statement(deleteGuard);
 	options.body.blank();
 
-	const responsePrintable = createPrintable(
-		createReturn(
-			createArray([
-				createArrayItem(createScalarBool(true), {
-					key: createScalarString('deleted'),
+	const responsePrintable = buildPrintable(
+		buildReturn(
+			buildArray([
+				buildArrayItem(buildScalarBool(true), {
+					key: buildScalarString('deleted'),
 				}),
-				createArrayItem(
+				buildArrayItem(
 					buildScalarCast('int', buildPropertyFetch('post', 'ID')),
-					{ key: createScalarString('id') }
+					{ key: buildScalarString('id') }
 				),
-				createArrayItem(createVariable('previous'), {
-					key: createScalarString('previous'),
+				buildArrayItem(buildVariable('previous'), {
+					key: buildScalarString('previous'),
 				}),
 			])
 		),

--- a/packages/cli/src/next/builders/php/resource/wpPost/mutations/routes/update.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/mutations/routes/update.ts
@@ -1,21 +1,21 @@
 import {
-	createArg,
-	createArray,
-	createArrayItem,
-	createAssign,
-	createExpressionStatement,
-	createFuncCall,
-	createIdentifier,
-	createMethodCall,
-	createName,
-	createReturn,
-	createScalarBool,
-	createScalarInt,
-	createScalarString,
-	createVariable,
-	createPrintable,
+	buildArg,
+	buildArray,
+	buildArrayItem,
+	buildAssign,
+	buildExpressionStatement,
+	buildFuncCall,
+	buildIdentifier,
+	buildMethodCall,
+	buildName,
+	buildReturn,
+	buildScalarBool,
+	buildScalarInt,
+	buildScalarString,
+	buildVariable,
+	buildPrintable,
 	PHP_INDENT,
-	createErrorCodeFactory,
+	makeErrorCodeFactory,
 } from '@wpkernel/php-json-ast';
 import { createIdentityValidationPrintables } from '../../identity';
 import {
@@ -48,16 +48,16 @@ export function buildUpdateRouteBody(
 	const indentLevel = options.indentLevel;
 	const indent = PHP_INDENT.repeat(indentLevel);
 	const identityVar = options.identity.param;
-	const errorCodeFactory = createErrorCodeFactory(options.resource.name);
+	const errorCodeFactory = makeErrorCodeFactory(options.resource.name);
 
-	const identityPrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable(identityVar),
-				createMethodCall(
-					createVariable('request'),
-					createIdentifier('get_param'),
-					[createArg(createScalarString(identityVar))]
+	const identityPrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable(identityVar),
+				buildMethodCall(
+					buildVariable('request'),
+					buildIdentifier('get_param'),
+					[buildArg(buildScalarString(identityVar))]
 				)
 			)
 		),
@@ -80,14 +80,14 @@ export function buildUpdateRouteBody(
 		options.body.blank();
 	}
 
-	const resolvePrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('post'),
-				createMethodCall(
-					createVariable('this'),
-					createIdentifier(`resolve${options.pascalName}Post`),
-					[createArg(createVariable(identityVar))]
+	const resolvePrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('post'),
+				buildMethodCall(
+					buildVariable('this'),
+					buildIdentifier(`resolve${options.pascalName}Post`),
+					[buildArg(buildVariable(identityVar))]
 				)
 			)
 		),
@@ -113,23 +113,21 @@ export function buildUpdateRouteBody(
 	options.body.statement(notFoundGuard);
 	options.body.blank();
 
-	const postDataPrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('post_data'),
-				createArray([
-					createArrayItem(buildPropertyFetch('post', 'ID'), {
-						key: createScalarString('ID'),
+	const postDataPrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('post_data'),
+				buildArray([
+					buildArrayItem(buildPropertyFetch('post', 'ID'), {
+						key: buildScalarString('ID'),
 					}),
-					createArrayItem(
-						createMethodCall(
-							createVariable('this'),
-							createIdentifier(
-								`get${options.pascalName}PostType`
-							),
+					buildArrayItem(
+						buildMethodCall(
+							buildVariable('this'),
+							buildIdentifier(`get${options.pascalName}PostType`),
 							[]
 						),
-						{ key: createScalarString('post_type') }
+						{ key: buildScalarString('post_type') }
 					),
 				])
 			)
@@ -153,13 +151,13 @@ export function buildUpdateRouteBody(
 	});
 	options.body.blank();
 
-	const updatePrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('result'),
-				createFuncCall(createName(['wp_update_post']), [
-					createArg(createVariable('post_data')),
-					createArg(createScalarBool(true)),
+	const updatePrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('result'),
+				buildFuncCall(buildName(['wp_update_post']), [
+					buildArg(buildVariable('post_data')),
+					buildArg(buildScalarBool(true)),
 				])
 			)
 		),
@@ -167,14 +165,13 @@ export function buildUpdateRouteBody(
 	);
 	options.body.statement(updatePrintable);
 
-	const resultReturn = createPrintable(
-		createReturn(createVariable('result')),
-		[`${indent}${PHP_INDENT}return $result;`]
-	);
+	const resultReturn = buildPrintable(buildReturn(buildVariable('result')), [
+		`${indent}${PHP_INDENT}return $result;`,
+	]);
 	const resultGuard = buildIfPrintable({
 		indentLevel,
-		condition: createFuncCall(createName(['is_wp_error']), [
-			createArg(createVariable('result')),
+		condition: buildFuncCall(buildName(['is_wp_error']), [
+			buildArg(buildVariable('result')),
 		]),
 		conditionText: `${indent}if ( is_wp_error( $result ) ) {`,
 		statements: [resultReturn],
@@ -192,8 +189,8 @@ export function buildUpdateRouteBody(
 		indentLevel,
 		condition: buildBinaryOperation(
 			'Identical',
-			createScalarInt(0),
-			createVariable('result')
+			buildScalarInt(0),
+			buildVariable('result')
 		),
 		conditionText: `${indent}if ( 0 === $result ) {`,
 		statements: [updateFailedReturn],

--- a/packages/cli/src/next/builders/php/resource/wpPost/taxonomyQuery.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/taxonomyQuery.ts
@@ -1,21 +1,21 @@
 import {
-	createArg,
-	createArray,
-	createArrayCast,
-	createArrayItem,
-	createArrowFunction,
-	createAssign,
-	createExpressionStatement,
-	createFuncCall,
-	createIdentifier,
-	createMethodCall,
-	createName,
-	createNull,
-	createParam,
-	createScalarInt,
-	createScalarString,
-	createVariable,
-	createPrintable,
+	buildArg,
+	buildArray,
+	buildArrayCast,
+	buildArrayItem,
+	buildArrowFunction,
+	buildAssign,
+	buildExpressionStatement,
+	buildFuncCall,
+	buildIdentifier,
+	buildMethodCall,
+	buildName,
+	buildNull,
+	buildParam,
+	buildScalarInt,
+	buildScalarString,
+	buildVariable,
+	buildPrintable,
 	PHP_INDENT,
 	escapeSingleQuotes,
 	toSnakeCase,
@@ -80,14 +80,14 @@ export function appendTaxonomyQueryBuilder(
 
 	for (const [key, descriptor] of options.entries) {
 		const variableName = `${toSnakeCase(key)}Terms`;
-		const requestPrintable = createPrintable(
-			createExpressionStatement(
-				createAssign(
-					createVariable(variableName),
-					createMethodCall(
-						createVariable('request'),
-						createIdentifier('get_param'),
-						[createArg(createScalarString(key))]
+		const requestPrintable = buildPrintable(
+			buildExpressionStatement(
+				buildAssign(
+					buildVariable(variableName),
+					buildMethodCall(
+						buildVariable('request'),
+						buildIdentifier('get_param'),
+						[buildArg(buildScalarString(key))]
 					)
 				)
 			),
@@ -100,42 +100,38 @@ export function appendTaxonomyQueryBuilder(
 		const childIndentLevel = indentLevel + 1;
 		const childIndent = PHP_INDENT.repeat(childIndentLevel);
 
-		const sanitisePrintable = createPrintable(
-			createExpressionStatement(
-				createAssign(
-					createVariable(variableName),
-					createFuncCall(createName(['array_filter']), [
-						createArg(
-							createFuncCall(createName(['array_map']), [
-								createArg(
-									createArrowFunction({
+		const sanitisePrintable = buildPrintable(
+			buildExpressionStatement(
+				buildAssign(
+					buildVariable(variableName),
+					buildFuncCall(buildName(['array_filter']), [
+						buildArg(
+							buildFuncCall(buildName(['array_map']), [
+								buildArg(
+									buildArrowFunction({
 										static: true,
 										params: [
-											createParam(
-												createVariable('value')
-											),
+											buildParam(buildVariable('value')),
 										],
 										expr: buildScalarCast(
 											'int',
-											createVariable('value')
+											buildVariable('value')
 										),
 									})
 								),
-								createArg(
-									createArrayCast(
-										createVariable(variableName)
-									)
+								buildArg(
+									buildArrayCast(buildVariable(variableName))
 								),
 							])
 						),
-						createArg(
-							createArrowFunction({
+						buildArg(
+							buildArrowFunction({
 								static: true,
-								params: [createParam(createVariable('value'))],
+								params: [buildParam(buildVariable('value'))],
 								expr: buildBinaryOperation(
 									'Greater',
-									createVariable('value'),
-									createScalarInt(0)
+									buildVariable('value'),
+									buildScalarInt(0)
 								),
 							})
 						),
@@ -154,22 +150,19 @@ export function appendTaxonomyQueryBuilder(
 		);
 
 		const nestedIndent = PHP_INDENT.repeat(childIndentLevel + 1);
-		const pushPrintable = createPrintable(
-			createExpressionStatement(
-				createAssign(
+		const pushPrintable = buildPrintable(
+			buildExpressionStatement(
+				buildAssign(
 					buildArrayDimFetch('tax_query', null),
-					createArray([
-						createArrayItem(
-							createScalarString(descriptor.taxonomy),
-							{
-								key: createScalarString('taxonomy'),
-							}
-						),
-						createArrayItem(createScalarString('term_id'), {
-							key: createScalarString('field'),
+					buildArray([
+						buildArrayItem(buildScalarString(descriptor.taxonomy), {
+							key: buildScalarString('taxonomy'),
 						}),
-						createArrayItem(createVariable(variableName), {
-							key: createScalarString('terms'),
+						buildArrayItem(buildScalarString('term_id'), {
+							key: buildScalarString('field'),
+						}),
+						buildArrayItem(buildVariable(variableName), {
+							key: buildScalarString('terms'),
 						}),
 					])
 				)
@@ -188,8 +181,8 @@ export function appendTaxonomyQueryBuilder(
 				indentLevel,
 				condition: buildBinaryOperation(
 					'NotIdentical',
-					createVariable(variableName),
-					createNull()
+					buildVariable(variableName),
+					buildNull()
 				),
 				conditionText: `${indent}if ( null !== $${variableName} ) {`,
 				statements: [
@@ -198,10 +191,10 @@ export function appendTaxonomyQueryBuilder(
 						indentLevel: childIndentLevel,
 						condition: buildBinaryOperation(
 							'Greater',
-							createFuncCall(createName(['count']), [
-								createArg(createVariable(variableName)),
+							buildFuncCall(buildName(['count']), [
+								buildArg(buildVariable(variableName)),
 							]),
-							createScalarInt(0)
+							buildScalarInt(0)
 						),
 						conditionText: `${childIndent}if ( count( $${variableName} ) > 0 ) {`,
 						statements: [pushPrintable],
@@ -211,14 +204,14 @@ export function appendTaxonomyQueryBuilder(
 		);
 	}
 
-	const assignPrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
+	const assignPrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
 				buildArrayDimFetch(
 					'query_args',
-					createScalarString('tax_query')
+					buildScalarString('tax_query')
 				),
-				createVariable('tax_query')
+				buildVariable('tax_query')
 			)
 		),
 		[`${indent}${PHP_INDENT}$query_args['tax_query'] = $tax_query;`]
@@ -229,10 +222,10 @@ export function appendTaxonomyQueryBuilder(
 			indentLevel,
 			condition: buildBinaryOperation(
 				'Greater',
-				createFuncCall(createName(['count']), [
-					createArg(createVariable('tax_query')),
+				buildFuncCall(buildName(['count']), [
+					buildArg(buildVariable('tax_query')),
 				]),
-				createScalarInt(0)
+				buildScalarInt(0)
 			),
 			conditionText: `${indent}if ( count( $tax_query ) > 0 ) {`,
 			statements: [assignPrintable],

--- a/packages/cli/src/next/builders/php/resource/wpTaxonomy/get.ts
+++ b/packages/cli/src/next/builders/php/resource/wpTaxonomy/get.ts
@@ -1,16 +1,16 @@
 import { KernelError } from '@wpkernel/core/contracts';
 import {
-	createArg,
-	createAssign,
-	createExpressionStatement,
-	createIdentifier,
-	createMethodCall,
-	createReturn,
-	createVariable,
-	createFuncCall,
-	createName,
-	createScalarString,
-	createPrintable,
+	buildArg,
+	buildAssign,
+	buildExpressionStatement,
+	buildIdentifier,
+	buildMethodCall,
+	buildReturn,
+	buildVariable,
+	buildFuncCall,
+	buildName,
+	buildScalarString,
+	buildPrintable,
 } from '@wpkernel/php-json-ast';
 import {
 	PHP_INDENT,
@@ -56,21 +56,21 @@ export function buildWpTaxonomyGetRouteBody(
 	const indent = PHP_INDENT.repeat(indentLevel);
 	const childIndent = PHP_INDENT.repeat(indentLevel + 1);
 
-	const identityAssign = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('identity'),
-				createMethodCall(
-					createVariable('this'),
-					createIdentifier(`validate${options.pascalName}Identity`),
+	const identityAssign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('identity'),
+				buildMethodCall(
+					buildVariable('this'),
+					buildIdentifier(`validate${options.pascalName}Identity`),
 					[
-						createArg(
-							createMethodCall(
-								createVariable('request'),
-								createIdentifier('get_param'),
+						buildArg(
+							buildMethodCall(
+								buildVariable('request'),
+								buildIdentifier('get_param'),
 								[
-									createArg(
-										createScalarString(
+									buildArg(
+										buildScalarString(
 											options.identity.param
 										)
 									),
@@ -89,12 +89,12 @@ export function buildWpTaxonomyGetRouteBody(
 
 	const errorGuard = buildIfPrintable({
 		indentLevel,
-		condition: createFuncCall(createName(['is_wp_error']), [
-			createArg(createVariable('identity')),
+		condition: buildFuncCall(buildName(['is_wp_error']), [
+			buildArg(buildVariable('identity')),
 		]),
 		conditionText: `${indent}if ( is_wp_error( $identity ) ) {`,
 		statements: [
-			createPrintable(createReturn(createVariable('identity')), [
+			buildPrintable(buildReturn(buildVariable('identity')), [
 				`${childIndent}return $identity;`,
 			]),
 		],
@@ -102,14 +102,14 @@ export function buildWpTaxonomyGetRouteBody(
 	options.body.statement(errorGuard);
 	options.body.blank();
 
-	const resolvePrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('term'),
-				createMethodCall(
-					createVariable('this'),
-					createIdentifier(`resolve${options.pascalName}Term`),
-					[createArg(createVariable('identity'))]
+	const resolvePrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('term'),
+				buildMethodCall(
+					buildVariable('this'),
+					buildIdentifier(`resolve${options.pascalName}Term`),
+					[buildArg(buildVariable('identity'))]
 				)
 			)
 		),
@@ -135,12 +135,12 @@ export function buildWpTaxonomyGetRouteBody(
 	options.body.statement(guard);
 	options.body.blank();
 
-	const returnPrintable = createPrintable(
-		createReturn(
-			createMethodCall(
-				createVariable('this'),
-				createIdentifier(`prepare${options.pascalName}TermResponse`),
-				[createArg(createVariable('term'))]
+	const returnPrintable = buildPrintable(
+		buildReturn(
+			buildMethodCall(
+				buildVariable('this'),
+				buildIdentifier(`prepare${options.pascalName}TermResponse`),
+				[buildArg(buildVariable('term'))]
 			)
 		),
 		[

--- a/packages/cli/src/next/builders/php/resource/wpTaxonomy/helpers.ts
+++ b/packages/cli/src/next/builders/php/resource/wpTaxonomy/helpers.ts
@@ -1,29 +1,29 @@
 import { KernelError } from '@wpkernel/core/contracts';
 import {
-	createArg,
-	createArray,
-	createArrayItem,
-	createAssign,
-	createExpressionStatement,
-	createFuncCall,
-	createIdentifier,
-	createMethodCall,
-	createName,
-	createNode,
-	createParam,
-	createReturn,
-	createScalarBool,
-	createScalarInt,
-	createScalarString,
-	createVariable,
-	createNull,
+	buildArg,
+	buildArray,
+	buildArrayItem,
+	buildAssign,
+	buildExpressionStatement,
+	buildFuncCall,
+	buildIdentifier,
+	buildMethodCall,
+	buildName,
+	buildNode,
+	buildParam,
+	buildReturn,
+	buildScalarBool,
+	buildScalarInt,
+	buildScalarString,
+	buildVariable,
+	buildNull,
 	type PhpNullableType,
-	createMethodTemplate,
+	assembleMethodTemplate,
 	PHP_INDENT,
 	type PhpMethodTemplate,
 } from '@wpkernel/php-json-ast';
 import {
-	createPrintable,
+	buildPrintable,
 	PHP_METHOD_MODIFIER_PRIVATE,
 	escapeSingleQuotes,
 } from '@wpkernel/php-json-ast';
@@ -72,20 +72,20 @@ function createGetTaxonomyHelper(
 	const indentLevel = 1;
 	const indent = PHP_INDENT.repeat(indentLevel + 1);
 
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `private function get${pascalName}Taxonomy(): string`,
 		indentLevel,
 		indentUnit: PHP_INDENT,
 		body: (body) => {
-			const returnPrintable = createPrintable(
-				createReturn(createScalarString(storage.taxonomy)),
+			const returnPrintable = buildPrintable(
+				buildReturn(buildScalarString(storage.taxonomy)),
 				[`${indent}return '${taxonomy}';`]
 			);
 			body.statement(returnPrintable);
 		},
 		ast: {
 			flags: PHP_METHOD_MODIFIER_PRIVATE,
-			returnType: createIdentifier('string'),
+			returnType: buildIdentifier('string'),
 		},
 	});
 }
@@ -98,15 +98,15 @@ function createPrepareTermHelper(
 	const indent = PHP_INDENT.repeat(indentLevel + 1);
 	const hierarchical = storage.hierarchical === true;
 
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `private function prepare${pascalName}TermResponse( WP_Term $term ): array`,
 		indentLevel,
 		indentUnit: PHP_INDENT,
 		body: (body) => {
-			const responseArray = createReturn(
-				createArrayTermResponse(hierarchical)
+			const responseArray = buildReturn(
+				buildArrayTermResponse(hierarchical)
 			);
-			const printable = createPrintable(responseArray, [
+			const printable = buildPrintable(responseArray, [
 				`${indent}return array(`,
 				`${indent}${PHP_INDENT}'id' => (int) $term->term_id,`,
 				`${indent}${PHP_INDENT}'slug' => (string) $term->slug,`,
@@ -125,61 +125,61 @@ function createPrepareTermHelper(
 		ast: {
 			flags: PHP_METHOD_MODIFIER_PRIVATE,
 			params: [
-				createParam(createVariable('term'), {
-					type: createName(['WP_Term']),
+				buildParam(buildVariable('term'), {
+					type: buildName(['WP_Term']),
 				}),
 			],
-			returnType: createIdentifier('array'),
+			returnType: buildIdentifier('array'),
 		},
 	});
 }
 
-function createArrayTermResponse(
+function buildArrayTermResponse(
 	hierarchical: boolean
-): ReturnType<typeof createArray> {
-	return createArray([
-		createArrayItem(
+): ReturnType<typeof buildArray> {
+	return buildArray([
+		buildArrayItem(
 			buildScalarCast('int', buildPropertyFetch('term', 'term_id')),
 			{
-				key: createScalarString('id'),
+				key: buildScalarString('id'),
 			}
 		),
-		createArrayItem(
+		buildArrayItem(
 			buildScalarCast('string', buildPropertyFetch('term', 'slug')),
 			{
-				key: createScalarString('slug'),
+				key: buildScalarString('slug'),
 			}
 		),
-		createArrayItem(
+		buildArrayItem(
 			buildScalarCast('string', buildPropertyFetch('term', 'name')),
 			{
-				key: createScalarString('name'),
+				key: buildScalarString('name'),
 			}
 		),
-		createArrayItem(
+		buildArrayItem(
 			buildScalarCast('string', buildPropertyFetch('term', 'taxonomy')),
-			{ key: createScalarString('taxonomy') }
+			{ key: buildScalarString('taxonomy') }
 		),
-		createArrayItem(createScalarBool(hierarchical), {
-			key: createScalarString('hierarchical'),
+		buildArrayItem(buildScalarBool(hierarchical), {
+			key: buildScalarString('hierarchical'),
 		}),
-		createArrayItem(
+		buildArrayItem(
 			buildScalarCast(
 				'string',
 				buildPropertyFetch('term', 'description')
 			),
-			{ key: createScalarString('description') }
+			{ key: buildScalarString('description') }
 		),
-		createArrayItem(
+		buildArrayItem(
 			buildScalarCast('int', buildPropertyFetch('term', 'parent')),
 			{
-				key: createScalarString('parent'),
+				key: buildScalarString('parent'),
 			}
 		),
-		createArrayItem(
+		buildArrayItem(
 			buildScalarCast('int', buildPropertyFetch('term', 'count')),
 			{
-				key: createScalarString('count'),
+				key: buildScalarString('count'),
 			}
 		),
 	]);
@@ -190,18 +190,18 @@ function createResolveTermHelper(pascalName: string): PhpMethodTemplate {
 	const indent = PHP_INDENT.repeat(indentLevel);
 	const childIndent = PHP_INDENT.repeat(indentLevel + 1);
 
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `private function resolve${pascalName}Term( $identity ): ?WP_Term`,
 		indentLevel,
 		indentUnit: PHP_INDENT,
 		body: (body) => {
-			const taxonomyAssign = createPrintable(
-				createExpressionStatement(
-					createAssign(
-						createVariable('taxonomy'),
-						createMethodCall(
-							createVariable('this'),
-							createIdentifier(`get${pascalName}Taxonomy`),
+			const taxonomyAssign = buildPrintable(
+				buildExpressionStatement(
+					buildAssign(
+						buildVariable('taxonomy'),
+						buildMethodCall(
+							buildVariable('this'),
+							buildIdentifier(`get${pascalName}Taxonomy`),
 							[]
 						)
 					)
@@ -212,18 +212,18 @@ function createResolveTermHelper(pascalName: string): PhpMethodTemplate {
 
 			const numberGuard = buildIfPrintable({
 				indentLevel,
-				condition: createFuncCall(createName(['is_int']), [
-					createArg(createVariable('identity')),
+				condition: buildFuncCall(buildName(['is_int']), [
+					buildArg(buildVariable('identity')),
 				]),
 				conditionText: `${indent}if ( is_int( $identity ) ) {`,
 				statements: [
-					createPrintable(
-						createExpressionStatement(
-							createAssign(
-								createVariable('term'),
-								createFuncCall(createName(['get_term']), [
-									createArg(createVariable('identity')),
-									createArg(createVariable('taxonomy')),
+					buildPrintable(
+						buildExpressionStatement(
+							buildAssign(
+								buildVariable('term'),
+								buildFuncCall(buildName(['get_term']), [
+									buildArg(buildVariable('identity')),
+									buildArg(buildVariable('taxonomy')),
 								])
 							)
 						),
@@ -236,24 +236,23 @@ function createResolveTermHelper(pascalName: string): PhpMethodTemplate {
 						condition: buildInstanceof('term', 'WP_Term'),
 						conditionText: `${childIndent}if ( $term instanceof WP_Term ) {`,
 						statements: [
-							createPrintable(
-								createReturn(createVariable('term')),
-								[`${childIndent}${PHP_INDENT}return $term;`]
-							),
+							buildPrintable(buildReturn(buildVariable('term')), [
+								`${childIndent}${PHP_INDENT}return $term;`,
+							]),
 						],
 					}),
 				],
 			});
 			body.statement(numberGuard);
 
-			const candidateAssign = createPrintable(
-				createExpressionStatement(
-					createAssign(
-						createVariable('candidate'),
-						createFuncCall(createName(['trim']), [
-							createArg(
-								createFuncCall(createName(['strval']), [
-									createArg(createVariable('identity')),
+			const candidateAssign = buildPrintable(
+				buildExpressionStatement(
+					buildAssign(
+						buildVariable('candidate'),
+						buildFuncCall(buildName(['trim']), [
+							buildArg(
+								buildFuncCall(buildName(['strval']), [
+									buildArg(buildVariable('identity')),
 								])
 							),
 						])
@@ -263,14 +262,14 @@ function createResolveTermHelper(pascalName: string): PhpMethodTemplate {
 			);
 
 			const lookupIndent = PHP_INDENT.repeat(indentLevel + 2);
-			const slugLookup = createPrintable(
-				createExpressionStatement(
-					createAssign(
-						createVariable('term'),
-						createFuncCall(createName(['get_term_by']), [
-							createArg(createScalarString('slug')),
-							createArg(createVariable('candidate')),
-							createArg(createVariable('taxonomy')),
+			const slugLookup = buildPrintable(
+				buildExpressionStatement(
+					buildAssign(
+						buildVariable('term'),
+						buildFuncCall(buildName(['get_term_by']), [
+							buildArg(buildScalarString('slug')),
+							buildArg(buildVariable('candidate')),
+							buildArg(buildVariable('taxonomy')),
 						])
 					)
 				),
@@ -283,20 +282,20 @@ function createResolveTermHelper(pascalName: string): PhpMethodTemplate {
 				condition: buildInstanceof('term', 'WP_Term'),
 				conditionText: `${lookupIndent}if ( $term instanceof WP_Term ) {`,
 				statements: [
-					createPrintable(createReturn(createVariable('term')), [
+					buildPrintable(buildReturn(buildVariable('term')), [
 						`${lookupIndent}${PHP_INDENT}return $term;`,
 					]),
 				],
 			});
 
-			const nameLookup = createPrintable(
-				createExpressionStatement(
-					createAssign(
-						createVariable('term'),
-						createFuncCall(createName(['get_term_by']), [
-							createArg(createScalarString('name')),
-							createArg(createVariable('candidate')),
-							createArg(createVariable('taxonomy')),
+			const nameLookup = buildPrintable(
+				buildExpressionStatement(
+					buildAssign(
+						buildVariable('term'),
+						buildFuncCall(buildName(['get_term_by']), [
+							buildArg(buildScalarString('name')),
+							buildArg(buildVariable('candidate')),
+							buildArg(buildVariable('taxonomy')),
 						])
 					)
 				),
@@ -309,7 +308,7 @@ function createResolveTermHelper(pascalName: string): PhpMethodTemplate {
 				condition: buildInstanceof('term', 'WP_Term'),
 				conditionText: `${lookupIndent}if ( $term instanceof WP_Term ) {`,
 				statements: [
-					createPrintable(createReturn(createVariable('term')), [
+					buildPrintable(buildReturn(buildVariable('term')), [
 						`${lookupIndent}${PHP_INDENT}return $term;`,
 					]),
 				],
@@ -319,8 +318,8 @@ function createResolveTermHelper(pascalName: string): PhpMethodTemplate {
 				indentLevel: indentLevel + 1,
 				condition: buildBinaryOperation(
 					'NotIdentical',
-					createScalarString(''),
-					createVariable('candidate')
+					buildScalarString(''),
+					buildVariable('candidate')
 				),
 				conditionText: `${childIndent}if ( '' !== $candidate ) {`,
 				statements: [slugLookup, slugGuard, nameLookup, nameGuard],
@@ -328,8 +327,8 @@ function createResolveTermHelper(pascalName: string): PhpMethodTemplate {
 
 			const stringGuard = buildIfPrintable({
 				indentLevel,
-				condition: createFuncCall(createName(['is_string']), [
-					createArg(createVariable('identity')),
+				condition: buildFuncCall(buildName(['is_string']), [
+					buildArg(buildVariable('identity')),
 				]),
 				conditionText: `${indent}if ( is_string( $identity ) ) {`,
 				statements: [candidateAssign, nonEmptyGuard],
@@ -337,16 +336,16 @@ function createResolveTermHelper(pascalName: string): PhpMethodTemplate {
 			body.statement(stringGuard);
 
 			body.statement(
-				createPrintable(createReturn(createNull()), [
+				buildPrintable(buildReturn(buildNull()), [
 					`${childIndent}return null;`,
 				])
 			);
 		},
 		ast: {
 			flags: PHP_METHOD_MODIFIER_PRIVATE,
-			params: [createParam(createVariable('identity'))],
-			returnType: createNode<PhpNullableType>('NullableType', {
-				type: createName(['WP_Term']),
+			params: [buildParam(buildVariable('identity'))],
+			returnType: buildNode<PhpNullableType>('NullableType', {
+				type: buildName(['WP_Term']),
 			}),
 		},
 	});
@@ -360,7 +359,7 @@ function createValidateIdentityHelper(
 	const indent = PHP_INDENT.repeat(indentLevel);
 	const childIndent = PHP_INDENT.repeat(indentLevel + 1);
 
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `private function validate${pascalName}Identity( $value )`,
 		indentLevel,
 		indentUnit: PHP_INDENT,
@@ -377,8 +376,8 @@ function createValidateIdentityHelper(
 					indentLevel,
 					condition: buildBinaryOperation(
 						'Identical',
-						createNull(),
-						createVariable('value')
+						buildNull(),
+						buildVariable('value')
 					),
 					conditionText: `${indent}if ( null === $value ) {`,
 					statements: [missingReturn],
@@ -398,14 +397,14 @@ function createValidateIdentityHelper(
 						indentLevel,
 						condition: buildBinaryOperation(
 							'BooleanAnd',
-							createFuncCall(createName(['is_string']), [
-								createArg(createVariable('value')),
+							buildFuncCall(buildName(['is_string']), [
+								buildArg(buildVariable('value')),
 							]),
 							buildBinaryOperation(
 								'Identical',
-								createScalarString(''),
-								createFuncCall(createName(['trim']), [
-									createArg(createVariable('value')),
+								buildScalarString(''),
+								buildFuncCall(buildName(['trim']), [
+									buildArg(buildVariable('value')),
 								])
 							)
 						),
@@ -418,8 +417,8 @@ function createValidateIdentityHelper(
 					buildIfPrintable({
 						indentLevel,
 						condition: buildBooleanNot(
-							createFuncCall(createName(['is_numeric']), [
-								createArg(createVariable('value')),
+							buildFuncCall(buildName(['is_numeric']), [
+								buildArg(buildVariable('value')),
 							])
 						),
 						conditionText: `${indent}if ( ! is_numeric( $value ) ) {`,
@@ -428,11 +427,11 @@ function createValidateIdentityHelper(
 				);
 
 				body.statement(
-					createPrintable(
-						createExpressionStatement(
-							createAssign(
-								createVariable('value'),
-								buildScalarCast('int', createVariable('value'))
+					buildPrintable(
+						buildExpressionStatement(
+							buildAssign(
+								buildVariable('value'),
+								buildScalarCast('int', buildVariable('value'))
 							)
 						),
 						[`${childIndent}$value = (int) $value;`]
@@ -444,8 +443,8 @@ function createValidateIdentityHelper(
 						indentLevel,
 						condition: buildBinaryOperation(
 							'SmallerOrEqual',
-							createVariable('value'),
-							createScalarInt(0)
+							buildVariable('value'),
+							buildScalarInt(0)
 						),
 						conditionText: `${indent}if ( $value <= 0 ) {`,
 						statements: [invalidReturn],
@@ -453,7 +452,7 @@ function createValidateIdentityHelper(
 				);
 
 				body.statement(
-					createPrintable(createReturn(createVariable('value')), [
+					buildPrintable(buildReturn(buildVariable('value')), [
 						`${childIndent}return $value;`,
 					])
 				);
@@ -466,15 +465,15 @@ function createValidateIdentityHelper(
 					condition: buildBinaryOperation(
 						'BooleanOr',
 						buildBooleanNot(
-							createFuncCall(createName(['is_string']), [
-								createArg(createVariable('value')),
+							buildFuncCall(buildName(['is_string']), [
+								buildArg(buildVariable('value')),
 							])
 						),
 						buildBinaryOperation(
 							'Identical',
-							createScalarString(''),
-							createFuncCall(createName(['trim']), [
-								createArg(createVariable('value')),
+							buildScalarString(''),
+							buildFuncCall(buildName(['trim']), [
+								buildArg(buildVariable('value')),
 							])
 						)
 					),
@@ -484,13 +483,13 @@ function createValidateIdentityHelper(
 			);
 
 			body.statement(
-				createPrintable(
-					createReturn(
-						createFuncCall(createName(['trim']), [
-							createArg(
+				buildPrintable(
+					buildReturn(
+						buildFuncCall(buildName(['trim']), [
+							buildArg(
 								buildScalarCast(
 									'string',
-									createVariable('value')
+									buildVariable('value')
 								)
 							),
 						])
@@ -501,7 +500,7 @@ function createValidateIdentityHelper(
 		},
 		ast: {
 			flags: PHP_METHOD_MODIFIER_PRIVATE,
-			params: [createParam(createVariable('value'))],
+			params: [buildParam(buildVariable('value'))],
 		},
 	});
 }

--- a/packages/cli/src/next/builders/php/resource/wpTaxonomy/list.ts
+++ b/packages/cli/src/next/builders/php/resource/wpTaxonomy/list.ts
@@ -1,24 +1,24 @@
 import { KernelError } from '@wpkernel/core/contracts';
 import {
-	createArg,
-	createArray,
-	createArrayItem,
-	createAssign,
-	createExpressionStatement,
-	createFuncCall,
-	createIdentifier,
-	createMethodCall,
-	createName,
-	createNode,
-	createReturn,
-	createScalarBool,
-	createScalarInt,
-	createScalarString,
-	createVariable,
+	buildArg,
+	buildArray,
+	buildArrayItem,
+	buildAssign,
+	buildExpressionStatement,
+	buildFuncCall,
+	buildIdentifier,
+	buildMethodCall,
+	buildName,
+	buildNode,
+	buildReturn,
+	buildScalarBool,
+	buildScalarInt,
+	buildScalarString,
+	buildVariable,
 	type PhpStmt,
 	type PhpStmtContinue,
 	type PhpStmtForeach,
-	createPrintable,
+	buildPrintable,
 	type PhpPrintable,
 	PHP_INDENT,
 	type PhpMethodBodyBuilder,
@@ -39,7 +39,7 @@ import {
 	buildScalarCast,
 } from '../utils';
 import { createListItemsInitialiser } from '../wpPost/list';
-import { createWpTermQueryInstantiation } from '@wpkernel/php-json-ast';
+import { buildWpTermQueryInstantiation } from '@wpkernel/php-json-ast';
 import type { IRResource } from '../../../../../ir/types';
 
 type WpTaxonomyStorage = Extract<
@@ -74,13 +74,13 @@ export function buildWpTaxonomyListRouteBody(
 	const childIndent = PHP_INDENT.repeat(indentLevel + 1);
 
 	options.body.statement(
-		createPrintable(
-			createExpressionStatement(
-				createAssign(
-					createVariable('taxonomy'),
-					createMethodCall(
-						createVariable('this'),
-						createIdentifier(`get${options.pascalName}Taxonomy`),
+		buildPrintable(
+			buildExpressionStatement(
+				buildAssign(
+					buildVariable('taxonomy'),
+					buildMethodCall(
+						buildVariable('this'),
+						buildIdentifier(`get${options.pascalName}Taxonomy`),
 						[]
 					)
 				)
@@ -113,14 +113,14 @@ export function buildWpTaxonomyListRouteBody(
 		indentLevel,
 		condition: buildBinaryOperation(
 			'SmallerOrEqual',
-			createVariable('page'),
-			createScalarInt(0)
+			buildVariable('page'),
+			buildScalarInt(0)
 		),
 		conditionText: `${indent}if ( $page <= 0 ) {`,
 		statements: [
-			createPrintable(
-				createExpressionStatement(
-					createAssign(createVariable('page'), createScalarInt(1))
+			buildPrintable(
+				buildExpressionStatement(
+					buildAssign(buildVariable('page'), buildScalarInt(1))
 				),
 				[`${childIndent}$page = 1;`]
 			),
@@ -146,27 +146,27 @@ export function buildWpTaxonomyListRouteBody(
 		indentLevel,
 	});
 
-	const numberAssign = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				buildArrayDimFetch('query_args', createScalarString('number')),
-				createVariable('per_page')
+	const numberAssign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildArrayDimFetch('query_args', buildScalarString('number')),
+				buildVariable('per_page')
 			)
 		),
 		[`${indent}$query_args['number'] = $per_page;`]
 	);
-	const offsetAssign = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				buildArrayDimFetch('query_args', createScalarString('offset')),
+	const offsetAssign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildArrayDimFetch('query_args', buildScalarString('offset')),
 				buildBinaryOperation(
 					'Mul',
 					buildBinaryOperation(
 						'Minus',
-						createVariable('page'),
-						createScalarInt(1)
+						buildVariable('page'),
+						buildScalarInt(1)
 					),
-					createVariable('per_page')
+					buildVariable('per_page')
 				)
 			)
 		),
@@ -177,21 +177,21 @@ export function buildWpTaxonomyListRouteBody(
 	options.body.blank();
 
 	options.body.statement(
-		createWpTermQueryInstantiation({
+		buildWpTermQueryInstantiation({
 			target: 'term_query',
 			indentLevel,
 		})
 	);
 
 	options.body.statement(
-		createPrintable(
-			createExpressionStatement(
-				createAssign(
-					createVariable('results'),
-					createMethodCall(
-						createVariable('term_query'),
-						createIdentifier('query'),
-						[createArg(createVariable('query_args'))]
+		buildPrintable(
+			buildExpressionStatement(
+				buildAssign(
+					buildVariable('results'),
+					buildMethodCall(
+						buildVariable('term_query'),
+						buildIdentifier('query'),
+						[buildArg(buildVariable('query_args'))]
 					)
 				)
 			),
@@ -201,12 +201,12 @@ export function buildWpTaxonomyListRouteBody(
 
 	const errorGuard = buildIfPrintable({
 		indentLevel,
-		condition: createFuncCall(createName(['is_wp_error']), [
-			createArg(createVariable('results')),
+		condition: buildFuncCall(buildName(['is_wp_error']), [
+			buildArg(buildVariable('results')),
 		]),
 		conditionText: `${indent}if ( is_wp_error( $results ) ) {`,
 		statements: [
-			createPrintable(createReturn(createVariable('results')), [
+			buildPrintable(buildReturn(buildVariable('results')), [
 				`${childIndent}return $results;`,
 			]),
 		],
@@ -223,53 +223,53 @@ export function buildWpTaxonomyListRouteBody(
 	options.body.statement(foreachPrintable);
 	options.body.blank();
 
-	const countQueryArgsAssign = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('count_query_args'),
-				createVariable('query_args')
+	const countQueryArgsAssign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('count_query_args'),
+				buildVariable('query_args')
 			)
 		),
 		[`${indent}$count_query_args = $query_args;`]
 	);
 	options.body.statement(countQueryArgsAssign);
 
-	const countFlagAssign = createPrintable(
-		createExpressionStatement(
-			createAssign(
+	const countFlagAssign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
 				buildArrayDimFetch(
 					'count_query_args',
-					createScalarString('count')
+					buildScalarString('count')
 				),
-				createScalarBool(true)
+				buildScalarBool(true)
 			)
 		),
 		[`${indent}$count_query_args['count'] = true;`]
 	);
 	options.body.statement(countFlagAssign);
 
-	const countNumberAssign = createPrintable(
-		createExpressionStatement(
-			createAssign(
+	const countNumberAssign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
 				buildArrayDimFetch(
 					'count_query_args',
-					createScalarString('number')
+					buildScalarString('number')
 				),
-				createScalarInt(0)
+				buildScalarInt(0)
 			)
 		),
 		[`${indent}$count_query_args['number'] = 0;`]
 	);
 	options.body.statement(countNumberAssign);
 
-	const countOffsetAssign = createPrintable(
-		createExpressionStatement(
-			createAssign(
+	const countOffsetAssign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
 				buildArrayDimFetch(
 					'count_query_args',
-					createScalarString('offset')
+					buildScalarString('offset')
 				),
-				createScalarInt(0)
+				buildScalarInt(0)
 			)
 		),
 		[`${indent}$count_query_args['offset'] = 0;`]
@@ -278,22 +278,22 @@ export function buildWpTaxonomyListRouteBody(
 	options.body.blank();
 
 	options.body.statement(
-		createWpTermQueryInstantiation({
+		buildWpTermQueryInstantiation({
 			target: 'count_query',
 			indentLevel,
 		})
 	);
 
-	const totalAssign = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('total'),
+	const totalAssign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('total'),
 				buildScalarCast(
 					'int',
-					createMethodCall(
-						createVariable('count_query'),
-						createIdentifier('query'),
-						[createArg(createVariable('count_query_args'))]
+					buildMethodCall(
+						buildVariable('count_query'),
+						buildIdentifier('query'),
+						[buildArg(buildVariable('count_query_args'))]
 					)
 				)
 			)
@@ -304,39 +304,39 @@ export function buildWpTaxonomyListRouteBody(
 
 	const pagesExpression = buildScalarCast(
 		'int',
-		createFuncCall(createName(['ceil']), [
-			createArg(
+		buildFuncCall(buildName(['ceil']), [
+			buildArg(
 				buildBinaryOperation(
 					'Div',
-					createVariable('total'),
-					createFuncCall(createName(['max']), [
-						createArg(createScalarInt(1)),
-						createArg(createVariable('per_page')),
+					buildVariable('total'),
+					buildFuncCall(buildName(['max']), [
+						buildArg(buildScalarInt(1)),
+						buildArg(buildVariable('per_page')),
 					])
 				)
 			),
 		])
 	);
-	const pagesAssign = createPrintable(
-		createExpressionStatement(
-			createAssign(createVariable('pages'), pagesExpression)
+	const pagesAssign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(buildVariable('pages'), pagesExpression)
 		),
 		[`${indent}$pages = (int) ceil( $total / max( 1, $per_page ) );`]
 	);
 	options.body.statement(pagesAssign);
 	options.body.blank();
 
-	const returnPrintable = createPrintable(
-		createReturn(
-			createArray([
-				createArrayItem(createVariable('items'), {
-					key: createScalarString('items'),
+	const returnPrintable = buildPrintable(
+		buildReturn(
+			buildArray([
+				buildArrayItem(buildVariable('items'), {
+					key: buildScalarString('items'),
 				}),
-				createArrayItem(createVariable('total'), {
-					key: createScalarString('total'),
+				buildArrayItem(buildVariable('total'), {
+					key: buildScalarString('total'),
 				}),
-				createArrayItem(createVariable('pages'), {
-					key: createScalarString('pages'),
+				buildArrayItem(buildVariable('pages'), {
+					key: buildScalarString('pages'),
 				}),
 			])
 		),
@@ -362,13 +362,13 @@ function appendExtraArgsMerge(options: {
 	const childIndent = PHP_INDENT.repeat(indentLevel + 1);
 
 	options.body.statement(
-		createPrintable(
-			createExpressionStatement(
-				createAssign(
-					createVariable('extra_args'),
-					createMethodCall(
-						createVariable('request'),
-						createIdentifier('get_params'),
+		buildPrintable(
+			buildExpressionStatement(
+				buildAssign(
+					buildVariable('extra_args'),
+					buildMethodCall(
+						buildVariable('request'),
+						buildIdentifier('get_params'),
 						[]
 					)
 				)
@@ -377,43 +377,43 @@ function appendExtraArgsMerge(options: {
 		)
 	);
 
-	const skipArray = createArray([
-		createArrayItem(createScalarString('page')),
-		createArrayItem(createScalarString('per_page')),
-		createArrayItem(createScalarString('taxonomy')),
-		createArrayItem(createScalarString('hide_empty')),
+	const skipArray = buildArray([
+		buildArrayItem(buildScalarString('page')),
+		buildArrayItem(buildScalarString('per_page')),
+		buildArrayItem(buildScalarString('taxonomy')),
+		buildArrayItem(buildScalarString('hide_empty')),
 	]);
 
-	const continuePrintable = createPrintable(
-		createNode<PhpStmtContinue>('Stmt_Continue', { num: null }),
+	const continuePrintable = buildPrintable(
+		buildNode<PhpStmtContinue>('Stmt_Continue', { num: null }),
 		[`${childIndent}${PHP_INDENT}continue;`]
 	);
 
 	const guard = buildIfPrintable({
 		indentLevel: indentLevel + 1,
-		condition: createFuncCall(createName(['in_array']), [
-			createArg(createVariable('key')),
-			createArg(skipArray),
-			createArg(createScalarBool(true)),
+		condition: buildFuncCall(buildName(['in_array']), [
+			buildArg(buildVariable('key')),
+			buildArg(skipArray),
+			buildArg(buildScalarBool(true)),
 		]),
 		conditionText: `${childIndent}if ( in_array( $key, array( 'page', 'per_page', 'taxonomy', 'hide_empty' ), true ) ) {`,
 		statements: [continuePrintable],
 	});
 
-	const assign = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				buildArrayDimFetch('query_args', createVariable('key')),
-				createVariable('value')
+	const assign = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildArrayDimFetch('query_args', buildVariable('key')),
+				buildVariable('value')
 			)
 		),
 		[`${childIndent}$query_args[ $key ] = $value;`]
 	);
 
-	const foreachNode = createNode<PhpStmtForeach>('Stmt_Foreach', {
-		expr: createVariable('extra_args'),
-		valueVar: createVariable('value'),
-		keyVar: createVariable('key'),
+	const foreachNode = buildNode<PhpStmtForeach>('Stmt_Foreach', {
+		expr: buildVariable('extra_args'),
+		valueVar: buildVariable('value'),
+		keyVar: buildVariable('key'),
 		byRef: false,
 		stmts: [guard.node, assign.node],
 	});
@@ -427,7 +427,7 @@ function appendExtraArgsMerge(options: {
 		`${indent}}`,
 	];
 
-	options.body.statement(createPrintable(foreachNode, foreachLines));
+	options.body.statement(buildPrintable(foreachNode, foreachLines));
 	options.body.blank();
 }
 
@@ -444,16 +444,16 @@ function createResultsForeach(options: {
 		condition: buildInstanceof('term', 'WP_Term'),
 		conditionText: `${childIndent}if ( $term instanceof WP_Term ) {`,
 		statements: [
-			createPrintable(
-				createExpressionStatement(
-					createAssign(
+			buildPrintable(
+				buildExpressionStatement(
+					buildAssign(
 						buildArrayDimFetch('items', null),
-						createMethodCall(
-							createVariable('this'),
-							createIdentifier(
+						buildMethodCall(
+							buildVariable('this'),
+							buildIdentifier(
 								`prepare${options.pascalName}TermResponse`
 							),
-							[createArg(createVariable('term'))]
+							[buildArg(buildVariable('term'))]
 						)
 					)
 				),
@@ -464,9 +464,9 @@ function createResultsForeach(options: {
 		],
 	});
 
-	const foreachNode = createNode<PhpStmtForeach>('Stmt_Foreach', {
-		expr: createVariable('results'),
-		valueVar: createVariable('term'),
+	const foreachNode = buildNode<PhpStmtForeach>('Stmt_Foreach', {
+		expr: buildVariable('results'),
+		valueVar: buildVariable('term'),
 		keyVar: null,
 		byRef: false,
 		stmts: [guard.node],
@@ -480,7 +480,7 @@ function createResultsForeach(options: {
 		`${indent}}`,
 	];
 
-	return createPrintable(foreachNode, lines);
+	return buildPrintable(foreachNode, lines);
 }
 
 function ensureStorage(resource: IRResource): WpTaxonomyStorage {

--- a/packages/cli/src/next/builders/php/resourceController/routes/get.ts
+++ b/packages/cli/src/next/builders/php/resourceController/routes/get.ts
@@ -1,12 +1,12 @@
 import {
-	createArg,
-	createAssign,
-	createExpressionStatement,
-	createIdentifier,
-	createMethodCall,
-	createReturn,
-	createVariable,
-	createPrintable,
+	buildArg,
+	buildAssign,
+	buildExpressionStatement,
+	buildIdentifier,
+	buildMethodCall,
+	buildReturn,
+	buildVariable,
+	buildPrintable,
 } from '@wpkernel/php-json-ast';
 import {
 	PHP_INDENT,
@@ -87,14 +87,14 @@ export function buildGetRouteBody(options: BuildGetRouteBodyOptions): boolean {
 		options.body.blank();
 	}
 
-	const resolvePrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('post'),
-				createMethodCall(
-					createVariable('this'),
-					createIdentifier(`resolve${options.pascalName}Post`),
-					[createArg(createVariable(param))]
+	const resolvePrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('post'),
+				buildMethodCall(
+					buildVariable('this'),
+					buildIdentifier(`resolve${options.pascalName}Post`),
+					[buildArg(buildVariable(param))]
 				)
 			)
 		),
@@ -120,14 +120,14 @@ export function buildGetRouteBody(options: BuildGetRouteBodyOptions): boolean {
 	options.body.statement(notFoundIf);
 	options.body.blank();
 
-	const returnPrintable = createPrintable(
-		createReturn(
-			createMethodCall(
-				createVariable('this'),
-				createIdentifier(`prepare${options.pascalName}Response`),
+	const returnPrintable = buildPrintable(
+		buildReturn(
+			buildMethodCall(
+				buildVariable('this'),
+				buildIdentifier(`prepare${options.pascalName}Response`),
 				[
-					createArg(createVariable('post')),
-					createArg(createVariable('request')),
+					buildArg(buildVariable('post')),
+					buildArg(buildVariable('request')),
 				]
 			)
 		),

--- a/packages/cli/src/next/builders/php/resourceController/routes/list.ts
+++ b/packages/cli/src/next/builders/php/resourceController/routes/list.ts
@@ -1,14 +1,14 @@
 import {
-	createArray,
-	createArrayItem,
-	createAssign,
-	createExpressionStatement,
-	createMethodCall,
-	createReturn,
-	createScalarString,
-	createVariable,
-	createIdentifier,
-	createPrintable,
+	buildArray,
+	buildArrayItem,
+	buildAssign,
+	buildExpressionStatement,
+	buildMethodCall,
+	buildReturn,
+	buildScalarString,
+	buildVariable,
+	buildIdentifier,
+	buildPrintable,
 	isNonEmptyString,
 } from '@wpkernel/php-json-ast';
 import {
@@ -69,13 +69,13 @@ export function buildListRouteBody(
 	const indentLevel = options.indentLevel;
 	const indent = PHP_INDENT.repeat(indentLevel);
 
-	const postTypePrintable = createPrintable(
-		createExpressionStatement(
-			createAssign(
-				createVariable('post_type'),
-				createMethodCall(
-					createVariable('this'),
-					createIdentifier(`get${options.pascalName}PostType`),
+	const postTypePrintable = buildPrintable(
+		buildExpressionStatement(
+			buildAssign(
+				buildVariable('post_type'),
+				buildMethodCall(
+					buildVariable('this'),
+					buildIdentifier(`get${options.pascalName}PostType`),
 					[]
 				)
 			)
@@ -100,13 +100,13 @@ export function buildListRouteBody(
 		: [];
 
 	if (statuses.length > 0) {
-		const statusesPrintable = createPrintable(
-			createExpressionStatement(
-				createAssign(
-					createVariable('statuses'),
-					createMethodCall(
-						createVariable('this'),
-						createIdentifier(`get${options.pascalName}Statuses`),
+		const statusesPrintable = buildPrintable(
+			buildExpressionStatement(
+				buildAssign(
+					buildVariable('statuses'),
+					buildMethodCall(
+						buildVariable('this'),
+						buildIdentifier(`get${options.pascalName}Statuses`),
 						[]
 					)
 				)
@@ -192,17 +192,17 @@ export function buildListRouteBody(
 		buildPropertyFetch('query', 'max_num_pages')
 	);
 
-	const returnPrintable = createPrintable(
-		createReturn(
-			createArray([
-				createArrayItem(createVariable('items'), {
-					key: createScalarString('items'),
+	const returnPrintable = buildPrintable(
+		buildReturn(
+			buildArray([
+				buildArrayItem(buildVariable('items'), {
+					key: buildScalarString('items'),
 				}),
-				createArrayItem(totalFetch, {
-					key: createScalarString('total'),
+				buildArrayItem(totalFetch, {
+					key: buildScalarString('total'),
 				}),
-				createArrayItem(pagesFetch, {
-					key: createScalarString('pages'),
+				buildArrayItem(pagesFetch, {
+					key: buildScalarString('pages'),
 				}),
 			])
 		),

--- a/packages/cli/src/next/builders/php/resourceController/stubs.ts
+++ b/packages/cli/src/next/builders/php/resourceController/stubs.ts
@@ -1,17 +1,17 @@
 import {
-	createComment,
-	createScalarInt,
-	createScalarString,
-	createStmtNop,
+	buildComment,
+	buildScalarInt,
+	buildScalarString,
+	buildStmtNop,
 	type PhpExprNew,
 	type PhpMethodBodyBuilder,
 } from '@wpkernel/php-json-ast';
 import {
-	createPrintable,
-	createNode,
-	createReturn,
-	createArg,
-	createName,
+	buildPrintable,
+	buildNode,
+	buildReturn,
+	buildArg,
+	buildName,
 } from '@wpkernel/php-json-ast';
 import type { IRRoute } from '../../../../ir/types';
 
@@ -24,10 +24,10 @@ export interface AppendNotImplementedStubOptions {
 export function appendNotImplementedStub(
 	options: AppendNotImplementedStubOptions
 ): void {
-	const todoPrintable = createPrintable(
-		createStmtNop({
+	const todoPrintable = buildPrintable(
+		buildStmtNop({
 			comments: [
-				createComment(
+				buildComment(
 					`// TODO: Implement handler for [${options.route.method}] ${options.route.path}.`
 				),
 			],
@@ -38,14 +38,14 @@ export function appendNotImplementedStub(
 	);
 	options.body.statement(todoPrintable);
 
-	const errorExpr = createNode<PhpExprNew>('Expr_New', {
-		class: createName(['WP_Error']),
+	const errorExpr = buildNode<PhpExprNew>('Expr_New', {
+		class: buildName(['WP_Error']),
 		args: [
-			createArg(createScalarInt(501)),
-			createArg(createScalarString('Not Implemented')),
+			buildArg(buildScalarInt(501)),
+			buildArg(buildScalarString('Not Implemented')),
 		],
 	});
-	const returnPrintable = createPrintable(createReturn(errorExpr), [
+	const returnPrintable = buildPrintable(buildReturn(errorExpr), [
 		`${options.indent}return new WP_Error( 501, 'Not Implemented' );`,
 	]);
 	options.body.statement(returnPrintable);

--- a/packages/cli/src/printers/blocks/ssr.ts
+++ b/packages/cli/src/printers/blocks/ssr.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import { PhpFileBuilder } from '../php/builder.js';
 import { appendGeneratedFileDocblock } from '../php/docblock.js';
 import { renderPhpFile } from '../php/render.js';
-import { createMethodTemplate, PHP_INDENT } from '../php/template.js';
+import { assembleMethodTemplate, PHP_INDENT } from '../php/template.js';
 import { sanitizeJson } from '../php/utils.js';
 import { renderPhpReturn } from '../php/value-renderer.js';
 import type { SSRBlockOptions, BlockPrinterResult } from './types.js';
@@ -409,7 +409,7 @@ function renderRegistrarFile(options: {
 	builder.appendStatement('{');
 
 	const methods = [
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: 'public static function register(): void',
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -465,7 +465,7 @@ function renderRegistrarFile(options: {
 				body.line('}');
 			},
 		}),
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature:
 				'private static function resolve_config_path( string $root, array $config, string $key ): ?string',
 			indentLevel: 1,
@@ -487,7 +487,7 @@ function renderRegistrarFile(options: {
 				body.line('return $path;');
 			},
 		}),
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature:
 				'private static function resolve_render_path( string $root, array $config ): ?string',
 			indentLevel: 1,
@@ -517,7 +517,7 @@ function renderRegistrarFile(options: {
 				body.line('return $candidate;');
 			},
 		}),
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature:
 				'private static function build_render_arguments( string $render_path ): array',
 			indentLevel: 1,
@@ -536,7 +536,7 @@ function renderRegistrarFile(options: {
 				body.line('];');
 			},
 		}),
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature:
 				'private static function render_template( string $render_path, array $attributes, string $content, ?\\WP_Block $block = null ): string',
 			indentLevel: 1,
@@ -552,7 +552,7 @@ function renderRegistrarFile(options: {
 				body.line('return (string) ob_get_clean();');
 			},
 		}),
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature:
 				'private static function resolve_directory_fallback( string $root, array $config ): ?string',
 			indentLevel: 1,
@@ -574,7 +574,7 @@ function renderRegistrarFile(options: {
 				body.line('return $path;');
 			},
 		}),
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature:
 				'private static function normalise_relative( string $root, string $relative ): string',
 			indentLevel: 1,

--- a/packages/cli/src/printers/php/__tests__/template.test.ts
+++ b/packages/cli/src/printers/php/__tests__/template.test.ts
@@ -1,8 +1,8 @@
-import { createMethodTemplate, PHP_INDENT } from '../template';
+import { assembleMethodTemplate, PHP_INDENT } from '../template';
 
-describe('createMethodTemplate', () => {
+describe('assembleMethodTemplate', () => {
 	it('renders docblocks and indents body lines', () => {
-		const lines = createMethodTemplate({
+		const lines = assembleMethodTemplate({
 			signature: 'public function demo(): void',
 			indentLevel: 1,
 			docblock: ['Example docblock'],
@@ -27,7 +27,7 @@ describe('createMethodTemplate', () => {
 	});
 
 	it('omits docblocks and body when no lines are emitted', () => {
-		const lines = createMethodTemplate({
+		const lines = assembleMethodTemplate({
 			signature: 'public function empty(): void',
 			indentLevel: 0,
 			body: () => {

--- a/packages/cli/src/printers/php/ast.ts
+++ b/packages/cli/src/printers/php/ast.ts
@@ -482,7 +482,7 @@ export type PhpNodeLike =
  * @param props
  * @param attributes
  */
-export function createNode<T extends PhpNode>(
+export function buildNode<T extends PhpNode>(
 	nodeType: T['nodeType'],
 	props: Omit<T, 'nodeType' | 'attributes'>,
 	attributes?: PhpAttributes
@@ -494,60 +494,56 @@ export function createNode<T extends PhpNode>(
 	} as T;
 }
 
-export function createIdentifier(
+export function buildIdentifier(
 	name: string,
 	attributes?: PhpAttributes
 ): PhpIdentifier {
-	return createNode<PhpIdentifier>('Identifier', { name }, attributes);
+	return buildNode<PhpIdentifier>('Identifier', { name }, attributes);
 }
 
-export function createName(
+export function buildName(
 	parts: string[],
 	attributes?: PhpAttributes
 ): PhpName {
-	return createNode<PhpName>('Name', { parts }, attributes);
+	return buildNode<PhpName>('Name', { parts }, attributes);
 }
 
-export function createFullyQualifiedName(
+export function buildFullyQualifiedName(
 	parts: string[],
 	attributes?: PhpAttributes
 ): PhpName {
-	return createNode<PhpName>('Name_FullyQualified', { parts }, attributes);
+	return buildNode<PhpName>('Name_FullyQualified', { parts }, attributes);
 }
 
-export function createNamespace(
+export function buildNamespace(
 	name: PhpName | null,
 	stmts: PhpStmt[],
 	attributes?: PhpAttributes
 ): PhpStmtNamespace {
-	return createNode<PhpStmtNamespace>(
+	return buildNode<PhpStmtNamespace>(
 		'Stmt_Namespace',
 		{ name, stmts },
 		attributes
 	);
 }
 
-export function createUse(
+export function buildUse(
 	type: number,
 	uses: PhpStmtUseUse[],
 	attributes?: PhpAttributes
 ): PhpStmtUse {
-	return createNode<PhpStmtUse>('Stmt_Use', { type, uses }, attributes);
+	return buildNode<PhpStmtUse>('Stmt_Use', { type, uses }, attributes);
 }
 
-export function createUseUse(
+export function buildUseUse(
 	name: PhpName,
 	alias: PhpIdentifier | null = null,
 	attributes?: PhpAttributes
 ): PhpStmtUseUse {
-	return createNode<PhpStmtUseUse>(
-		'Stmt_UseUse',
-		{ name, alias },
-		attributes
-	);
+	return buildNode<PhpStmtUseUse>('Stmt_UseUse', { name, alias }, attributes);
 }
 
-export function createClass(
+export function buildClass(
 	name: PhpIdentifier | null,
 	options: {
 		flags?: number;
@@ -558,7 +554,7 @@ export function createClass(
 	} = {},
 	attributes?: PhpAttributes
 ): PhpStmtClass {
-	return createNode<PhpStmtClass>(
+	return buildNode<PhpStmtClass>(
 		'Stmt_Class',
 		{
 			name,
@@ -572,7 +568,7 @@ export function createClass(
 	);
 }
 
-export function createClassMethod(
+export function buildClassMethod(
 	name: PhpIdentifier,
 	options: {
 		byRef?: boolean;
@@ -584,7 +580,7 @@ export function createClassMethod(
 	} = {},
 	attributes?: PhpAttributes
 ): PhpStmtClassMethod {
-	return createNode<PhpStmtClassMethod>(
+	return buildNode<PhpStmtClassMethod>(
 		'Stmt_ClassMethod',
 		{
 			name,
@@ -599,7 +595,7 @@ export function createClassMethod(
 	);
 }
 
-export function createParam(
+export function buildParam(
 	variable: PhpExpr,
 	options: {
 		type?: PhpType | null;
@@ -611,7 +607,7 @@ export function createParam(
 	} = {},
 	attributes?: PhpAttributes
 ): PhpParam {
-	return createNode<PhpParam>(
+	return buildNode<PhpParam>(
 		'Param',
 		{
 			type: options.type ?? null,
@@ -626,32 +622,32 @@ export function createParam(
 	);
 }
 
-export function createReturn(
+export function buildReturn(
 	expr: PhpExpr | null,
 	attributes?: PhpAttributes
 ): PhpStmtReturn {
-	return createNode<PhpStmtReturn>('Stmt_Return', { expr }, attributes);
+	return buildNode<PhpStmtReturn>('Stmt_Return', { expr }, attributes);
 }
 
-export function createExpressionStatement(
+export function buildExpressionStatement(
 	expr: PhpExpr,
 	attributes?: PhpAttributes
 ): PhpStmtExpression {
-	return createNode<PhpStmtExpression>(
+	return buildNode<PhpStmtExpression>(
 		'Stmt_Expression',
 		{ expr },
 		attributes
 	);
 }
 
-export function createArray(
+export function buildArray(
 	items: PhpExprArrayItem[],
 	attributes?: PhpAttributes
 ): PhpExprArray {
-	return createNode<PhpExprArray>('Expr_Array', { items }, attributes);
+	return buildNode<PhpExprArray>('Expr_Array', { items }, attributes);
 }
 
-export function createArrayItem(
+export function buildArrayItem(
 	value: PhpExpr,
 	options: {
 		key?: PhpExpr | null;
@@ -660,7 +656,7 @@ export function createArrayItem(
 	} = {},
 	attributes?: PhpAttributes
 ): PhpExprArrayItem {
-	return createNode<PhpExprArrayItem>(
+	return buildNode<PhpExprArrayItem>(
 		'Expr_ArrayItem',
 		{
 			key: options.key ?? null,
@@ -672,116 +668,108 @@ export function createArrayItem(
 	);
 }
 
-export function createScalarString(
+export function buildScalarString(
 	value: string,
 	attributes?: PhpAttributes
 ): PhpScalarString {
-	return createNode<PhpScalarString>('Scalar_String', { value }, attributes);
+	return buildNode<PhpScalarString>('Scalar_String', { value }, attributes);
 }
 
-export function createScalarInt(
+export function buildScalarInt(
 	value: number,
 	attributes?: PhpAttributes
 ): PhpScalarLNumber {
-	return createNode<PhpScalarLNumber>(
-		'Scalar_LNumber',
-		{ value },
-		attributes
-	);
+	return buildNode<PhpScalarLNumber>('Scalar_LNumber', { value }, attributes);
 }
 
-export function createScalarFloat(
+export function buildScalarFloat(
 	value: number,
 	attributes?: PhpAttributes
 ): PhpScalarDNumber {
-	return createNode<PhpScalarDNumber>(
-		'Scalar_DNumber',
-		{ value },
-		attributes
-	);
+	return buildNode<PhpScalarDNumber>('Scalar_DNumber', { value }, attributes);
 }
 
-export function createScalarBool(
+export function buildScalarBool(
 	value: boolean,
 	attributes?: PhpAttributes
 ): PhpExprConstFetch {
-	return createNode<PhpExprConstFetch>(
+	return buildNode<PhpExprConstFetch>(
 		'Expr_ConstFetch',
 		{
-			name: createName(value ? ['true'] : ['false']),
+			name: buildName(value ? ['true'] : ['false']),
 		},
 		attributes
 	);
 }
 
-export function createNull(attributes?: PhpAttributes): PhpExprConstFetch {
-	return createNode<PhpExprConstFetch>(
+export function buildNull(attributes?: PhpAttributes): PhpExprConstFetch {
+	return buildNode<PhpExprConstFetch>(
 		'Expr_ConstFetch',
 		{
-			name: createName(['null']),
+			name: buildName(['null']),
 		},
 		attributes
 	);
 }
 
-export function createVariable(
+export function buildVariable(
 	name: string | PhpExpr,
 	attributes?: PhpAttributes
 ): PhpExprVariable {
-	return createNode<PhpExprVariable>('Expr_Variable', { name }, attributes);
+	return buildNode<PhpExprVariable>('Expr_Variable', { name }, attributes);
 }
 
-export function createAssign(
+export function buildAssign(
 	variable: PhpExpr,
 	expr: PhpExpr,
 	attributes?: PhpAttributes
 ): PhpExprAssign {
-	return createNode<PhpExprAssign>(
+	return buildNode<PhpExprAssign>(
 		'Expr_Assign',
 		{ var: variable, expr },
 		attributes
 	);
 }
 
-export function createMethodCall(
+export function buildMethodCall(
 	variable: PhpExpr,
 	name: PhpIdentifier | PhpExpr,
 	args: PhpArg[] = [],
 	attributes?: PhpAttributes
 ): PhpExprMethodCall {
-	return createNode<PhpExprMethodCall>(
+	return buildNode<PhpExprMethodCall>(
 		'Expr_MethodCall',
 		{ var: variable, name, args },
 		attributes
 	);
 }
 
-export function createStaticCall(
+export function buildStaticCall(
 	className: PhpName | PhpExpr,
 	name: PhpIdentifier | PhpExpr,
 	args: PhpArg[] = [],
 	attributes?: PhpAttributes
 ): PhpExprStaticCall {
-	return createNode<PhpExprStaticCall>(
+	return buildNode<PhpExprStaticCall>(
 		'Expr_StaticCall',
 		{ class: className, name, args },
 		attributes
 	);
 }
 
-export function createFuncCall(
+export function buildFuncCall(
 	name: PhpName | PhpExpr,
 	args: PhpArg[] = [],
 	attributes?: PhpAttributes
 ): PhpExprFuncCall {
-	return createNode<PhpExprFuncCall>(
+	return buildNode<PhpExprFuncCall>(
 		'Expr_FuncCall',
 		{ name, args },
 		attributes
 	);
 }
 
-export function createArg(
+export function buildArg(
 	value: PhpExpr,
 	options: {
 		byRef?: boolean;
@@ -790,7 +778,7 @@ export function createArg(
 	} = {},
 	attributes?: PhpAttributes
 ): PhpArg {
-	return createNode<PhpArg>(
+	return buildNode<PhpArg>(
 		'Arg',
 		{
 			value,

--- a/packages/cli/src/printers/php/base-controller.ts
+++ b/packages/cli/src/printers/php/base-controller.ts
@@ -2,7 +2,7 @@ import { PhpFileBuilder } from './builder';
 import { appendMethodTemplates } from './builder-helpers';
 import { appendGeneratedFileDocblock } from './docblock';
 import type { PrinterContext } from '../types';
-import { createMethodTemplate, PHP_INDENT } from './template';
+import { assembleMethodTemplate, PHP_INDENT } from './template';
 import { escapeSingleQuotes } from './utils';
 
 export function createBaseControllerBuilder(
@@ -21,7 +21,7 @@ export function createBaseControllerBuilder(
 	builder.appendStatement('{');
 
 	const methods = [
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: 'public function get_namespace(): string',
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/persistence-registry.ts
+++ b/packages/cli/src/printers/php/persistence-registry.ts
@@ -2,7 +2,7 @@ import { PhpFileBuilder } from './builder';
 import { appendMethodTemplates } from './builder-helpers';
 import { appendGeneratedFileDocblock } from './docblock';
 import type { PrinterContext } from '../types';
-import { createMethodTemplate, PHP_INDENT } from './template';
+import { assembleMethodTemplate, PHP_INDENT } from './template';
 import { sanitizeJson } from './utils';
 import { renderPhpReturn } from './value-renderer';
 
@@ -22,7 +22,7 @@ export function createPersistenceRegistryBuilder(
 	builder.appendStatement('{');
 
 	const methods = [
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: 'public static function get_config(): array',
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/policy-helper.ts
+++ b/packages/cli/src/printers/php/policy-helper.ts
@@ -3,7 +3,7 @@ import { PhpFileBuilder } from './builder';
 import { appendGeneratedFileDocblock } from './docblock';
 import { sanitizeJson } from './utils';
 import { renderPhpExpression } from './value-renderer';
-import { createMethodTemplate, PHP_INDENT } from './template';
+import { assembleMethodTemplate, PHP_INDENT } from './template';
 import type { IRPolicyDefinition } from '../../ir';
 
 export function createPolicyHelperBuilder(
@@ -26,11 +26,11 @@ export function createPolicyHelperBuilder(
 	builder.appendStatement('final class Policy');
 	builder.appendStatement('{');
 
-	const mapStatement = createConstStatement(
+	const mapStatement = buildConstStatement(
 		'POLICY_MAP',
 		buildPolicyMap(context)
 	);
-	const fallbackStatement = createConstStatement(
+	const fallbackStatement = buildConstStatement(
 		'FALLBACK',
 		sanitizeJson(context.ir.policyMap.fallback)
 	);
@@ -58,7 +58,7 @@ export function createPolicyHelperBuilder(
 	return builder;
 }
 
-function createConstStatement(name: string, value: unknown): string {
+function buildConstStatement(name: string, value: unknown): string {
 	const lines = renderPhpExpression(value, 1);
 	const indent = PHP_INDENT;
 	if (lines.length === 0) {
@@ -98,7 +98,7 @@ function createPolicyEntry(
 }
 
 function createCallbackMethod(): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature:
 			'public static function callback( string $policy_key ): callable',
 		indentLevel: 1,
@@ -115,7 +115,7 @@ function createCallbackMethod(): string[] {
 }
 
 function createEnforceMethod(): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature:
 			'public static function enforce( string $policy_key, WP_REST_Request $request )',
 		indentLevel: 1,
@@ -163,7 +163,7 @@ function createEnforceMethod(): string[] {
 }
 
 function createDefinitionMethod(): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature:
 			'private static function get_definition( string $policy_key ): array',
 		indentLevel: 1,
@@ -180,7 +180,7 @@ function createDefinitionMethod(): string[] {
 }
 
 function createBindingMethod(): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature:
 			'private static function get_binding( array $definition ): ?string',
 		indentLevel: 1,
@@ -198,7 +198,7 @@ function createBindingMethod(): string[] {
 }
 
 function createErrorMethod(): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature:
 			'private static function create_error( string $code, string $message, array $context = array() ): WP_Error',
 		indentLevel: 1,

--- a/packages/cli/src/printers/php/resource-controller.ts
+++ b/packages/cli/src/printers/php/resource-controller.ts
@@ -3,7 +3,7 @@ import { appendMethodTemplates } from './builder-helpers';
 import { appendGeneratedFileDocblock } from './docblock';
 import type { PrinterContext } from '../types';
 import type { IRResource, IRRoute } from '../../ir';
-import { createMethodTemplate, PHP_INDENT } from './template';
+import { assembleMethodTemplate, PHP_INDENT } from './template';
 import { toPascalCase, escapeSingleQuotes } from './utils';
 import { buildRestArgsPayload } from './rest-args';
 import { renderPhpReturn } from './value-renderer';
@@ -42,7 +42,7 @@ export function createResourceControllerArtifact(
 	);
 
 	const methods: string[][] = [
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: 'public function get_resource_name(): string',
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -50,7 +50,7 @@ export function createResourceControllerArtifact(
 				body.line(`return '${escapeSingleQuotes(resource.name)}';`);
 			},
 		}),
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: 'public function get_schema_key(): string',
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -60,7 +60,7 @@ export function createResourceControllerArtifact(
 				);
 			},
 		}),
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: 'public function get_rest_args(): array',
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/routes.ts
+++ b/packages/cli/src/printers/php/routes.ts
@@ -2,7 +2,7 @@ import type { Reporter } from '@wpkernel/core/reporter';
 import type { IRResource, IRRoute } from '../../ir';
 import type { PrinterContext } from '../types';
 import { type PhpFileBuilder } from './builder';
-import { createMethodTemplate, PHP_INDENT } from './template';
+import { assembleMethodTemplate, PHP_INDENT } from './template';
 import { escapeSingleQuotes, toPascalCase } from './utils';
 import { createWpPostHandlers } from './wp-post';
 import { createWpTaxonomyHandlers } from './wp-taxonomy';
@@ -108,7 +108,7 @@ function createRouteStubs(options: {
 	builder.addUse('WP_REST_Request');
 
 	return routes.map((route) =>
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `public function ${createRouteMethodName(
 				route,
 				options.context

--- a/packages/cli/src/printers/php/template.ts
+++ b/packages/cli/src/printers/php/template.ts
@@ -39,7 +39,7 @@ export interface PhpMethodTemplateOptions {
 	body: (body: PhpMethodBodyBuilder) => void;
 }
 
-export function createMethodTemplate(
+export function assembleMethodTemplate(
 	options: PhpMethodTemplateOptions
 ): string[] {
 	const indentUnit = options.indentUnit ?? PHP_INDENT;

--- a/packages/cli/src/printers/php/transient.ts
+++ b/packages/cli/src/printers/php/transient.ts
@@ -1,9 +1,9 @@
 import type { IRResource, IRRoute } from '../../ir';
 import type { PrinterContext } from '../types';
 import type { PhpFileBuilder } from './builder';
-import { createMethodTemplate, PHP_INDENT } from './template';
+import { assembleMethodTemplate, PHP_INDENT } from './template';
 import {
-	createErrorCodeFactory,
+	makeErrorCodeFactory,
 	escapeSingleQuotes,
 	toPascalCase,
 	toSnakeCase,
@@ -45,7 +45,7 @@ function createContext(options: {
 	resource: IRResource;
 }): TransientContext {
 	const pascalName = toPascalCase(options.resource.name);
-	const errorCode = createErrorCodeFactory(options.resource.name);
+	const errorCode = makeErrorCodeFactory(options.resource.name);
 
 	options.builder.addUse('WP_Error');
 	options.builder.addUse('WP_REST_Request');
@@ -112,7 +112,7 @@ function createGetMethod(
 	context: TransientContext,
 	definition: RouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,
@@ -135,7 +135,7 @@ function createSetMethod(
 	context: TransientContext,
 	definition: RouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,
@@ -168,7 +168,7 @@ function createUnsupportedMethod(
 	context: TransientContext,
 	definition: RouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,
@@ -187,7 +187,7 @@ function createHelperMethods(context: TransientContext): string[][] {
 	const helpers: string[][] = [];
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function get${context.pascalName}TransientKey(): string`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -200,7 +200,7 @@ function createHelperMethods(context: TransientContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function normalise${context.pascalName}Expiration( $value ): int`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/utils.ts
+++ b/packages/cli/src/printers/php/utils.ts
@@ -46,7 +46,7 @@ export function isNonEmptyString(value: unknown): value is string {
 	return typeof value === 'string' && value.trim().length > 0;
 }
 
-export function createErrorCodeFactory(
+export function makeErrorCodeFactory(
 	resourceName: string
 ): (suffix: string) => string {
 	const base = toSnakeCase(resourceName) || 'resource';

--- a/packages/cli/src/printers/php/wp-option.ts
+++ b/packages/cli/src/printers/php/wp-option.ts
@@ -1,9 +1,9 @@
 import type { IRResource, IRRoute } from '../../ir';
 import type { PrinterContext } from '../types';
 import type { PhpFileBuilder } from './builder';
-import { createMethodTemplate, PHP_INDENT } from './template';
+import { assembleMethodTemplate, PHP_INDENT } from './template';
 import {
-	createErrorCodeFactory,
+	makeErrorCodeFactory,
 	escapeSingleQuotes,
 	toPascalCase,
 } from './utils';
@@ -48,7 +48,7 @@ function createContext(options: {
 }): WpOptionContext {
 	const storage = options.resource.storage as WpOptionStorage;
 	const pascalName = toPascalCase(options.resource.name);
-	const errorCode = createErrorCodeFactory(options.resource.name);
+	const errorCode = makeErrorCodeFactory(options.resource.name);
 
 	options.builder.addUse('WP_Error');
 	options.builder.addUse('WP_REST_Request');
@@ -108,7 +108,7 @@ function createGetMethod(
 	context: WpOptionContext,
 	definition: RouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,
@@ -133,7 +133,7 @@ function createUpdateMethod(
 	context: WpOptionContext,
 	definition: RouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,
@@ -174,7 +174,7 @@ function createUnsupportedMethod(
 	context: WpOptionContext,
 	definition: RouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,
@@ -193,7 +193,7 @@ function createHelperMethods(context: WpOptionContext): string[][] {
 	const helpers: string[][] = [];
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function get${context.pascalName}OptionName(): string`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -206,7 +206,7 @@ function createHelperMethods(context: WpOptionContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function normalise${context.pascalName}Autoload( $value ): ?string`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-post/context.ts
+++ b/packages/cli/src/printers/php/wp-post/context.ts
@@ -1,11 +1,7 @@
 import type { PrinterContext } from '../../types';
 import type { IRResource } from '../../../ir';
 import type { PhpFileBuilder } from '../builder';
-import {
-	createErrorCodeFactory,
-	isNonEmptyString,
-	toPascalCase,
-} from '../utils';
+import { makeErrorCodeFactory, isNonEmptyString, toPascalCase } from '../utils';
 import { resolveIdentityConfig } from '../identity';
 import {
 	type IdentityConfig,
@@ -68,7 +64,7 @@ export function createWpPostContext(
 	options.builder.addUse('WP_Query');
 	options.builder.addUse('WP_REST_Request');
 
-	const errorCode = createErrorCodeFactory(options.resource.name);
+	const errorCode = makeErrorCodeFactory(options.resource.name);
 
 	const titleCaseName = (): string => pascalName;
 

--- a/packages/cli/src/printers/php/wp-post/create.ts
+++ b/packages/cli/src/printers/php/wp-post/create.ts
@@ -1,5 +1,5 @@
 import {
-	createMethodTemplate,
+	assembleMethodTemplate,
 	PHP_INDENT,
 	type PhpMethodBodyBuilder,
 } from '../template';
@@ -12,7 +12,7 @@ export function createCreateMethod(
 	context: WpPostContext,
 	definition: WpPostRouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-post/delete.ts
+++ b/packages/cli/src/printers/php/wp-post/delete.ts
@@ -1,5 +1,5 @@
 import {
-	createMethodTemplate,
+	assembleMethodTemplate,
 	PHP_INDENT,
 	type PhpMethodBodyBuilder,
 } from '../template';
@@ -11,7 +11,7 @@ export function createDeleteMethod(
 	context: WpPostContext,
 	definition: WpPostRouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-post/get.ts
+++ b/packages/cli/src/printers/php/wp-post/get.ts
@@ -1,5 +1,5 @@
 import {
-	createMethodTemplate,
+	assembleMethodTemplate,
 	PHP_INDENT,
 	type PhpMethodBodyBuilder,
 } from '../template';
@@ -11,7 +11,7 @@ export function createGetMethod(
 	context: WpPostContext,
 	definition: WpPostRouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-post/helpers.ts
+++ b/packages/cli/src/printers/php/wp-post/helpers.ts
@@ -1,4 +1,4 @@
-import { createMethodTemplate, PHP_INDENT } from '../template';
+import { assembleMethodTemplate, PHP_INDENT } from '../template';
 import { escapeSingleQuotes, toSnakeCase } from '../utils';
 import type { WpPostContext } from './context';
 import { appendMetaSanitizer } from './meta';
@@ -7,7 +7,7 @@ export function createHelperMethods(context: WpPostContext): string[][] {
 	const helpers: string[][] = [];
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function get${context.pascalName}PostType(): string`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -22,7 +22,7 @@ export function createHelperMethods(context: WpPostContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function get${context.pascalName}Statuses(): array`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -41,7 +41,7 @@ export function createHelperMethods(context: WpPostContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function get${context.pascalName}DefaultStatus(): string`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -54,7 +54,7 @@ export function createHelperMethods(context: WpPostContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function normalise${context.pascalName}Status( $status ): string`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -84,7 +84,7 @@ export function createHelperMethods(context: WpPostContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function resolve${context.pascalName}Post( $identity ): ?WP_Post`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -187,7 +187,7 @@ export function createHelperMethods(context: WpPostContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function prepare${context.pascalName}Response( WP_Post $post, WP_REST_Request $request ): array`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -247,7 +247,7 @@ export function createHelperMethods(context: WpPostContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function sync${context.pascalName}Meta( int $post_id, WP_REST_Request $request ): void`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -286,7 +286,7 @@ export function createHelperMethods(context: WpPostContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function sync${context.pascalName}Taxonomies( int $post_id, WP_REST_Request $request )`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-post/list.ts
+++ b/packages/cli/src/printers/php/wp-post/list.ts
@@ -1,5 +1,5 @@
 import {
-	createMethodTemplate,
+	assembleMethodTemplate,
 	PHP_INDENT,
 	type PhpMethodBodyBuilder,
 } from '../template';
@@ -12,7 +12,7 @@ export function createListMethod(
 	context: WpPostContext,
 	definition: WpPostRouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-post/stub.ts
+++ b/packages/cli/src/printers/php/wp-post/stub.ts
@@ -1,4 +1,4 @@
-import { createMethodTemplate, PHP_INDENT } from '../template';
+import { assembleMethodTemplate, PHP_INDENT } from '../template';
 import type { WpPostContext } from './context';
 import type { WpPostRouteDefinition } from './types';
 
@@ -6,7 +6,7 @@ export function createStubMethod(
 	context: WpPostContext,
 	definition: WpPostRouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-post/update.ts
+++ b/packages/cli/src/printers/php/wp-post/update.ts
@@ -1,5 +1,5 @@
 import {
-	createMethodTemplate,
+	assembleMethodTemplate,
 	PHP_INDENT,
 	type PhpMethodBodyBuilder,
 } from '../template';
@@ -12,7 +12,7 @@ export function createUpdateMethod(
 	context: WpPostContext,
 	definition: WpPostRouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-taxonomy/context.ts
+++ b/packages/cli/src/printers/php/wp-taxonomy/context.ts
@@ -1,7 +1,7 @@
 import type { PrinterContext } from '../../types';
 import type { IRResource } from '../../../ir';
 import type { PhpFileBuilder } from '../builder';
-import { createErrorCodeFactory, toPascalCase } from '../utils';
+import { makeErrorCodeFactory, toPascalCase } from '../utils';
 import { resolveIdentityConfig } from '../identity';
 import type {
 	WpTaxonomyRouteDefinition,
@@ -22,7 +22,7 @@ export function createWpTaxonomyContext(
 	const storage = options.resource.storage as WpTaxonomyStorage;
 	const pascalName = toPascalCase(options.resource.name);
 	const identity = resolveIdentityConfig(options.resource);
-	const errorCode = createErrorCodeFactory(options.resource.name);
+	const errorCode = makeErrorCodeFactory(options.resource.name);
 
 	options.builder.addUse('WP_Error');
 	options.builder.addUse('WP_REST_Request');

--- a/packages/cli/src/printers/php/wp-taxonomy/helpers.ts
+++ b/packages/cli/src/printers/php/wp-taxonomy/helpers.ts
@@ -1,4 +1,4 @@
-import { createMethodTemplate, PHP_INDENT } from '../template';
+import { assembleMethodTemplate, PHP_INDENT } from '../template';
 import { escapeSingleQuotes } from '../utils';
 import type { WpTaxonomyContext } from './types';
 
@@ -6,7 +6,7 @@ export function createHelperMethods(context: WpTaxonomyContext): string[][] {
 	const helpers: string[][] = [];
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function get${context.pascalName}Taxonomy(): string`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -17,7 +17,7 @@ export function createHelperMethods(context: WpTaxonomyContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function prepare${context.pascalName}TermResponse( WP_Term $term ): array`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -41,7 +41,7 @@ export function createHelperMethods(context: WpTaxonomyContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function resolve${context.pascalName}Term( $identity ): ?WP_Term`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -78,7 +78,7 @@ export function createHelperMethods(context: WpTaxonomyContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function extract${context.pascalName}TermArgs( WP_REST_Request $request ): array`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,
@@ -106,7 +106,7 @@ export function createHelperMethods(context: WpTaxonomyContext): string[][] {
 	);
 
 	helpers.push(
-		createMethodTemplate({
+		assembleMethodTemplate({
 			signature: `private function validate${context.pascalName}Identity( $value )`,
 			indentLevel: 1,
 			indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-taxonomy/methods/create.ts
+++ b/packages/cli/src/printers/php/wp-taxonomy/methods/create.ts
@@ -1,4 +1,4 @@
-import { createMethodTemplate, PHP_INDENT } from '../../template';
+import { assembleMethodTemplate, PHP_INDENT } from '../../template';
 import { escapeSingleQuotes } from '../../utils';
 import type { WpTaxonomyContext, WpTaxonomyRouteDefinition } from '../types';
 
@@ -6,7 +6,7 @@ export function createCreateMethod(
 	context: WpTaxonomyContext,
 	definition: WpTaxonomyRouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-taxonomy/methods/get.ts
+++ b/packages/cli/src/printers/php/wp-taxonomy/methods/get.ts
@@ -1,4 +1,4 @@
-import { createMethodTemplate, PHP_INDENT } from '../../template';
+import { assembleMethodTemplate, PHP_INDENT } from '../../template';
 import type { WpTaxonomyContext, WpTaxonomyRouteDefinition } from '../types';
 
 export function createGetMethod(
@@ -6,7 +6,7 @@ export function createGetMethod(
 	definition: WpTaxonomyRouteDefinition
 ): string[] {
 	const identityParam = context.identity.param;
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-taxonomy/methods/list.ts
+++ b/packages/cli/src/printers/php/wp-taxonomy/methods/list.ts
@@ -1,11 +1,11 @@
-import { createMethodTemplate, PHP_INDENT } from '../../template';
+import { assembleMethodTemplate, PHP_INDENT } from '../../template';
 import type { WpTaxonomyContext, WpTaxonomyRouteDefinition } from '../types';
 
 export function createListMethod(
 	context: WpTaxonomyContext,
 	definition: WpTaxonomyRouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-taxonomy/methods/remove.ts
+++ b/packages/cli/src/printers/php/wp-taxonomy/methods/remove.ts
@@ -1,4 +1,4 @@
-import { createMethodTemplate, PHP_INDENT } from '../../template';
+import { assembleMethodTemplate, PHP_INDENT } from '../../template';
 import { escapeSingleQuotes } from '../../utils';
 import type { WpTaxonomyContext, WpTaxonomyRouteDefinition } from '../types';
 
@@ -7,7 +7,7 @@ export function createRemoveMethod(
 	definition: WpTaxonomyRouteDefinition
 ): string[] {
 	const identityParam = context.identity.param;
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-taxonomy/methods/unsupported.ts
+++ b/packages/cli/src/printers/php/wp-taxonomy/methods/unsupported.ts
@@ -1,4 +1,4 @@
-import { createMethodTemplate, PHP_INDENT } from '../../template';
+import { assembleMethodTemplate, PHP_INDENT } from '../../template';
 import { escapeSingleQuotes } from '../../utils';
 import type { WpTaxonomyContext, WpTaxonomyRouteDefinition } from '../types';
 
@@ -6,7 +6,7 @@ export function createUnsupportedMethod(
 	context: WpTaxonomyContext,
 	definition: WpTaxonomyRouteDefinition
 ): string[] {
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,

--- a/packages/cli/src/printers/php/wp-taxonomy/methods/update.ts
+++ b/packages/cli/src/printers/php/wp-taxonomy/methods/update.ts
@@ -1,4 +1,4 @@
-import { createMethodTemplate, PHP_INDENT } from '../../template';
+import { assembleMethodTemplate, PHP_INDENT } from '../../template';
 import { escapeSingleQuotes } from '../../utils';
 import type { WpTaxonomyContext, WpTaxonomyRouteDefinition } from '../types';
 
@@ -7,7 +7,7 @@ export function createUpdateMethod(
 	definition: WpTaxonomyRouteDefinition
 ): string[] {
 	const identityParam = context.identity.param;
-	return createMethodTemplate({
+	return assembleMethodTemplate({
 		signature: `public function ${definition.methodName}( WP_REST_Request $request )`,
 		indentLevel: 1,
 		indentUnit: PHP_INDENT,

--- a/packages/php-json-ast/src/__tests__/factories.wpQuery.test.ts
+++ b/packages/php-json-ast/src/__tests__/factories.wpQuery.test.ts
@@ -1,8 +1,8 @@
-import { createWpQueryInstantiation } from '../factories/wpQuery';
+import { buildWpQueryInstantiation } from '../factories/wpQuery';
 
-describe('createWpQueryInstantiation', () => {
+describe('buildWpQueryInstantiation', () => {
 	it('creates a WP_Query instantiation with default formatting', () => {
-		const printable = createWpQueryInstantiation({
+		const printable = buildWpQueryInstantiation({
 			target: 'query',
 			argsVariable: 'query_args',
 		});
@@ -20,7 +20,7 @@ describe('createWpQueryInstantiation', () => {
 	});
 
 	it('supports custom indentation and variable prefixes', () => {
-		const printable = createWpQueryInstantiation({
+		const printable = buildWpQueryInstantiation({
 			target: '$customQuery',
 			argsVariable: '$args',
 			indentLevel: 2,
@@ -41,7 +41,7 @@ describe('createWpQueryInstantiation', () => {
 
 	it('throws when provided with empty variable names', () => {
 		expect(() =>
-			createWpQueryInstantiation({ target: '', argsVariable: 'args' })
+			buildWpQueryInstantiation({ target: '', argsVariable: 'args' })
 		).toThrow('Variable name must not be empty.');
 	});
 });

--- a/packages/php-json-ast/src/__tests__/factories.wpTermQuery.test.ts
+++ b/packages/php-json-ast/src/__tests__/factories.wpTermQuery.test.ts
@@ -1,8 +1,8 @@
-import { createWpTermQueryInstantiation } from '../factories/wpTermQuery';
+import { buildWpTermQueryInstantiation } from '../factories/wpTermQuery';
 
-describe('createWpTermQueryInstantiation', () => {
+describe('buildWpTermQueryInstantiation', () => {
 	it('creates a WP_Term_Query instantiation without arguments', () => {
-		const printable = createWpTermQueryInstantiation({
+		const printable = buildWpTermQueryInstantiation({
 			target: 'term_query',
 		});
 
@@ -18,7 +18,7 @@ describe('createWpTermQueryInstantiation', () => {
 	});
 
 	it('supports constructor arguments and indentation overrides', () => {
-		const printable = createWpTermQueryInstantiation({
+		const printable = buildWpTermQueryInstantiation({
 			target: '$query',
 			argsVariable: '$args',
 			indentLevel: 1,
@@ -39,7 +39,7 @@ describe('createWpTermQueryInstantiation', () => {
 
 	it('throws when provided with an empty variable name', () => {
 		expect(() =>
-			createWpTermQueryInstantiation({ target: '', argsVariable: 'args' })
+			buildWpTermQueryInstantiation({ target: '', argsVariable: 'args' })
 		).toThrow('Variable name must not be empty.');
 	});
 });

--- a/packages/php-json-ast/src/__tests__/modernExpressions.test.ts
+++ b/packages/php-json-ast/src/__tests__/modernExpressions.test.ts
@@ -6,19 +6,19 @@ import {
 	type WorkspaceLike,
 } from '@wpkernel/php-driver';
 import {
-	createArg,
-	createArrowFunction,
-	createAssign,
-	createExpressionStatement,
-	createIdentifier,
-	createMatch,
-	createMatchArm,
-	createNullsafeMethodCall,
-	createParam,
-	createScalarInt,
-	createScalarString,
-	createThrow,
-	createVariable,
+	buildArg,
+	buildArrowFunction,
+	buildAssign,
+	buildExpressionStatement,
+	buildIdentifier,
+	buildMatch,
+	buildMatchArm,
+	buildNullsafeMethodCall,
+	buildParam,
+	buildScalarInt,
+	buildScalarString,
+	buildThrow,
+	buildVariable,
 	type PhpProgram,
 } from '../nodes';
 type Workspace = WorkspaceLike & {
@@ -119,29 +119,29 @@ describe('modern PHP expressions', () => {
 		expect(existsSync(phpBinary)).toBe(true);
 
 		const program: PhpProgram = [
-			createExpressionStatement(
-				createAssign(
-					createVariable('callback'),
-					createArrowFunction({
-						params: [createParam(createVariable('value'))],
-						expr: createMatch(createVariable('value'), [
-							createMatchArm(
-								[createScalarInt(0)],
-								createScalarString('zero')
+			buildExpressionStatement(
+				buildAssign(
+					buildVariable('callback'),
+					buildArrowFunction({
+						params: [buildParam(buildVariable('value'))],
+						expr: buildMatch(buildVariable('value'), [
+							buildMatchArm(
+								[buildScalarInt(0)],
+								buildScalarString('zero')
 							),
-							createMatchArm(null, createScalarString('other')),
+							buildMatchArm(null, buildScalarString('other')),
 						]),
 					})
 				)
 			),
-			createExpressionStatement(
-				createNullsafeMethodCall(
-					createVariable('repository'),
-					createIdentifier('find'),
-					[createArg(createScalarInt(42))]
+			buildExpressionStatement(
+				buildNullsafeMethodCall(
+					buildVariable('repository'),
+					buildIdentifier('find'),
+					[buildArg(buildScalarInt(42))]
 				)
 			),
-			createExpressionStatement(createThrow(createVariable('error'))),
+			buildExpressionStatement(buildThrow(buildVariable('error'))),
 		];
 
 		const versionCheck = spawnSync(phpBinary, ['-v'], { encoding: 'utf8' });

--- a/packages/php-json-ast/src/__tests__/nodes.base.test.ts
+++ b/packages/php-json-ast/src/__tests__/nodes.base.test.ts
@@ -1,8 +1,8 @@
 import {
-	createAttribute,
-	createAttributeGroup,
-	createName,
-	createNode,
+	buildAttribute,
+	buildAttributeGroup,
+	buildName,
+	buildNode,
 	mergeNodeAttributes,
 } from '../nodes';
 
@@ -18,7 +18,7 @@ function createTestNode(
 	value: string,
 	attributes?: Record<string, unknown>
 ): TestNode {
-	return createNode<TestNode>(TEST_NODE_TYPE, { value }, attributes);
+	return buildNode<TestNode>(TEST_NODE_TYPE, { value }, attributes);
 }
 
 describe('PHP AST node helpers', () => {
@@ -71,9 +71,9 @@ describe('PHP AST node helpers', () => {
 	});
 
 	it('creates attribute nodes through the dedicated helpers', () => {
-		const attribute = createAttribute(createName(['Example']), []);
+		const attribute = buildAttribute(buildName(['Example']), []);
 
-		const group = createAttributeGroup([attribute]);
+		const group = buildAttributeGroup([attribute]);
 
 		expect(group).toMatchObject({
 			nodeType: 'AttributeGroup',

--- a/packages/php-json-ast/src/__tests__/programBuilder.test.ts
+++ b/packages/php-json-ast/src/__tests__/programBuilder.test.ts
@@ -7,12 +7,12 @@ type BuilderOutput = any;
 import { appendClassTemplate, appendMethodTemplates } from '../append';
 import { appendGeneratedFileDocblock } from '../docblocks';
 import {
-	createClassTemplate,
-	createMethodTemplate,
+	assembleClassTemplate,
+	assembleMethodTemplate,
 	PHP_INDENT,
 } from '../templates';
 import { createPhpFileBuilder } from '../programBuilder';
-import { createIdentifier, createStmtNop } from '../nodes';
+import { buildIdentifier, buildStmtNop } from '../nodes';
 import {
 	PHP_CLASS_MODIFIER_ABSTRACT,
 	PHP_METHOD_MODIFIER_PUBLIC,
@@ -128,7 +128,7 @@ describe('programBuilder helpers', () => {
 				builder.addUse('Demo\\Contracts');
 				builder.appendStatement('// class declaration');
 
-				const method = createMethodTemplate({
+				const method = assembleMethodTemplate({
 					signature: 'public function label(): string',
 					indentLevel: 1,
 					indentUnit: PHP_INDENT,
@@ -137,18 +137,18 @@ describe('programBuilder helpers', () => {
 					},
 					ast: {
 						flags: PHP_METHOD_MODIFIER_PUBLIC,
-						returnType: createIdentifier('string'),
+						returnType: buildIdentifier('string'),
 					},
 				});
 
-				const classTemplate = createClassTemplate({
+				const classTemplate = assembleClassTemplate({
 					name: 'Example',
 					flags: PHP_CLASS_MODIFIER_ABSTRACT,
 					methods: [method],
 				});
 
 				appendClassTemplate(builder, classTemplate);
-				builder.appendProgramStatement(createStmtNop());
+				builder.appendProgramStatement(buildStmtNop());
 			},
 		});
 
@@ -202,7 +202,7 @@ describe('programBuilder helpers', () => {
 			namespace: 'Demo\\Blank',
 			metadata: { kind: 'policy-helper' },
 			build: (builder) => {
-				const first = createMethodTemplate({
+				const first = assembleMethodTemplate({
 					signature: 'public function first()',
 					indentLevel: 1,
 					body: (body) => {
@@ -214,7 +214,7 @@ describe('programBuilder helpers', () => {
 					},
 				});
 
-				const second = createMethodTemplate({
+				const second = assembleMethodTemplate({
 					signature: 'public function second()',
 					indentLevel: 1,
 					body: (body) => {
@@ -276,7 +276,7 @@ describe('programBuilder helpers', () => {
 
 				builder.appendDocblock('Example docblock');
 				builder.appendStatement('return 1;');
-				builder.appendProgramStatement(createStmtNop());
+				builder.appendProgramStatement(buildStmtNop());
 
 				const overrideMetadata: PhpFileMetadata = {
 					kind: 'base-controller',

--- a/packages/php-json-ast/src/__tests__/templates.test.ts
+++ b/packages/php-json-ast/src/__tests__/templates.test.ts
@@ -1,16 +1,16 @@
 import {
-	createClassMethod,
-	createDocComment,
-	createIdentifier,
-	createReturn,
-	createStmtNop,
+	buildClassMethod,
+	buildDocComment,
+	buildIdentifier,
+	buildReturn,
+	buildStmtNop,
 } from '../nodes';
-import { createPrintable } from '../printables';
+import { buildPrintable } from '../printables';
 import {
 	PHP_INDENT,
 	PhpMethodBodyBuilder,
-	createClassTemplate,
-	createMethodTemplate,
+	assembleClassTemplate,
+	assembleMethodTemplate,
 } from '../templates';
 import { PHP_CLASS_MODIFIER_FINAL } from '../modifiers';
 
@@ -20,12 +20,10 @@ describe('PhpMethodBodyBuilder', () => {
 		builder.line('echo 1;');
 		builder.line();
 
-		const printable = createPrintable(createStmtNop(), ['noop']);
+		const printable = buildPrintable(buildStmtNop(), ['noop']);
 		builder.statement(printable);
 
-		const returnPrintable = createPrintable(createReturn(null), [
-			'return;',
-		]);
+		const returnPrintable = buildPrintable(buildReturn(null), ['return;']);
 		builder.statement(returnPrintable, { applyIndent: true });
 
 		expect(builder.toLines()).toEqual([
@@ -38,23 +36,23 @@ describe('PhpMethodBodyBuilder', () => {
 	});
 });
 
-describe('createMethodTemplate', () => {
+describe('assembleMethodTemplate', () => {
 	it('builds method templates with docblocks and AST metadata', () => {
-		const template = createMethodTemplate({
+		const template = assembleMethodTemplate({
 			signature: 'public function example(): int',
 			indentLevel: 1,
 			docblock: ['Example description.'],
 			body: (body) => {
 				body.line('$value = 1;');
-				const printable = createPrintable(
-					createReturn(createIdentifier('value') as any),
+				const printable = buildPrintable(
+					buildReturn(buildIdentifier('value') as any),
 					['return $value;']
 				);
 				body.statement(printable, { applyIndent: true });
 			},
 			ast: {
 				name: 'example',
-				returnType: createIdentifier('int'),
+				returnType: buildIdentifier('int'),
 			},
 		});
 
@@ -73,7 +71,7 @@ describe('createMethodTemplate', () => {
 	});
 
 	it('merges docblock comments with existing attributes and custom indentation', () => {
-		const template = createMethodTemplate({
+		const template = assembleMethodTemplate({
 			signature: 'public function annotated()',
 			indentLevel: 0,
 			indentUnit: '\t',
@@ -81,7 +79,7 @@ describe('createMethodTemplate', () => {
 			body: () => undefined,
 			ast: {
 				attributes: {
-					comments: [createDocComment(['Existing comment.'])],
+					comments: [buildDocComment(['Existing comment.'])],
 				},
 			},
 		});
@@ -98,7 +96,7 @@ describe('createMethodTemplate', () => {
 	});
 
 	it('omits docblocks and body lines when none are provided', () => {
-		const template = createMethodTemplate({
+		const template = assembleMethodTemplate({
 			signature: 'public function empty()',
 			indentLevel: 0,
 			body: () => undefined,
@@ -108,27 +106,27 @@ describe('createMethodTemplate', () => {
 	});
 });
 
-describe('createClassTemplate', () => {
+describe('assembleClassTemplate', () => {
 	it('builds class templates with docblocks, inheritance, and methods', () => {
-		const method = createMethodTemplate({
+		const method = assembleMethodTemplate({
 			signature: 'public function demo()',
 			indentLevel: 1,
 			body: () => undefined,
 			ast: { name: 'demo' },
 		});
 
-		const helperNode = createClassMethod(createIdentifier('helper'));
-		const template = createClassTemplate({
+		const helperNode = buildClassMethod(buildIdentifier('helper'));
+		const template = assembleClassTemplate({
 			name: 'Sample',
 			flags: PHP_CLASS_MODIFIER_FINAL,
 			docblock: ['Class summary.'],
 			extends: '\\Vendor\\BaseClass',
 			implements: ['JsonSerializable', ['IteratorAggregate']],
 			attributes: {
-				comments: [createDocComment(['Existing class comment.'])],
+				comments: [buildDocComment(['Existing class comment.'])],
 			},
 			members: [
-				createPrintable(helperNode, [
+				buildPrintable(helperNode, [
 					'        public function helper() {}',
 				]),
 			],
@@ -154,7 +152,7 @@ describe('createClassTemplate', () => {
 	});
 
 	it('skips optional clauses when they are not provided', () => {
-		const template = createClassTemplate({
+		const template = assembleClassTemplate({
 			name: 'EmptyClass',
 			methods: [],
 			members: [],

--- a/packages/php-json-ast/src/__tests__/valueRenderers.test.ts
+++ b/packages/php-json-ast/src/__tests__/valueRenderers.test.ts
@@ -1,13 +1,13 @@
 import { KernelError } from '../KernelError';
 import {
-	createPhpReturn,
-	createPhpExpression,
+	buildPhpReturnPrintable,
+	buildPhpExpressionPrintable,
 	renderPhpReturn,
 } from '../valueRenderers';
 
 describe('valueRenderers', () => {
 	it('creates printable return statements for scalars', () => {
-		const printable = createPhpReturn('demo', 1);
+		const printable = buildPhpReturnPrintable('demo', 1);
 		expect(printable.lines).toEqual(["        return 'demo';"]);
 		expect(printable.node.expr).toMatchObject({
 			nodeType: 'Scalar_String',
@@ -18,7 +18,7 @@ describe('valueRenderers', () => {
 	});
 
 	it('renders indexed arrays with nested expressions', () => {
-		const printable = createPhpExpression([1, 'two', [false]], 0);
+		const printable = buildPhpExpressionPrintable([1, 'two', [false]], 0);
 		expect(printable.lines).toEqual([
 			'[',
 			'        1,',
@@ -32,7 +32,7 @@ describe('valueRenderers', () => {
 	});
 
 	it('renders associative arrays with escaped keys', () => {
-		const printable = createPhpExpression(
+		const printable = buildPhpExpressionPrintable(
 			{
 				label: 'demo',
 				"inner'value": { nested: null },
@@ -52,25 +52,25 @@ describe('valueRenderers', () => {
 	});
 
 	it('supports numeric and boolean scalars', () => {
-		const numeric = createPhpExpression(42, 0);
+		const numeric = buildPhpExpressionPrintable(42, 0);
 		expect(numeric.lines).toEqual(['42']);
 
-		const floating = createPhpExpression(3.14, 0);
+		const floating = buildPhpExpressionPrintable(3.14, 0);
 		expect(floating.lines).toEqual(['3.14']);
 
-		const truthy = createPhpExpression(true, 0);
+		const truthy = buildPhpExpressionPrintable(true, 0);
 		expect(truthy.lines).toEqual(['true']);
 
-		const bigintPrintable = createPhpExpression(BigInt(99), 0);
+		const bigintPrintable = buildPhpExpressionPrintable(BigInt(99), 0);
 		expect(bigintPrintable.lines).toEqual(["'99'"]);
 	});
 
 	it('throws when encountering unsupported values', () => {
-		expect(() => createPhpExpression(Symbol('demo'), 0)).toThrow(
+		expect(() => buildPhpExpressionPrintable(Symbol('demo'), 0)).toThrow(
 			KernelError
 		);
-		expect(() => createPhpExpression(Number.POSITIVE_INFINITY, 0)).toThrow(
-			KernelError
-		);
+		expect(() =>
+			buildPhpExpressionPrintable(Number.POSITIVE_INFINITY, 0)
+		).toThrow(KernelError);
 	});
 });

--- a/packages/php-json-ast/src/docblocks.ts
+++ b/packages/php-json-ast/src/docblocks.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_DOC_HEADER } from './constants';
-import { createDocComment, type PhpDocComment } from './nodes';
+import { buildDocComment, type PhpDocComment } from './nodes';
 import type { PhpAstBuilderAdapter } from './programBuilder';
 
 export function appendGeneratedFileDocblock(
@@ -15,9 +15,9 @@ export function appendGeneratedFileDocblock(
 	}
 }
 
-export function createGeneratedFileDocComment(
+export function buildGeneratedFileDocComment(
 	extraLines: Iterable<string>
 ): PhpDocComment {
 	const lines = [...DEFAULT_DOC_HEADER, ...extraLines];
-	return createDocComment(lines);
+	return buildDocComment(lines);
 }

--- a/packages/php-json-ast/src/factories/wpQuery.ts
+++ b/packages/php-json-ast/src/factories/wpQuery.ts
@@ -1,19 +1,19 @@
 import { KernelError } from '../KernelError';
 import {
-	createArg,
-	createAssign,
-	createExpressionStatement,
-	createName,
-	createNode,
-	createVariable,
+	buildArg,
+	buildAssign,
+	buildExpressionStatement,
+	buildName,
+	buildNode,
+	buildVariable,
 	type PhpExprNew,
 	type PhpStmtExpression,
 } from '../nodes';
-import { createPrintable, type PhpPrintable } from '../printables';
+import { buildPrintable, type PhpPrintable } from '../printables';
 
 const DEFAULT_INDENT_UNIT = '        ';
 
-export interface CreateWpQueryInstantiationOptions {
+export interface BuildWpQueryInstantiationOptions {
 	readonly target: string;
 	readonly argsVariable: string;
 	readonly indentLevel?: number;
@@ -48,8 +48,8 @@ function normaliseVariableName(name: string): NormalisedVariableName {
 	return { raw: trimmed, display: `$${trimmed}` };
 }
 
-export function createWpQueryInstantiation(
-	options: CreateWpQueryInstantiationOptions
+export function buildWpQueryInstantiation(
+	options: BuildWpQueryInstantiationOptions
 ): PhpPrintable<PhpStmtExpression> {
 	const indentUnit = options.indentUnit ?? DEFAULT_INDENT_UNIT;
 	const indentLevel = options.indentLevel ?? 0;
@@ -57,17 +57,17 @@ export function createWpQueryInstantiation(
 	const target = normaliseVariableName(options.target);
 	const args = normaliseVariableName(options.argsVariable);
 
-	const expression = createExpressionStatement(
-		createAssign(
-			createVariable(target.raw),
-			createNode<PhpExprNew>('Expr_New', {
-				class: createName(['WP_Query']),
-				args: [createArg(createVariable(args.raw))],
+	const expression = buildExpressionStatement(
+		buildAssign(
+			buildVariable(target.raw),
+			buildNode<PhpExprNew>('Expr_New', {
+				class: buildName(['WP_Query']),
+				args: [buildArg(buildVariable(args.raw))],
 			})
 		)
 	);
 
 	const line = `${indent}${target.display} = new WP_Query( ${args.display} );`;
 
-	return createPrintable(expression, [line]);
+	return buildPrintable(expression, [line]);
 }

--- a/packages/php-json-ast/src/factories/wpTermQuery.ts
+++ b/packages/php-json-ast/src/factories/wpTermQuery.ts
@@ -1,19 +1,19 @@
 import { KernelError } from '../KernelError';
 import {
-	createArg,
-	createAssign,
-	createExpressionStatement,
-	createName,
-	createNode,
-	createVariable,
+	buildArg,
+	buildAssign,
+	buildExpressionStatement,
+	buildName,
+	buildNode,
+	buildVariable,
 	type PhpExprNew,
 	type PhpStmtExpression,
 } from '../nodes';
-import { createPrintable, type PhpPrintable } from '../printables';
+import { buildPrintable, type PhpPrintable } from '../printables';
 
 const DEFAULT_INDENT_UNIT = '        ';
 
-export interface CreateWpTermQueryInstantiationOptions {
+export interface BuildWpTermQueryInstantiationOptions {
 	readonly target: string;
 	readonly argsVariable?: string;
 	readonly indentLevel?: number;
@@ -48,8 +48,8 @@ function normaliseVariableName(name: string): NormalisedVariableName {
 	return { raw: trimmed, display: `$${trimmed}` };
 }
 
-export function createWpTermQueryInstantiation(
-	options: CreateWpTermQueryInstantiationOptions
+export function buildWpTermQueryInstantiation(
+	options: BuildWpTermQueryInstantiationOptions
 ): PhpPrintable<PhpStmtExpression> {
 	const indentUnit = options.indentUnit ?? DEFAULT_INDENT_UNIT;
 	const indentLevel = options.indentLevel ?? 0;
@@ -60,18 +60,18 @@ export function createWpTermQueryInstantiation(
 		? normaliseVariableName(options.argsVariable)
 		: undefined;
 
-	const instantiation = createNode<PhpExprNew>('Expr_New', {
-		class: createName(['WP_Term_Query']),
-		args: args ? [createArg(createVariable(args.raw))] : [],
+	const instantiation = buildNode<PhpExprNew>('Expr_New', {
+		class: buildName(['WP_Term_Query']),
+		args: args ? [buildArg(buildVariable(args.raw))] : [],
 	});
 
-	const expression = createExpressionStatement(
-		createAssign(createVariable(target.raw), instantiation)
+	const expression = buildExpressionStatement(
+		buildAssign(buildVariable(target.raw), instantiation)
 	);
 
 	const line = args
 		? `${indent}${target.display} = new WP_Term_Query( ${args.display} );`
 		: `${indent}${target.display} = new WP_Term_Query();`;
 
-	return createPrintable(expression, [line]);
+	return buildPrintable(expression, [line]);
 }

--- a/packages/php-json-ast/src/nodes/arguments.ts
+++ b/packages/php-json-ast/src/nodes/arguments.ts
@@ -1,4 +1,4 @@
-import { createNode, type PhpAttributes, type PhpNode } from './base';
+import { buildNode, type PhpAttributes, type PhpNode } from './base';
 import type { PhpExpr } from './expressions';
 import type { PhpIdentifier } from './identifier';
 
@@ -10,7 +10,7 @@ export interface PhpArg extends PhpNode {
 	readonly name: PhpIdentifier | null;
 }
 
-export function createArg(
+export function buildArg(
 	value: PhpExpr,
 	options: {
 		byRef?: boolean;
@@ -19,7 +19,7 @@ export function createArg(
 	} = {},
 	attributes?: PhpAttributes
 ): PhpArg {
-	return createNode<PhpArg>(
+	return buildNode<PhpArg>(
 		'Arg',
 		{
 			value,

--- a/packages/php-json-ast/src/nodes/attributes.ts
+++ b/packages/php-json-ast/src/nodes/attributes.ts
@@ -1,5 +1,5 @@
 import type { PhpArg } from './arguments';
-import { createNode, type PhpAttributes, type PhpNode } from './base';
+import { buildNode, type PhpAttributes, type PhpNode } from './base';
 import type { PhpIdentifier } from './identifier';
 import type { PhpName } from './name';
 
@@ -14,17 +14,17 @@ export interface PhpAttribute extends PhpNode {
 	readonly args: PhpArg[];
 }
 
-export function createAttributeGroup(
+export function buildAttributeGroup(
 	attrs: PhpAttribute[],
 	attributes?: PhpAttributes
 ): PhpAttrGroup {
-	return createNode<PhpAttrGroup>('AttributeGroup', { attrs }, attributes);
+	return buildNode<PhpAttrGroup>('AttributeGroup', { attrs }, attributes);
 }
 
-export function createAttribute(
+export function buildAttribute(
 	name: PhpName | PhpIdentifier,
 	args: PhpArg[],
 	attributes?: PhpAttributes
 ): PhpAttribute {
-	return createNode<PhpAttribute>('Attribute', { name, args }, attributes);
+	return buildNode<PhpAttribute>('Attribute', { name, args }, attributes);
 }

--- a/packages/php-json-ast/src/nodes/base.ts
+++ b/packages/php-json-ast/src/nodes/base.ts
@@ -55,7 +55,7 @@ export function mergeNodeAttributes<T extends PhpNode>(
  * @param props
  * @param attributes
  */
-export function createNode<T extends PhpNode>(
+export function buildNode<T extends PhpNode>(
 	nodeType: T['nodeType'],
 	props: Omit<T, 'nodeType' | 'attributes'>,
 	attributes?: PhpAttributes

--- a/packages/php-json-ast/src/nodes/comments.ts
+++ b/packages/php-json-ast/src/nodes/comments.ts
@@ -14,7 +14,7 @@ export interface PhpComment extends PhpCommentLocation {
 
 export type PhpDocComment = PhpComment & { readonly nodeType: 'Comment_Doc' };
 
-export function createComment(
+export function buildComment(
 	text: string,
 	location: PhpCommentLocation = {}
 ): PhpComment {
@@ -39,7 +39,7 @@ function formatDocblockText(lines: readonly string[]): string {
 	return ['/**', body, ' */'].join('\n');
 }
 
-export function createDocComment(
+export function buildDocComment(
 	lines: readonly string[],
 	location: PhpCommentLocation = {}
 ): PhpDocComment {

--- a/packages/php-json-ast/src/nodes/const.ts
+++ b/packages/php-json-ast/src/nodes/const.ts
@@ -1,4 +1,4 @@
-import { createNode, type PhpAttributes, type PhpNode } from './base';
+import { buildNode, type PhpAttributes, type PhpNode } from './base';
 import type { PhpExpr } from './expressions';
 import type { PhpIdentifier } from './identifier';
 
@@ -8,10 +8,10 @@ export interface PhpConst extends PhpNode {
 	readonly value: PhpExpr;
 }
 
-export function createConst(
+export function buildConst(
 	name: PhpIdentifier,
 	value: PhpExpr,
 	attributes?: PhpAttributes
 ): PhpConst {
-	return createNode<PhpConst>('Const', { name, value }, attributes);
+	return buildNode<PhpConst>('Const', { name, value }, attributes);
 }

--- a/packages/php-json-ast/src/nodes/declareItem.ts
+++ b/packages/php-json-ast/src/nodes/declareItem.ts
@@ -1,6 +1,6 @@
-import { createNode, type PhpAttributes, type PhpNode } from './base';
+import { buildNode, type PhpAttributes, type PhpNode } from './base';
 import type { PhpExpr } from './expressions';
-import { createIdentifier, type PhpIdentifier } from './identifier';
+import { buildIdentifier, type PhpIdentifier } from './identifier';
 
 export interface PhpDeclareItem extends PhpNode {
 	readonly nodeType: 'DeclareItem';
@@ -8,13 +8,13 @@ export interface PhpDeclareItem extends PhpNode {
 	readonly value: PhpExpr;
 }
 
-export function createDeclareItem(
+export function buildDeclareItem(
 	key: string | PhpIdentifier,
 	value: PhpExpr,
 	attributes?: PhpAttributes
 ): PhpDeclareItem {
-	const identifier = typeof key === 'string' ? createIdentifier(key) : key;
-	return createNode<PhpDeclareItem>(
+	const identifier = typeof key === 'string' ? buildIdentifier(key) : key;
+	return buildNode<PhpDeclareItem>(
 		'DeclareItem',
 		{ key: identifier, value },
 		attributes

--- a/packages/php-json-ast/src/nodes/expressions/index.ts
+++ b/packages/php-json-ast/src/nodes/expressions/index.ts
@@ -1,8 +1,8 @@
-import { createNode, type PhpAttributes, type PhpNode } from '../base';
+import { buildNode, type PhpAttributes, type PhpNode } from '../base';
 import type { PhpArg } from '../arguments';
 import type { PhpAttrGroup } from '../attributes';
 import type { PhpIdentifier } from '../identifier';
-import { createName, type PhpName } from '../name';
+import { buildName, type PhpName } from '../name';
 import type { PhpParam } from '../params';
 import type { PhpScalar } from '../scalar';
 import type { PhpStmt } from '../stmt';
@@ -250,14 +250,14 @@ export type PhpExprCastScalar =
 	| PhpExprCastString
 	| PhpExprCastBool;
 
-export function createArray(
+export function buildArray(
 	items: PhpExprArrayItem[],
 	attributes?: PhpAttributes
 ): PhpExprArray {
-	return createNode<PhpExprArray>('Expr_Array', { items }, attributes);
+	return buildNode<PhpExprArray>('Expr_Array', { items }, attributes);
 }
 
-export function createArrayItem(
+export function buildArrayItem(
 	value: PhpExpr,
 	options: {
 		key?: PhpExpr | null;
@@ -266,7 +266,7 @@ export function createArrayItem(
 	} = {},
 	attributes?: PhpAttributes
 ): PhpExprArrayItem {
-	return createNode<PhpExprArrayItem>(
+	return buildNode<PhpExprArrayItem>(
 		'Expr_ArrayItem',
 		{
 			key: options.key ?? null,
@@ -278,170 +278,166 @@ export function createArrayItem(
 	);
 }
 
-export function createScalarBool(
+export function buildScalarBool(
 	value: boolean,
 	attributes?: PhpAttributes
 ): PhpExprConstFetch {
-	return createNode<PhpExprConstFetch>(
+	return buildNode<PhpExprConstFetch>(
 		'Expr_ConstFetch',
 		{
-			name: createName(value ? ['true'] : ['false']),
+			name: buildName(value ? ['true'] : ['false']),
 		},
 		attributes
 	);
 }
 
-export function createNull(attributes?: PhpAttributes): PhpExprConstFetch {
-	return createNode<PhpExprConstFetch>(
+export function buildNull(attributes?: PhpAttributes): PhpExprConstFetch {
+	return buildNode<PhpExprConstFetch>(
 		'Expr_ConstFetch',
 		{
-			name: createName(['null']),
+			name: buildName(['null']),
 		},
 		attributes
 	);
 }
 
-export function createVariable(
+export function buildVariable(
 	name: string | PhpExpr,
 	attributes?: PhpAttributes
 ): PhpExprVariable {
-	return createNode<PhpExprVariable>('Expr_Variable', { name }, attributes);
+	return buildNode<PhpExprVariable>('Expr_Variable', { name }, attributes);
 }
 
-export function createAssign(
+export function buildAssign(
 	variable: PhpExpr,
 	expr: PhpExpr,
 	attributes?: PhpAttributes
 ): PhpExprAssign {
-	return createNode<PhpExprAssign>(
+	return buildNode<PhpExprAssign>(
 		'Expr_Assign',
 		{ var: variable, expr },
 		attributes
 	);
 }
 
-export function createArrayDimFetch(
+export function buildArrayDimFetch(
 	variable: PhpExpr,
 	dim: PhpExpr | null,
 	attributes?: PhpAttributes
 ): PhpExprArrayDimFetch {
-	return createNode<PhpExprArrayDimFetch>(
+	return buildNode<PhpExprArrayDimFetch>(
 		'Expr_ArrayDimFetch',
 		{ var: variable, dim },
 		attributes
 	);
 }
 
-export function createMethodCall(
+export function buildMethodCall(
 	variable: PhpExpr,
 	name: PhpIdentifier | PhpExpr,
 	args: PhpArg[] = [],
 	attributes?: PhpAttributes
 ): PhpExprMethodCall {
-	return createNode<PhpExprMethodCall>(
+	return buildNode<PhpExprMethodCall>(
 		'Expr_MethodCall',
 		{ var: variable, name, args },
 		attributes
 	);
 }
 
-export function createNullsafeMethodCall(
+export function buildNullsafeMethodCall(
 	variable: PhpExpr,
 	name: PhpIdentifier | PhpExpr,
 	args: PhpArg[] = [],
 	attributes?: PhpAttributes
 ): PhpExprNullsafeMethodCall {
-	return createNode<PhpExprNullsafeMethodCall>(
+	return buildNode<PhpExprNullsafeMethodCall>(
 		'Expr_NullsafeMethodCall',
 		{ var: variable, name, args },
 		attributes
 	);
 }
 
-export function createStaticCall(
+export function buildStaticCall(
 	className: PhpName | PhpExpr,
 	name: PhpIdentifier | PhpExpr,
 	args: PhpArg[] = [],
 	attributes?: PhpAttributes
 ): PhpExprStaticCall {
-	return createNode<PhpExprStaticCall>(
+	return buildNode<PhpExprStaticCall>(
 		'Expr_StaticCall',
 		{ class: className, name, args },
 		attributes
 	);
 }
 
-export function createFuncCall(
+export function buildFuncCall(
 	name: PhpName | PhpExpr,
 	args: PhpArg[] = [],
 	attributes?: PhpAttributes
 ): PhpExprFuncCall {
-	return createNode<PhpExprFuncCall>(
+	return buildNode<PhpExprFuncCall>(
 		'Expr_FuncCall',
 		{ name, args },
 		attributes
 	);
 }
 
-export function createPropertyFetch(
+export function buildPropertyFetch(
 	variable: PhpExpr,
 	name: PhpIdentifier | PhpExpr,
 	attributes?: PhpAttributes
 ): PhpExprPropertyFetch {
-	return createNode<PhpExprPropertyFetch>(
+	return buildNode<PhpExprPropertyFetch>(
 		'Expr_PropertyFetch',
 		{ var: variable, name },
 		attributes
 	);
 }
 
-export function createNullsafePropertyFetch(
+export function buildNullsafePropertyFetch(
 	variable: PhpExpr,
 	name: PhpIdentifier | PhpExpr,
 	attributes?: PhpAttributes
 ): PhpExprNullsafePropertyFetch {
-	return createNode<PhpExprNullsafePropertyFetch>(
+	return buildNode<PhpExprNullsafePropertyFetch>(
 		'Expr_NullsafePropertyFetch',
 		{ var: variable, name },
 		attributes
 	);
 }
 
-export function createBooleanNot(
+export function buildBooleanNot(
 	expr: PhpExpr,
 	attributes?: PhpAttributes
 ): PhpExprBooleanNot {
-	return createNode<PhpExprBooleanNot>(
+	return buildNode<PhpExprBooleanNot>(
 		'Expr_BooleanNot',
 		{ expr },
 		attributes
 	);
 }
 
-export function createInstanceof(
+export function buildInstanceof(
 	expr: PhpExpr,
 	className: PhpName | PhpExpr,
 	attributes?: PhpAttributes
 ): PhpExprInstanceof {
-	return createNode<PhpExprInstanceof>(
+	return buildNode<PhpExprInstanceof>(
 		'Expr_Instanceof',
 		{ expr, class: className },
 		attributes
 	);
 }
 
-export function createArrayCast(
+export function buildArrayCast(
 	expr: PhpExpr,
 	attributes?: PhpAttributes
 ): PhpExprCastArray {
-	return createNode<PhpExprCastArray>(
-		'Expr_Cast_Array',
-		{ expr },
-		attributes
-	);
+	return buildNode<PhpExprCastArray>('Expr_Cast_Array', { expr }, attributes);
 }
 
-export function createScalarCast(
+export function buildScalarCast(
 	kind: 'int' | 'float' | 'string' | 'bool',
 	expr: PhpExpr,
 	attributes?: PhpAttributes
@@ -458,22 +454,22 @@ export function createScalarCast(
 		>
 	)[kind];
 
-	return createNode<PhpExprCastScalar>(nodeType, { expr }, attributes);
+	return buildNode<PhpExprCastScalar>(nodeType, { expr }, attributes);
 }
 
-export function createClosureUse(
+export function buildClosureUse(
 	variable: PhpExprVariable,
 	options: { byRef?: boolean } = {},
 	attributes?: PhpAttributes
 ): PhpClosureUse {
-	return createNode<PhpClosureUse>(
+	return buildNode<PhpClosureUse>(
 		'ClosureUse',
 		{ var: variable, byRef: options.byRef ?? false },
 		attributes
 	);
 }
 
-export function createClosure(
+export function buildClosure(
 	options: {
 		static?: boolean;
 		byRef?: boolean;
@@ -485,7 +481,7 @@ export function createClosure(
 	} = {},
 	attributes?: PhpAttributes
 ): PhpExprClosure {
-	return createNode<PhpExprClosure>(
+	return buildNode<PhpExprClosure>(
 		'Expr_Closure',
 		{
 			static: options.static ?? false,
@@ -500,7 +496,7 @@ export function createClosure(
 	);
 }
 
-export function createArrowFunction(
+export function buildArrowFunction(
 	options: {
 		static?: boolean;
 		byRef?: boolean;
@@ -511,7 +507,7 @@ export function createArrowFunction(
 	},
 	attributes?: PhpAttributes
 ): PhpExprArrowFunction {
-	return createNode<PhpExprArrowFunction>(
+	return buildNode<PhpExprArrowFunction>(
 		'Expr_ArrowFunction',
 		{
 			static: options.static ?? false,
@@ -525,25 +521,25 @@ export function createArrowFunction(
 	);
 }
 
-export function createMatchArm(
+export function buildMatchArm(
 	conds: PhpExpr[] | null,
 	body: PhpExpr,
 	attributes?: PhpAttributes
 ): PhpMatchArm {
-	return createNode<PhpMatchArm>('MatchArm', { conds, body }, attributes);
+	return buildNode<PhpMatchArm>('MatchArm', { conds, body }, attributes);
 }
 
-export function createMatch(
+export function buildMatch(
 	cond: PhpExpr,
 	arms: PhpMatchArm[],
 	attributes?: PhpAttributes
 ): PhpExprMatch {
-	return createNode<PhpExprMatch>('Expr_Match', { cond, arms }, attributes);
+	return buildNode<PhpExprMatch>('Expr_Match', { cond, arms }, attributes);
 }
 
-export function createThrow(
+export function buildThrow(
 	expr: PhpExpr,
 	attributes?: PhpAttributes
 ): PhpExprThrow {
-	return createNode<PhpExprThrow>('Expr_Throw', { expr }, attributes);
+	return buildNode<PhpExprThrow>('Expr_Throw', { expr }, attributes);
 }

--- a/packages/php-json-ast/src/nodes/identifier.ts
+++ b/packages/php-json-ast/src/nodes/identifier.ts
@@ -1,13 +1,13 @@
-import { createNode, type PhpAttributes, type PhpNode } from './base';
+import { buildNode, type PhpAttributes, type PhpNode } from './base';
 
 export interface PhpIdentifier extends PhpNode {
 	readonly nodeType: 'Identifier';
 	readonly name: string;
 }
 
-export function createIdentifier(
+export function buildIdentifier(
 	name: string,
 	attributes?: PhpAttributes
 ): PhpIdentifier {
-	return createNode<PhpIdentifier>('Identifier', { name }, attributes);
+	return buildNode<PhpIdentifier>('Identifier', { name }, attributes);
 }

--- a/packages/php-json-ast/src/nodes/name.ts
+++ b/packages/php-json-ast/src/nodes/name.ts
@@ -1,20 +1,20 @@
-import { createNode, type PhpAttributes, type PhpNode } from './base';
+import { buildNode, type PhpAttributes, type PhpNode } from './base';
 
 export interface PhpName extends PhpNode {
 	readonly nodeType: 'Name' | 'Name_FullyQualified' | 'Name_Relative';
 	readonly parts: string[];
 }
 
-export function createName(
+export function buildName(
 	parts: string[],
 	attributes?: PhpAttributes
 ): PhpName {
-	return createNode<PhpName>('Name', { parts }, attributes);
+	return buildNode<PhpName>('Name', { parts }, attributes);
 }
 
-export function createFullyQualifiedName(
+export function buildFullyQualifiedName(
 	parts: string[],
 	attributes?: PhpAttributes
 ): PhpName {
-	return createNode<PhpName>('Name_FullyQualified', { parts }, attributes);
+	return buildNode<PhpName>('Name_FullyQualified', { parts }, attributes);
 }

--- a/packages/php-json-ast/src/nodes/params.ts
+++ b/packages/php-json-ast/src/nodes/params.ts
@@ -1,4 +1,4 @@
-import { createNode, type PhpAttributes, type PhpNode } from './base';
+import { buildNode, type PhpAttributes, type PhpNode } from './base';
 import type { PhpAttrGroup } from './attributes';
 import type { PhpExpr } from './expressions';
 import type { PhpType } from './types';
@@ -14,7 +14,7 @@ export interface PhpParam extends PhpNode {
 	readonly attrGroups: PhpAttrGroup[];
 }
 
-export function createParam(
+export function buildParam(
 	variable: PhpExpr,
 	options: {
 		type?: PhpType | null;
@@ -26,7 +26,7 @@ export function createParam(
 	} = {},
 	attributes?: PhpAttributes
 ): PhpParam {
-	return createNode<PhpParam>(
+	return buildNode<PhpParam>(
 		'Param',
 		{
 			type: options.type ?? null,

--- a/packages/php-json-ast/src/nodes/scalar/index.ts
+++ b/packages/php-json-ast/src/nodes/scalar/index.ts
@@ -1,4 +1,4 @@
-import { createNode, type PhpAttributes, type PhpNode } from '../base';
+import { buildNode, type PhpAttributes, type PhpNode } from '../base';
 
 export interface PhpScalarBase extends PhpNode {
 	readonly nodeType: `Scalar_${string}`;
@@ -30,31 +30,23 @@ export type PhpScalar =
 	| PhpScalarMagicConst
 	| PhpScalarBase;
 
-export function createScalarString(
+export function buildScalarString(
 	value: string,
 	attributes?: PhpAttributes
 ): PhpScalarString {
-	return createNode<PhpScalarString>('Scalar_String', { value }, attributes);
+	return buildNode<PhpScalarString>('Scalar_String', { value }, attributes);
 }
 
-export function createScalarInt(
+export function buildScalarInt(
 	value: number,
 	attributes?: PhpAttributes
 ): PhpScalarLNumber {
-	return createNode<PhpScalarLNumber>(
-		'Scalar_LNumber',
-		{ value },
-		attributes
-	);
+	return buildNode<PhpScalarLNumber>('Scalar_LNumber', { value }, attributes);
 }
 
-export function createScalarFloat(
+export function buildScalarFloat(
 	value: number,
 	attributes?: PhpAttributes
 ): PhpScalarDNumber {
-	return createNode<PhpScalarDNumber>(
-		'Scalar_DNumber',
-		{ value },
-		attributes
-	);
+	return buildNode<PhpScalarDNumber>('Scalar_DNumber', { value }, attributes);
 }

--- a/packages/php-json-ast/src/nodes/stmt/index.ts
+++ b/packages/php-json-ast/src/nodes/stmt/index.ts
@@ -1,4 +1,4 @@
-import { createNode, type PhpAttributes, type PhpNode } from '../base';
+import { buildNode, type PhpAttributes, type PhpNode } from '../base';
 import type { PhpAttrGroup } from '../attributes';
 import type { PhpConst } from '../const';
 import type { PhpDeclareItem } from '../declareItem';
@@ -231,57 +231,57 @@ export type PhpStmt =
 
 export type PhpProgram = ReadonlyArray<PhpStmt>;
 
-export function createNamespace(
+export function buildNamespace(
 	name: PhpName | null,
 	stmts: PhpStmt[],
 	attributes?: PhpAttributes
 ): PhpStmtNamespace {
-	return createNode<PhpStmtNamespace>(
+	return buildNode<PhpStmtNamespace>(
 		'Stmt_Namespace',
 		{ name, stmts },
 		attributes
 	);
 }
 
-export function createStmtNop(attributes?: PhpAttributes): PhpStmtNop {
-	return createNode<PhpStmtNop>('Stmt_Nop', {}, attributes);
+export function buildStmtNop(attributes?: PhpAttributes): PhpStmtNop {
+	return buildNode<PhpStmtNop>('Stmt_Nop', {}, attributes);
 }
 
-export function createUse(
+export function buildUse(
 	type: number,
 	uses: PhpStmtUseUse[],
 	attributes?: PhpAttributes
 ): PhpStmtUse {
-	return createNode<PhpStmtUse>('Stmt_Use', { type, uses }, attributes);
+	return buildNode<PhpStmtUse>('Stmt_Use', { type, uses }, attributes);
 }
 
-export function createUseUse(
+export function buildUseUse(
 	name: PhpName,
 	alias: PhpIdentifier | null = null,
 	options: { type?: number; attributes?: PhpAttributes } = {}
 ): PhpStmtUseUse {
 	const { type = 0, attributes } = options;
-	return createNode<PhpStmtUseUse>(
+	return buildNode<PhpStmtUseUse>(
 		'Stmt_UseUse',
 		{ name, alias, type },
 		attributes
 	);
 }
 
-export function createGroupUse(
+export function buildGroupUse(
 	type: number,
 	prefix: PhpName,
 	uses: PhpStmtUseUse[],
 	attributes?: PhpAttributes
 ): PhpStmtGroupUse {
-	return createNode<PhpStmtGroupUse>(
+	return buildNode<PhpStmtGroupUse>(
 		'Stmt_GroupUse',
 		{ type, prefix, uses },
 		attributes
 	);
 }
 
-export function createClass(
+export function buildClass(
 	name: PhpIdentifier | null,
 	options: {
 		flags?: number;
@@ -293,7 +293,7 @@ export function createClass(
 	} = {},
 	attributes?: PhpAttributes
 ): PhpStmtClass {
-	return createNode<PhpStmtClass>(
+	return buildNode<PhpStmtClass>(
 		'Stmt_Class',
 		{
 			name,
@@ -308,12 +308,12 @@ export function createClass(
 	);
 }
 
-export function createDeclare(
+export function buildDeclare(
 	declares: PhpDeclareItem[],
 	options: { stmts?: PhpStmt[] | null } = {},
 	attributes?: PhpAttributes
 ): PhpStmtDeclare {
-	return createNode<PhpStmtDeclare>(
+	return buildNode<PhpStmtDeclare>(
 		'Stmt_Declare',
 		{
 			declares,
@@ -323,7 +323,7 @@ export function createDeclare(
 	);
 }
 
-export function createClassMethod(
+export function buildClassMethod(
 	name: PhpIdentifier,
 	options: {
 		byRef?: boolean;
@@ -335,7 +335,7 @@ export function createClassMethod(
 	} = {},
 	attributes?: PhpAttributes
 ): PhpStmtClassMethod {
-	return createNode<PhpStmtClassMethod>(
+	return buildNode<PhpStmtClassMethod>(
 		'Stmt_ClassMethod',
 		{
 			name,
@@ -350,25 +350,25 @@ export function createClassMethod(
 	);
 }
 
-export function createReturn(
+export function buildReturn(
 	expr: PhpExpr | null,
 	attributes?: PhpAttributes
 ): PhpStmtReturn {
-	return createNode<PhpStmtReturn>('Stmt_Return', { expr }, attributes);
+	return buildNode<PhpStmtReturn>('Stmt_Return', { expr }, attributes);
 }
 
-export function createExpressionStatement(
+export function buildExpressionStatement(
 	expr: PhpExpr,
 	attributes?: PhpAttributes
 ): PhpStmtExpression {
-	return createNode<PhpStmtExpression>(
+	return buildNode<PhpStmtExpression>(
 		'Stmt_Expression',
 		{ expr },
 		attributes
 	);
 }
 
-export function createIfStatement(
+export function buildIfStatement(
 	cond: PhpExpr,
 	stmts: PhpStmt[],
 	options: {
@@ -377,7 +377,7 @@ export function createIfStatement(
 	} = {},
 	attributes?: PhpAttributes
 ): PhpStmtIf {
-	return createNode<PhpStmtIf>(
+	return buildNode<PhpStmtIf>(
 		'Stmt_If',
 		{
 			cond,

--- a/packages/php-json-ast/src/printables.ts
+++ b/packages/php-json-ast/src/printables.ts
@@ -3,7 +3,7 @@ export interface PhpPrintable<TNode> {
 	readonly lines: readonly string[];
 }
 
-export function createPrintable<TNode>(
+export function buildPrintable<TNode>(
 	node: TNode,
 	lines: readonly string[]
 ): PhpPrintable<TNode> {

--- a/packages/php-json-ast/src/templates.ts
+++ b/packages/php-json-ast/src/templates.ts
@@ -1,10 +1,10 @@
 import {
-	createClass,
-	createClassMethod,
-	createDocComment,
-	createFullyQualifiedName,
-	createIdentifier,
-	createName,
+	buildClass,
+	buildClassMethod,
+	buildDocComment,
+	buildFullyQualifiedName,
+	buildIdentifier,
+	buildName,
 	type PhpAttrGroup,
 	type PhpAttributes,
 	type PhpName,
@@ -15,7 +15,7 @@ import {
 	type PhpClassStmt,
 	type PhpType,
 } from './nodes';
-import { createPrintable, type PhpPrintable } from './printables';
+import { buildPrintable, type PhpPrintable } from './printables';
 import { formatClassModifiers } from './modifiers';
 
 export const PHP_INDENT = '        ';
@@ -102,7 +102,7 @@ export interface PhpMethodTemplateOptions {
 	ast?: PhpMethodTemplateAstOptions;
 }
 
-export function createMethodTemplate(
+export function assembleMethodTemplate(
 	options: PhpMethodTemplateOptions
 ): PhpMethodTemplate {
 	const indentUnit = options.indentUnit ?? PHP_INDENT;
@@ -132,7 +132,7 @@ export function createMethodTemplate(
 
 	lines.push(`${indent}}`);
 
-	const methodNode = createMethodNode(options, bodyBuilder.toStatements());
+	const methodNode = buildMethodNode(options, bodyBuilder.toStatements());
 
 	const template = Object.assign([...lines], {
 		node: methodNode,
@@ -141,7 +141,7 @@ export function createMethodTemplate(
 	return template;
 }
 
-function createMethodNode(
+function buildMethodNode(
 	options: PhpMethodTemplateOptions,
 	bodyStatements: PhpStmt[]
 ): PhpStmtClassMethod {
@@ -154,8 +154,8 @@ function createMethodNode(
 		options.docblock
 	);
 
-	return createClassMethod(
-		createIdentifier(methodName),
+	return buildClassMethod(
+		buildIdentifier(methodName),
 		{
 			byRef: astOptions.byRef ?? false,
 			flags: astOptions.flags ?? 0,
@@ -176,7 +176,7 @@ function mergeAttributes(
 		return attributes;
 	}
 
-	const docComment = createDocComment(docblock);
+	const docComment = buildDocComment(docblock);
 
 	if (!attributes) {
 		return { comments: [docComment] };
@@ -224,7 +224,7 @@ export interface PhpClassTemplateOptions {
 
 export type PhpClassTemplate = PhpPrintable<PhpStmtClass>;
 
-export function createClassTemplate(
+export function assembleClassTemplate(
 	options: PhpClassTemplateOptions
 ): PhpClassTemplate {
 	const docblock = options.docblock ?? [];
@@ -238,8 +238,8 @@ export function createClassTemplate(
 		.filter((name): name is PhpName => Boolean(name));
 
 	const classMembers = options.members ?? [];
-	const classNode = createClass(
-		createIdentifier(options.name),
+	const classNode = buildClass(
+		buildIdentifier(options.name),
 		{
 			flags: options.flags ?? 0,
 			extends: extendsName,
@@ -301,7 +301,7 @@ export function createClassTemplate(
 
 	lines.push('}');
 
-	return createPrintable(classNode, lines);
+	return buildPrintable(classNode, lines);
 }
 
 function normaliseName(
@@ -324,10 +324,10 @@ function normaliseName(
 	}
 
 	if (typeof value === 'string' && value.startsWith('\\')) {
-		return createFullyQualifiedName([...parts]);
+		return buildFullyQualifiedName([...parts]);
 	}
 
-	return createName([...parts]);
+	return buildName([...parts]);
 }
 
 function formatExtendsClause(name: PhpName | null): string {

--- a/packages/php-json-ast/src/utils.ts
+++ b/packages/php-json-ast/src/utils.ts
@@ -46,7 +46,7 @@ export function isNonEmptyString(value: unknown): value is string {
 	return typeof value === 'string' && value.trim().length > 0;
 }
 
-export function createErrorCodeFactory(
+export function makeErrorCodeFactory(
 	resourceName: string
 ): (suffix: string) => string {
 	const base = toSnakeCase(resourceName) || 'resource';


### PR DESCRIPTION
## Summary
- rename the PHP JSON AST factory helpers to `build*`/`assemble*` variants and update program scaffolding to use the new names
- align CLI PHP builders, printers, and helper tests with the refreshed helper APIs so resource controllers and macros compile against the new factories

## Testing
- pnpm --filter @wpkernel/php-json-ast build
- pnpm --filter @wpkernel/php-json-ast test
- pnpm --filter @wpkernel/cli test
- jest --coverage --watchman=false

------
https://chatgpt.com/codex/tasks/task_e_68fa84543d7883259a6f3cbaa247a19f