### PR TITLE
Sprint ?: Resource helper AST migration

### DIFF
--- a/packages/cli/src/next/builders/php/resource/__tests__/errors.test.ts
+++ b/packages/cli/src/next/builders/php/resource/__tests__/errors.test.ts
@@ -1,20 +1,19 @@
-import { createWpErrorReturn } from '../errors';
+import { buildWpErrorReturn } from '../errors';
 
 describe('resource error helpers', () => {
 	it('renders a WP_Error return with status metadata', () => {
-		const printable = createWpErrorReturn({
-			indentLevel: 2,
+		const statement = buildWpErrorReturn({
 			code: 'demo_error',
 			message: 'Demo message.',
 			status: 418,
 		});
 
-		expect(printable.node).toMatchObject({
+		expect(statement).toMatchObject({
 			nodeType: 'Stmt_Return',
 			expr: { nodeType: 'Expr_New', class: { parts: ['WP_Error'] } },
 		});
 
-		const args = printable.node.expr?.args ?? [];
+		const args = statement.expr?.args ?? [];
 		expect(args).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({

--- a/packages/cli/src/next/builders/php/resource/errors.ts
+++ b/packages/cli/src/next/builders/php/resource/errors.ts
@@ -9,24 +9,16 @@ import {
 	buildScalarString,
 	type PhpExprNew,
 	type PhpStmtReturn,
-	type PhpPrintable,
-	PHP_INDENT,
 } from '@wpkernel/php-json-ast';
-import { formatStatementPrintable } from './printer';
 
-export interface WpErrorReturnAstOptions {
+export interface WpErrorReturnOptions {
 	readonly code: string;
 	readonly message: string;
 	readonly status?: number;
 }
 
-export interface WpErrorReturnOptions extends WpErrorReturnAstOptions {
-	readonly indentLevel: number;
-	readonly indentUnit?: string;
-}
-
 export function buildWpErrorReturn(
-	options: WpErrorReturnAstOptions
+	options: WpErrorReturnOptions
 ): PhpStmtReturn {
 	const { code, message, status = 400 } = options;
 
@@ -46,14 +38,4 @@ export function buildWpErrorReturn(
 	});
 
 	return buildReturn(errorExpr);
-}
-
-export function createWpErrorReturn(
-	options: WpErrorReturnOptions
-): PhpPrintable<PhpStmtReturn> {
-	const node = buildWpErrorReturn(options);
-	return formatStatementPrintable(node, {
-		indentLevel: options.indentLevel,
-		indentUnit: options.indentUnit ?? PHP_INDENT,
-	});
 }

--- a/packages/cli/src/next/builders/php/resource/wpTaxonomy/get.ts
+++ b/packages/cli/src/next/builders/php/resource/wpTaxonomy/get.ts
@@ -19,9 +19,9 @@ import {
 	PHP_INDENT,
 } from '@wpkernel/php-json-ast';
 import { appendResourceCacheEvent } from '../cache';
-import { createWpErrorReturn } from '../errors';
+import { buildWpErrorReturn } from '../errors';
 import { buildInstanceof, buildBooleanNot } from '../utils';
-import { buildIfPrintable } from '../printable';
+import { buildIfPrintable, printStatement } from '../printable';
 import type { IRResource } from '../../../../../ir/types';
 import type { ResolvedIdentity } from '../../identity';
 import { formatStatementPrintable } from '../printer';
@@ -111,12 +111,14 @@ export function buildWpTaxonomyGetRouteBody(
 		)
 	);
 
-	const notFoundReturn = createWpErrorReturn({
-		indentLevel: indentLevel + 1,
-		code: options.errorCodeFactory('not_found'),
-		message: `Unable to locate ${options.pascalName} term.`,
-		status: 404,
-	});
+	const notFoundReturn = printStatement(
+		buildWpErrorReturn({
+			code: options.errorCodeFactory('not_found'),
+			message: `Unable to locate ${options.pascalName} term.`,
+			status: 404,
+		}),
+		{ indentLevel: indentLevel + 1, indentUnit: PHP_INDENT }
+	);
 
 	const guard = buildIfPrintable({
 		indentLevel,

--- a/packages/cli/src/next/builders/php/resource/wpTaxonomy/helpers.ts
+++ b/packages/cli/src/next/builders/php/resource/wpTaxonomy/helpers.ts
@@ -37,8 +37,8 @@ import {
 	buildPropertyFetch,
 	buildScalarCast,
 } from '../utils';
-import { buildIfPrintable } from '../printable';
-import { createWpErrorReturn } from '../errors';
+import { buildIfPrintable, printStatement } from '../printable';
+import { buildWpErrorReturn } from '../errors';
 import { formatStatementPrintable } from '../printer';
 
 type WpTaxonomyStorage = Extract<
@@ -328,12 +328,17 @@ function createValidateIdentityHelper(
 		indentLevel,
 		indentUnit: PHP_INDENT,
 		body: (body) => {
-			const missingReturn = createWpErrorReturn({
-				indentLevel: statementIndent + 1,
-				code: errorCodeFactory('missing_identifier'),
-				message: `Missing identifier for ${pascalName}.`,
-				status: 400,
-			});
+			const missingReturn = printStatement(
+				buildWpErrorReturn({
+					code: errorCodeFactory('missing_identifier'),
+					message: `Missing identifier for ${pascalName}.`,
+					status: 400,
+				}),
+				{
+					indentLevel: statementIndent + 1,
+					indentUnit: PHP_INDENT,
+				}
+			);
 
 			body.statement(
 				buildIfPrintable({
@@ -348,12 +353,17 @@ function createValidateIdentityHelper(
 			);
 
 			if (identity.type === 'number') {
-				const invalidReturn = createWpErrorReturn({
-					indentLevel: statementIndent + 1,
-					code: errorCodeFactory('invalid_identifier'),
-					message: `Invalid identifier for ${pascalName}.`,
-					status: 400,
-				});
+				const invalidReturn = printStatement(
+					buildWpErrorReturn({
+						code: errorCodeFactory('invalid_identifier'),
+						message: `Invalid identifier for ${pascalName}.`,
+						status: 400,
+					}),
+					{
+						indentLevel: statementIndent + 1,
+						indentUnit: PHP_INDENT,
+					}
+				);
 
 				body.statement(
 					buildIfPrintable({

--- a/packages/cli/src/next/builders/php/resourceController/routes/get.ts
+++ b/packages/cli/src/next/builders/php/resourceController/routes/get.ts
@@ -19,8 +19,9 @@ import {
 	buildIdentityValidationStatements,
 	buildIfPrintable,
 	buildInstanceof,
-	createWpErrorReturn,
+	buildWpErrorReturn,
 	buildWpTaxonomyGetRouteBody,
+	printStatement,
 } from '../../resource';
 import { formatStatementPrintable } from '../../resource/printer';
 import type { ResolvedIdentity } from '../../identity';
@@ -109,12 +110,14 @@ export function buildGetRouteBody(options: BuildGetRouteBodyOptions): boolean {
 	);
 	options.body.statement(resolvePrintable);
 
-	const notFoundReturn = createWpErrorReturn({
-		indentLevel: indentLevel + 1,
-		code: options.errorCodeFactory('not_found'),
-		message: `${options.pascalName} not found.`,
-		status: 404,
-	});
+	const notFoundReturn = printStatement(
+		buildWpErrorReturn({
+			code: options.errorCodeFactory('not_found'),
+			message: `${options.pascalName} not found.`,
+			status: 404,
+		}),
+		{ indentLevel: indentLevel + 1, indentUnit: PHP_INDENT }
+	);
 
 	const notFoundIf = buildIfPrintable({
 		indentLevel,


### PR DESCRIPTION
## Summary

Sprint ?: Resource helper AST migration — return AST nodes from resource helpers.

**Sprint:** Norms (AST parity cleanup)
**Scope:** actions · policy · resource · data · reporter · ui · cli · e2e

## Links

- Roadmap section: <!-- link to the section in your docs site or repo -->
- Sprint doc / spec: <!-- link to sprint notes/spec for this PR -->
- Related issues: <!-- #123, #456 -->
- Demo/preview (if any): <!-- URL -->

## Why

String-based helpers in the PHP resource builders still emitted printable wrappers. We need the helpers to hand back AST nodes so downstream builders can operate on the structured representation instead of pre-rendered strings.

## What

- Return `PhpStmtReturn` from the resource error helper instead of printable wrappers.
- Rework the PHP value helper to build literal AST nodes directly, including recursive array/object handling.
- Update taxonomy and controller builders to format AST statements explicitly, keeping generated output stable.
- Refresh the resource error unit test to assert on returned AST node shapes.

## How

Port the helpers to rely on the `@wpkernel/php-json-ast` builders for arrays, scalars, and returns, dropping `formatStatementPrintable` usage. Immediate consumers now call `printStatement` when they require printable output, preserving their current behavior while working with native AST nodes internally.

## Testing

How reviewers test locally:

1. `pnpm --filter @wpkernel/cli test -- --runTestsByPath packages/cli/src/next/builders/php/resource/__tests__/errors.test.ts packages/cli/src/next/builders/php/resource/__tests__/phpValue.test.ts packages/cli/src/next/builders/php/resource/__tests__/query.test.ts`
   **Expected:** All three suites pass.
2. (Pre-commit) `pnpm test:coverage`
   **Expected:** Global test suite passes with coverage summary.

### Test Matrix (tick what’s covered)

- [x] Unit (pnpm test)
- [ ] E2E (pnpm e2e)
- [x] Types (pnpm typecheck)
- [ ] Docs examples (build/run)
- [ ] WordPress playground / wp-env sanity

## Screenshots / Recordings (if applicable)

_None_

## Breaking Changes

- [x] None

## Affected Packages

- [ ] `@wpkernel/core`
- [ ] `@wpkernel/ui`
- [x] `@wpkernel/cli`
- [ ] `@wpkernel/e2e-utils`

## Release

- [x] **patch** — bugfixes / alignment (0.x.1)
- [ ] **minor** — feature sprint (default) (0.x.0)
- [ ] **major** — breaking API (x.0.0)

> Update CHANGELOG.md files in affected packages with summary of changes.
> _If infra/docs-only, add label **no-release**._

## Checklist

- [x] Tests pass (`pnpm test`, where relevant: `pnpm e2e`)
- [x] Lint passes (`pnpm lint`)
- [x] Types pass (`pnpm typecheck`, `pnpm typecheck:tests`)
- [ ] CHANGELOG.md updated in affected packages (or PR labelled `no-release`)
- [ ] Docs updated (site/README)
- [ ] Examples updated (if API changed)`

------
https://chatgpt.com/codex/tasks/task_e_68fb90edeca08331bdb994eec0005ccd