### PR TITLE
Fix pretty printer script path resolution in php driver

### DIFF
--- a/packages/php-driver/src/prettyPrinter.ts
+++ b/packages/php-driver/src/prettyPrinter.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import { KernelError } from '@wpkernel/core/error';
 import type {
@@ -15,7 +16,25 @@ export interface CreatePhpPrettyPrinterOptions {
 }
 
 function resolveDefaultScriptPath(): string {
-	return path.resolve(__dirname, '..', 'php', 'pretty-print.php');
+	if (typeof __dirname === 'string') {
+		return path.resolve(__dirname, '..', 'php', 'pretty-print.php');
+	}
+
+	const moduleUrl = getImportMetaUrl();
+	if (moduleUrl) {
+		const currentDirectory = path.dirname(fileURLToPath(moduleUrl));
+		return path.resolve(currentDirectory, '..', 'php', 'pretty-print.php');
+	}
+
+	return path.resolve(process.cwd(), 'php', 'pretty-print.php');
+}
+
+function getImportMetaUrl(): string | null {
+	try {
+		return new Function('return import.meta.url;')() as string;
+	} catch {
+		return null;
+	}
 }
 
 export function buildPhpPrettyPrinter(


### PR DESCRIPTION
## Summary
- ensure the PHP pretty printer resolves its script path for both CommonJS and ESM execution
- fall back to the current working directory when neither __dirname nor import.meta are available

## Testing
- pnpm test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68fd66559de483318d5f0c65d13d175c