### PR TITLE
Restore resource printer control flow formatting

### DIFF
--- a/packages/cli/src/next/builders/php/resource/__tests__/printer.test.ts
+++ b/packages/cli/src/next/builders/php/resource/__tests__/printer.test.ts
@@ -1,0 +1,172 @@
+import {
+	buildArray,
+	buildArrayItem,
+	buildArrowFunction,
+	buildBooleanNot,
+	buildReturn,
+	buildScalarInt,
+	buildScalarString,
+	buildVariable,
+	buildNode,
+	buildIfStatement,
+	buildIdentifier,
+	buildParam,
+	type PhpStmtElse,
+	type PhpStmtForeach,
+} from '@wpkernel/php-json-ast';
+import {
+	buildVariableAssignment,
+	normaliseVariableReference,
+	printStatement,
+	buildBinaryOperation,
+} from '../utils';
+import { formatInlinePhpExpression } from '../printer';
+
+describe('resource printer helpers', () => {
+	it('formats assignment statements', () => {
+		const assignment = buildVariableAssignment(
+			normaliseVariableReference('result'),
+			buildScalarInt(42)
+		);
+
+		const printable = printStatement(assignment, 0);
+		expect(printable.lines).toEqual(['$result = 42;']);
+	});
+
+	it('formats assignments to empty arrays without extra indentation', () => {
+		const assignment = buildVariableAssignment(
+			normaliseVariableReference('items'),
+			buildArray([])
+		);
+
+		const printable = printStatement(assignment, 0);
+		expect(printable.lines).toEqual(['$items = [];']);
+	});
+
+	it('formats if statements with else branches', () => {
+		const condition = buildVariable('flag');
+		const thenBranch = buildVariableAssignment(
+			normaliseVariableReference('value'),
+			buildScalarInt(1)
+		);
+		const elseBranchStmt = buildVariableAssignment(
+			normaliseVariableReference('value'),
+			buildScalarInt(0)
+		);
+
+		const elseNode = buildNode<PhpStmtElse>('Stmt_Else', {
+			stmts: [elseBranchStmt],
+		});
+
+		const ifNode = buildIfStatement(condition, [thenBranch], {
+			elseBranch: elseNode,
+		});
+
+		const printable = printStatement(ifNode, 0);
+		expect(printable.lines).toEqual([
+			'if ($flag) {',
+			'        $value = 1;',
+			'} else {',
+			'        $value = 0;',
+			'}',
+		]);
+	});
+
+	it('formats foreach loops with keyed references and blank lines', () => {
+		const guard = buildIfStatement(buildVariable('shouldSkip'), [
+			buildVariableAssignment(
+				normaliseVariableReference('value'),
+				buildScalarInt(1)
+			),
+		]);
+		const appendResult = buildVariableAssignment(
+			normaliseVariableReference('result'),
+			buildVariable('item')
+		);
+
+		const foreachNode = buildNode<PhpStmtForeach>('Stmt_Foreach', {
+			expr: buildVariable('items'),
+			keyVar: buildVariable('key'),
+			valueVar: buildVariable('item'),
+			byRef: true,
+			stmts: [guard, appendResult],
+		});
+
+		const printable = printStatement(foreachNode, 0);
+		expect(printable.lines).toEqual([
+			'foreach ( $items as $key => &$item ) {',
+			'        if ($shouldSkip) {',
+			'                $value = 1;',
+			'        }',
+			'',
+			'        $result = $item;',
+			'}',
+		]);
+	});
+
+	it('formats return statements with nested arrays', () => {
+		const arrayNode = buildArray([
+			buildArrayItem(buildScalarInt(1)),
+			buildArrayItem(buildScalarInt(2), {
+				key: buildScalarString('two'),
+			}),
+		]);
+
+		const printable = printStatement(buildReturn(arrayNode), 1);
+		expect(printable.lines).toEqual([
+			'        return [',
+			'                1,',
+			"                'two' => 2,",
+			'        ];',
+		]);
+	});
+
+	it('formats return statements without expressions', () => {
+		const printable = printStatement(buildReturn(null), 0);
+		expect(printable.lines).toEqual(['return;']);
+	});
+
+	it('formats inline arrow functions with typed parameters', () => {
+		const arrowFunction = buildArrowFunction({
+			static: true,
+			byRef: true,
+			params: [
+				buildParam(buildVariable('value'), {
+					type: buildIdentifier('int'),
+					byRef: true,
+					variadic: true,
+					default: buildScalarInt(10),
+				}),
+			],
+			expr: buildBooleanNot(
+				buildBinaryOperation(
+					'Greater',
+					buildVariable('value'),
+					buildScalarInt(0)
+				)
+			),
+		});
+
+		expect(formatInlinePhpExpression(arrowFunction)).toEqual(
+			'static fn &(int &...$value = 10) => !($value > 0)'
+		);
+	});
+
+	it('preserves binary operator precedence for grouped expressions', () => {
+		const offsetAssignment = buildVariableAssignment(
+			normaliseVariableReference('offset'),
+			buildBinaryOperation(
+				'Mul',
+				buildBinaryOperation(
+					'Minus',
+					buildVariable('page'),
+					buildScalarInt(1)
+				),
+				buildVariable('per_page')
+			)
+		);
+
+		const printable = printStatement(offsetAssignment, 0);
+		expect(printable.lines).toEqual(['$offset = ($page - 1) * $per_page;']);
+	});
+});

--- a/packages/cli/src/next/builders/php/resource/__tests__/query.test.ts
+++ b/packages/cli/src/next/builders/php/resource/__tests__/query.test.ts
@@ -36,6 +36,15 @@ describe('query helpers', () => {
 		]);
 	});
 
+	it('creates query arg assignments with no entries', () => {
+		const assignment = createQueryArgsAssignment({
+			targetVariable: 'query_args',
+			entries: [],
+		});
+
+		expect(assignment.lines).toEqual(['$query_args = [];']);
+	});
+
 	it('normalises pagination parameters', () => {
 		const [assign, ensurePositive, clamp] = createPaginationNormalisation({
 			requestVariable: '$request',
@@ -96,5 +105,14 @@ describe('query helpers', () => {
 
 		expect(printable.lines).toEqual(['$query = new WP_Query( $args );']);
 		expect(metadata.cache?.events).toHaveLength(1);
+	});
+
+	it('executes WP_Query without cache metadata when cache is omitted', () => {
+		const printable = createWpQueryExecution({
+			target: 'query',
+			argsVariable: 'args',
+		});
+
+		expect(printable.lines).toEqual(['$query = new WP_Query( $args );']);
 	});
 });

--- a/packages/cli/src/next/builders/php/resource/phpValue.ts
+++ b/packages/cli/src/next/builders/php/resource/phpValue.ts
@@ -3,8 +3,6 @@ import {
 	type PhpExpr,
 	buildPrintable,
 	type PhpPrintable,
-} from '@wpkernel/php-json-ast';
-import {
 	PHP_INDENT,
 	buildPhpExpressionPrintable,
 } from '@wpkernel/php-json-ast';
@@ -48,20 +46,18 @@ export function expression(
 
 export function renderPhpValue(
 	value: PhpValueDescriptor,
-	indentLevel: number,
-	indentUnit: string = PHP_INDENT
+	indentLevel: number
 ): PhpPrintableExpr {
 	if (isVariableDescriptor(value)) {
-		return renderVariable(value, indentLevel, indentUnit);
+		return renderVariable(value, indentLevel);
 	}
 
 	if (isExpressionDescriptor(value)) {
-		return renderExpression(value, indentLevel, indentUnit);
+		return renderExpression(value, indentLevel);
 	}
 
 	const printable = buildPhpExpressionPrintable(value, 0);
-	const lines = formatExpression(printable.node, indentLevel, indentUnit);
-	return buildPrintable(printable.node, lines);
+	return renderPrintableExpression(printable.node, indentLevel);
 }
 
 function isVariableDescriptor(
@@ -88,24 +84,24 @@ function isExpressionDescriptor(
 
 function renderVariable(
 	descriptor: VariableValueDescriptor,
-	indentLevel: number,
-	indentUnit: string
+	indentLevel: number
 ): PhpPrintableExpr {
 	const reference = normaliseVariableReference(descriptor.name);
 	const variableExpression = buildVariable(reference.raw);
-	const lines = formatExpression(variableExpression, indentLevel, indentUnit);
-	return buildPrintable(variableExpression, lines);
+	return renderPrintableExpression(variableExpression, indentLevel);
 }
 
 function renderExpression(
 	descriptor: ExpressionValueDescriptor,
-	indentLevel: number,
-	indentUnit: string
+	indentLevel: number
 ): PhpPrintableExpr {
-	const lines = formatExpression(
-		descriptor.printable.node,
-		indentLevel,
-		indentUnit
-	);
-	return buildPrintable(descriptor.printable.node, lines);
+	return renderPrintableExpression(descriptor.printable.node, indentLevel);
+}
+
+function renderPrintableExpression(
+	expr: PhpExpr,
+	indentLevel: number
+): PhpPrintableExpr {
+	const lines = formatExpression(expr, indentLevel, PHP_INDENT);
+	return buildPrintable(expr, lines);
 }

--- a/packages/cli/src/next/builders/php/resource/printer.ts
+++ b/packages/cli/src/next/builders/php/resource/printer.ts
@@ -97,6 +97,46 @@ const BINARY_OPERATOR_LABELS: Partial<Record<ExprNodeType, string>> = {
 	Expr_BinaryOp_NotIdentical: '!==',
 };
 
+const BINARY_OPERATOR_PRECEDENCE: Partial<
+	Record<PhpExprBinaryOp['nodeType'], number>
+> = {
+	Expr_BinaryOp_Mul: 6,
+	Expr_BinaryOp_Div: 6,
+	Expr_BinaryOp_Mod: 6,
+	Expr_BinaryOp_Plus: 5,
+	Expr_BinaryOp_Minus: 5,
+	Expr_BinaryOp_Smaller: 4,
+	Expr_BinaryOp_SmallerOrEqual: 4,
+	Expr_BinaryOp_Greater: 4,
+	Expr_BinaryOp_GreaterOrEqual: 4,
+	Expr_BinaryOp_Equal: 3,
+	Expr_BinaryOp_NotEqual: 3,
+	Expr_BinaryOp_Identical: 3,
+	Expr_BinaryOp_NotIdentical: 3,
+	Expr_BinaryOp_BooleanAnd: 2,
+	Expr_BinaryOp_BooleanOr: 1,
+};
+
+const REQUIRE_RIGHT_ASSOCIATIVE_PARENS: ReadonlySet<
+	PhpExprBinaryOp['nodeType']
+> = new Set([
+	'Expr_BinaryOp_Plus',
+	'Expr_BinaryOp_Minus',
+	'Expr_BinaryOp_Mul',
+	'Expr_BinaryOp_Div',
+	'Expr_BinaryOp_Mod',
+	'Expr_BinaryOp_Smaller',
+	'Expr_BinaryOp_SmallerOrEqual',
+	'Expr_BinaryOp_Greater',
+	'Expr_BinaryOp_GreaterOrEqual',
+	'Expr_BinaryOp_Equal',
+	'Expr_BinaryOp_NotEqual',
+	'Expr_BinaryOp_Identical',
+	'Expr_BinaryOp_NotIdentical',
+	'Expr_BinaryOp_BooleanAnd',
+	'Expr_BinaryOp_BooleanOr',
+]);
+
 const BOOLEAN_NOT_PAREN_NODES: ReadonlySet<ExprNodeType> = new Set([
 	'Expr_BinaryOp_Plus',
 	'Expr_BinaryOp_Minus',
@@ -347,19 +387,49 @@ function formatIfStatement(
 	const condition = formatInlineExpression(statement.cond);
 	const lines = [`${currentIndent}if (${condition}) {`];
 
-	for (let index = 0; index < statement.stmts.length; index += 1) {
-		const child = statement.stmts[index]!;
-		const formatted = formatStatement(child, indentLevel + 1, indentUnit);
-		lines.push(...formatted);
+	appendIfBranchStatements(lines, statement.stmts, indentLevel, indentUnit);
 
-		const next = statement.stmts[index + 1];
-		if (next !== undefined && shouldInsertBlankLineBetween(child, next)) {
-			lines.push('');
-		}
+	for (const elseifBranch of statement.elseifs ?? []) {
+		const elseifCondition = formatInlineExpression(elseifBranch.cond);
+		lines.push(`${currentIndent}} elseif (${elseifCondition}) {`);
+		appendIfBranchStatements(
+			lines,
+			elseifBranch.stmts,
+			indentLevel,
+			indentUnit
+		);
+	}
+
+	if (statement.else) {
+		lines.push(`${currentIndent}} else {`);
+		appendIfBranchStatements(
+			lines,
+			statement.else.stmts,
+			indentLevel,
+			indentUnit
+		);
 	}
 
 	lines.push(`${currentIndent}}`);
 	return lines;
+}
+
+function appendIfBranchStatements(
+	lines: string[],
+	statements: readonly PhpStmt[],
+	indentLevel: number,
+	indentUnit: string
+): void {
+	for (let index = 0; index < statements.length; index += 1) {
+		const child = statements[index]!;
+		const formatted = formatStatement(child, indentLevel + 1, indentUnit);
+		lines.push(...formatted);
+
+		const next = statements[index + 1];
+		if (next !== undefined && shouldInsertBlankLineBetween(child, next)) {
+			lines.push('');
+		}
+	}
 }
 
 function formatForeachStatement(
@@ -497,9 +567,20 @@ function formatIdentifierOrExpr(
 
 function formatBinaryOp(expression: PhpExprBinaryOp): string {
 	const operator = mapBinaryOperator(expression.nodeType);
-	return `${formatInlineExpression(expression.left)} ${operator} ${formatInlineExpression(
-		expression.right
-	)}`;
+	const precedence = getBinaryOperatorPrecedence(expression.nodeType);
+	const left = formatBinaryOperand(
+		expression.left,
+		precedence,
+		expression.nodeType,
+		'left'
+	);
+	const right = formatBinaryOperand(
+		expression.right,
+		precedence,
+		expression.nodeType,
+		'right'
+	);
+	return `${left} ${operator} ${right}`;
 }
 
 function mapBinaryOperator(nodeType: PhpExprBinaryOp['nodeType']): string {
@@ -507,6 +588,49 @@ function mapBinaryOperator(nodeType: PhpExprBinaryOp['nodeType']): string {
 		BINARY_OPERATOR_LABELS[nodeType] ??
 		nodeType.replace('Expr_BinaryOp_', '')
 	);
+}
+
+function getBinaryOperatorPrecedence(
+	nodeType: PhpExprBinaryOp['nodeType']
+): number {
+	const precedence = BINARY_OPERATOR_PRECEDENCE[nodeType];
+	if (precedence === undefined) {
+		throw new Error(
+			`Missing precedence mapping for binary operator: ${nodeType}`
+		);
+	}
+
+	return precedence;
+}
+
+function formatBinaryOperand(
+	operand: PhpExpr,
+	parentPrecedence: number,
+	parentType: PhpExprBinaryOp['nodeType'],
+	side: 'left' | 'right'
+): string {
+	const rendered = formatInlineExpression(operand);
+	if (!isBinaryOp(operand)) {
+		return rendered;
+	}
+
+	const childType = operand.nodeType as PhpExprBinaryOp['nodeType'];
+	const childPrecedence = getBinaryOperatorPrecedence(childType);
+	const requiresParens =
+		childPrecedence < parentPrecedence ||
+		(side === 'right' &&
+			childPrecedence === parentPrecedence &&
+			REQUIRE_RIGHT_ASSOCIATIVE_PARENS.has(parentType));
+
+	if (requiresParens) {
+		return `(${rendered})`;
+	}
+
+	return rendered;
+}
+
+function isBinaryOp(expr: PhpExpr): expr is PhpExprBinaryOp {
+	return expr.nodeType.startsWith('Expr_BinaryOp_');
 }
 
 function formatNewExpression(expr: PhpExprNew): string {

--- a/packages/cli/src/next/builders/php/resource/request.ts
+++ b/packages/cli/src/next/builders/php/resource/request.ts
@@ -1,23 +1,20 @@
 import {
 	buildArg,
-	buildAssign,
-	buildExpressionStatement,
 	buildIdentifier,
 	buildMethodCall,
 	buildScalarString,
 	buildVariable,
 	type PhpExpr,
 	type PhpStmtExpression,
-	buildPrintable,
 	type PhpPrintable,
 } from '@wpkernel/php-json-ast';
-import { PHP_INDENT } from '@wpkernel/php-json-ast';
 import {
 	buildScalarCast,
 	normaliseVariableReference,
+	buildVariableAssignment,
+	printStatement,
 	type ScalarCastKind,
 } from './utils';
-import { formatStatement } from './printer';
 
 export interface RequestParamAssignmentOptions {
 	readonly requestVariable: string;
@@ -25,7 +22,6 @@ export interface RequestParamAssignmentOptions {
 	readonly targetVariable?: string;
 	readonly cast?: ScalarCastKind;
 	readonly indentLevel?: number;
-	readonly indentUnit?: string;
 }
 
 export function createRequestParamAssignment(
@@ -37,7 +33,6 @@ export function createRequestParamAssignment(
 		targetVariable = param,
 		cast,
 		indentLevel = 0,
-		indentUnit = PHP_INDENT,
 	} = options;
 
 	const request = normaliseVariableReference(requestVariable);
@@ -52,10 +47,7 @@ export function createRequestParamAssignment(
 		? buildScalarCast(cast, methodCall)
 		: methodCall;
 
-	const assignment = buildAssign(buildVariable(target.raw), expression);
-	const statement = buildExpressionStatement(assignment);
+	const statement = buildVariableAssignment(target, expression);
 
-	const lines = formatStatement(statement, indentLevel, indentUnit);
-
-	return buildPrintable(statement, lines);
+	return printStatement(statement, indentLevel);
 }


### PR DESCRIPTION
## Summary
- render else and elseif branches from resource if statements by reusing a shared branch formatter
- guard binary operations with explicit precedence handling to preserve grouping during printing
- extend printer tests with else expectations and precedence regression coverage

## Testing
- pnpm --filter @wpkernel/cli test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68fab7ae457c832588cf821b01b241fe