### PR TITLE
Task 2: Audit PHP builder helpers

### DIFF
--- a/packages/cli/docs/mvp-plan.md
+++ b/packages/cli/docs/mvp-plan.md
@@ -17,7 +17,7 @@ _See [Docs Index](./index.md) for navigation._
 | Slot  | Scope                                             | Status              | Notes                                                            |
 | ----- | ------------------------------------------------- | ------------------- | ---------------------------------------------------------------- |
 | 0.4.1 | Task 1 – Harden PHP writer helper                 | ✓ shipped (this PR) | Coverage + logging guardrails landed via writer helper tests.    |
-| 0.4.2 | Task 2 – Audit PHP builder helpers for AST purity | ⬜ available        | Verify all helpers use canonical factories + add tests.          |
+| 0.4.2 | Task 2 – Audit PHP builder helpers for AST purity | ✓ shipped (this PR) | Verify all helpers use canonical factories + add tests.          |
 | 0.4.3 | Task 3 – End-to-end generate coverage             | ⬜ available        | Use next workspace fixtures only.                                |
 | 0.4.4 | Task 4 – Driver configuration & documentation     | ⬜ available        | Update docs + exports alongside code.                            |
 | 0.4.5 | Phase 1 (wp-option parity) – AST builders land    | ⬜ available        | Implement controllers/helpers.                                   |

--- a/packages/cli/docs/pipeline-integration-tasks.md
+++ b/packages/cli/docs/pipeline-integration-tasks.md
@@ -9,7 +9,7 @@ _See [Docs Index](./index.md) for navigation._
 | Task                                                  | Reserved version | Status              | Additional checks                                                 |
 | ----------------------------------------------------- | ---------------- | ------------------- | ----------------------------------------------------------------- |
 | Task 1 – Harden Next PHP Writer Helper                | 0.4.1            | ✓ shipped (this PR) | `pnpm --filter @wpkernel/cli test -- --testPathPatterns writer`   |
-| Task 2 – Audit PHP Builder Helpers for AST Purity     | 0.4.2            | ⬜ available        | `pnpm --filter @wpkernel/cli test --testPathPattern=builders/php` |
+| Task 2 – Audit PHP Builder Helpers for AST Purity     | 0.4.2            | ✓ shipped (this PR) | `pnpm --filter @wpkernel/cli test --testPathPattern=builders/php` |
 | Task 3 – End-to-End Generate Pipeline Coverage        | 0.4.3            | ⬜ available        | `pnpm --filter @wpkernel/test-utils test`                         |
 | Task 4 – Surface Driver Configuration & Documentation | 0.4.4            | ⬜ available        | `pnpm --filter @wpkernel/php-driver test`                         |
 
@@ -32,6 +32,10 @@ Helpers under `packages/cli/src/next/builders/php/` mostly compose AST nodes via
 - Search for direct object literals (`{ kind: 'program', … }`) or `statements` imports that bypass the shared factories; update them to call `@wpkernel/php-json-ast` helpers instead.
 - Update unit tests to snapshot canonical factory output. Where fixtures relied on loose shapes, regenerate them using the updated helpers to avoid manual JSON editing.
 - Verify no helper reintroduces string-based fallbacks (e.g., `renderPhpFile`). Remove dead imports as you go so static analysis stays clean.
+
+**Completion notes**
+
+Task 2 replaces every `buildNode('Expr_*')` usage in the PHP builders with dedicated factories from `@wpkernel/php-json-ast`, adds missing helpers for `new`, ternary, foreach, continue, and nullable types, and backfills builder tests so the canonical factories stay covered. CLI helpers now consume those exports directly, eliminating bespoke AST object literals.
 
 Task 3 – End-to-End Generate Pipeline Coverage (Complexity: Medium–High)
 The next pipeline chains the PHP helpers (`packages/cli/src/next/builders/php/builder.ts:20-63`) but today’s test coverage stops at unit-level assertions for individual helpers and the writer. There is no test that runs the full `generate` phase against a mock workspace and verifies the emitted `.php`/`.ast.json` artefacts end-to-end. Standing up that integration test means assembling representative AST payloads, wiring a fake workspace that captures writes, and snapshotting both outputs while proving the legacy string printers never run. The setup and fixture work push the effort into the mid range, yet it is still achievable in a single cloud run.

--- a/packages/cli/src/next/builders/php/policy.ts
+++ b/packages/cli/src/next/builders/php/policy.ts
@@ -16,7 +16,7 @@ import {
 	buildDocComment,
 	buildIdentifier,
 	buildName,
-	buildNode,
+	buildNew,
 	buildParam,
 	buildReturn,
 	buildScalarString,
@@ -28,7 +28,6 @@ import {
 	PHP_METHOD_MODIFIER_STATIC,
 	type PhpAstBuilderAdapter,
 	type PhpAttributes,
-	type PhpExprNew,
 	type PhpStmtClassMethod,
 } from '@wpkernel/php-json-ast';
 import { renderPhpValue } from './resource/phpValue';
@@ -153,15 +152,12 @@ function buildEnforceMethod(): PhpStmtClassMethod {
 		],
 	});
 
-	const errorExpr = buildNode<PhpExprNew>('Expr_New', {
-		class: buildName(['WP_Error']),
-		args: [
-			buildArg(buildScalarString('wpk_policy_stub')),
-			buildArg(
-				buildScalarString('Policy enforcement is not yet implemented.')
-			),
-		],
-	});
+	const errorExpr = buildNew(buildName(['WP_Error']), [
+		buildArg(buildScalarString('wpk_policy_stub')),
+		buildArg(
+			buildScalarString('Policy enforcement is not yet implemented.')
+		),
+	]);
 
 	return buildClassMethod(
 		buildIdentifier('enforce'),

--- a/packages/cli/src/next/builders/php/resource/errors.ts
+++ b/packages/cli/src/next/builders/php/resource/errors.ts
@@ -5,12 +5,11 @@ import {
 	buildFuncCall,
 	buildIfStatement,
 	buildName,
-	buildNode,
+	buildNew,
 	buildReturn,
 	buildScalarInt,
 	buildScalarString,
 	type PhpExpr,
-	type PhpExprNew,
 	type PhpStmt,
 	type PhpStmtIf,
 	type PhpStmtReturn,
@@ -27,20 +26,17 @@ export function buildWpErrorReturn(
 ): PhpStmtReturn {
 	const { code, message, status = 400 } = options;
 
-	const errorExpr = buildNode<PhpExprNew>('Expr_New', {
-		class: buildName(['WP_Error']),
-		args: [
-			buildArg(buildScalarString(code)),
-			buildArg(buildScalarString(message)),
-			buildArg(
-				buildArray([
-					buildArrayItem(buildScalarInt(status), {
-						key: buildScalarString('status'),
-					}),
-				])
-			),
-		],
-	});
+	const errorExpr = buildNew(buildName(['WP_Error']), [
+		buildArg(buildScalarString(code)),
+		buildArg(buildScalarString(message)),
+		buildArg(
+			buildArray([
+				buildArrayItem(buildScalarInt(status), {
+					key: buildScalarString('status'),
+				}),
+			])
+		),
+	]);
 
 	return buildReturn(errorExpr);
 }

--- a/packages/cli/src/next/builders/php/resource/query.ts
+++ b/packages/cli/src/next/builders/php/resource/query.ts
@@ -6,12 +6,11 @@ import {
 	buildIdentifier,
 	buildMethodCall,
 	buildName,
-	buildNode,
+	buildNew,
 	buildScalarInt,
 	buildScalarString,
 	buildVariable,
 	type PhpExprBinaryOp,
-	type PhpExprNew,
 	type PhpStmtExpression,
 	type PhpStmtIf,
 	type ResourceControllerCacheOperation,
@@ -188,10 +187,9 @@ export function buildWpQueryExecutionStatement(
 
 	const targetRef = normaliseVariableReference(target);
 	const argsRef = normaliseVariableReference(argsVariable);
-	const instantiation = buildNode<PhpExprNew>('Expr_New', {
-		class: buildName(['WP_Query']),
-		args: [buildArg(buildVariable(argsRef.raw))],
-	});
+	const instantiation = buildNew(buildName(['WP_Query']), [
+		buildArg(buildVariable(argsRef.raw)),
+	]);
 
 	return buildVariableAssignment(targetRef, instantiation);
 }

--- a/packages/cli/src/next/builders/php/resource/utils.ts
+++ b/packages/cli/src/next/builders/php/resource/utils.ts
@@ -5,15 +5,16 @@ import {
 	buildArrayDimFetch as buildArrayDimFetchNode,
 	buildArrayItem,
 	buildAssign,
+	buildBinaryOperation as buildBinaryOperationNode,
 	buildBooleanNot as buildBooleanNotExpr,
 	buildExpressionStatement,
+	buildForeach,
 	buildFuncCall,
 	buildIdentifier,
 	buildIfStatement,
 	buildInstanceof as buildInstanceofExpr,
 	buildMethodCall,
 	buildName,
-	buildNode,
 	buildPropertyFetch as buildPropertyFetchNode,
 	buildReturn,
 	buildScalarCast as buildScalarCastNode,
@@ -21,8 +22,8 @@ import {
 	buildStmtNop,
 	buildVariable,
 	type PhpArg,
+	type PhpBinaryOperator,
 	type PhpExpr,
-	type PhpExprBinaryOp,
 	type PhpExprBooleanNot,
 	type PhpExprFuncCall,
 	type PhpExprMethodCall,
@@ -74,30 +75,14 @@ export function buildScalarCast(kind: ScalarCastKind, expr: PhpExpr): PhpExpr {
 	return buildScalarCastNode(kind, expr);
 }
 
-export type BinaryOperator =
-	| 'Plus'
-	| 'Minus'
-	| 'Mul'
-	| 'Div'
-	| 'Mod'
-	| 'BooleanAnd'
-	| 'BooleanOr'
-	| 'Smaller'
-	| 'SmallerOrEqual'
-	| 'Greater'
-	| 'GreaterOrEqual'
-	| 'Equal'
-	| 'NotEqual'
-	| 'Identical'
-	| 'NotIdentical';
+export type BinaryOperator = PhpBinaryOperator;
 
 export function buildBinaryOperation(
 	operator: BinaryOperator,
 	left: PhpExpr,
 	right: PhpExpr
-): PhpExprBinaryOp {
-	const nodeType = `Expr_BinaryOp_${operator}` as PhpExprBinaryOp['nodeType'];
-	return buildNode<PhpExprBinaryOp>(nodeType, { left, right });
+) {
+	return buildBinaryOperationNode(operator, left, right);
 }
 
 export interface IfStatementOptions {
@@ -284,8 +269,7 @@ export function buildForeachStatement(
 			? buildVariable(options.value)
 			: options.value;
 
-	return buildNode<PhpStmtForeach>('Stmt_Foreach', {
-		expr: options.iterable,
+	return buildForeach(options.iterable, {
 		valueVar,
 		keyVar,
 		byRef: options.byRef ?? false,

--- a/packages/cli/src/next/builders/php/resource/wpPost/list.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/list.ts
@@ -2,16 +2,16 @@ import {
 	buildArg,
 	buildArray,
 	buildAssign,
+	buildContinue,
 	buildExpressionStatement,
+	buildForeach,
 	buildFuncCall,
 	buildIdentifier,
 	buildIfStatement,
 	buildMethodCall,
 	buildName,
-	buildNode,
 	buildVariable,
 	type PhpStmt,
-	type PhpStmtContinue,
 	type PhpStmtForeach,
 } from '@wpkernel/php-json-ast';
 import {
@@ -44,9 +44,7 @@ export function buildListForeachStatement(
 		)
 	);
 
-	const continueStatement = buildNode<PhpStmtContinue>('Stmt_Continue', {
-		num: null,
-	});
+	const continueStatement = buildContinue();
 
 	const guard = buildIfStatement(
 		buildBooleanNot(buildInstanceof('post', 'WP_Post')),
@@ -67,11 +65,9 @@ export function buildListForeachStatement(
 		)
 	);
 
-	return buildNode<PhpStmtForeach>('Stmt_Foreach', {
-		expr: buildPropertyFetch('query', 'posts'),
+	return buildForeach(buildPropertyFetch('query', 'posts'), {
 		valueVar: buildVariable('post_id'),
 		keyVar: null,
-		byRef: false,
 		stmts: [assignment, guard, pushStatement],
 	});
 }

--- a/packages/cli/src/next/builders/php/resource/wpPost/mutations/helpers.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/mutations/helpers.ts
@@ -9,7 +9,7 @@ import {
 	buildIfStatement,
 	buildMethodCall,
 	buildName,
-	buildNode,
+	buildTernary as buildPhpTernary,
 	buildParam,
 	buildReturn,
 	buildScalarBool,
@@ -705,11 +705,7 @@ function buildTernary(
 	ifExpr: PhpExpr | null,
 	elseExpr: PhpExpr
 ): PhpExprTernary {
-	return buildNode<PhpExprTernary>('Expr_Ternary', {
-		cond: condition,
-		if: ifExpr,
-		else: elseExpr,
-	});
+	return buildPhpTernary(condition, ifExpr, elseExpr);
 }
 
 function variableExpr(name: string): PhpExpr {

--- a/packages/cli/src/next/builders/php/resource/wpPost/mutations/macros.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/mutations/macros.ts
@@ -8,7 +8,7 @@ import {
 	buildIfStatement,
 	buildMethodCall,
 	buildName,
-	buildNode,
+	buildNew,
 	buildReturn,
 	buildScalarInt,
 	buildScalarString,
@@ -16,7 +16,6 @@ import {
 	buildVariable,
 	buildNull,
 	type PhpExpr,
-	type PhpExprNew,
 	type PhpStmt,
 } from '@wpkernel/php-json-ast';
 import {
@@ -233,21 +232,18 @@ export function buildCachePrimingStatements(
 		)
 	);
 
-	const failureExpr = buildNode<PhpExprNew>('Expr_New', {
-		class: buildName(['WP_Error']),
-		args: [
-			buildArg(buildScalarString(options.errorCode)),
-			buildArg(buildScalarString(options.failureMessage)),
-			buildArg(
-				buildArrayLiteral([
-					{
-						key: 'status',
-						value: buildScalarInt(500),
-					},
-				])
-			),
-		],
-	});
+	const failureExpr = buildNew(buildName(['WP_Error']), [
+		buildArg(buildScalarString(options.errorCode)),
+		buildArg(buildScalarString(options.failureMessage)),
+		buildArg(
+			buildArrayLiteral([
+				{
+					key: 'status',
+					value: buildScalarInt(500),
+				},
+			])
+		),
+	]);
 	const failureGuard = buildIfStatement(
 		buildBooleanNot(buildInstanceof(postVariableName, 'WP_Post')),
 		[buildReturn(failureExpr)]

--- a/packages/cli/src/next/builders/php/resource/wpTaxonomy/helpers.ts
+++ b/packages/cli/src/next/builders/php/resource/wpTaxonomy/helpers.ts
@@ -10,7 +10,7 @@ import {
 	buildIdentifier,
 	buildMethodCall,
 	buildName,
-	buildNode,
+	buildNullableType,
 	buildParam,
 	buildReturn,
 	buildScalarBool,
@@ -20,7 +20,6 @@ import {
 	buildNull,
 	PHP_METHOD_MODIFIER_PRIVATE,
 	type PhpExprMethodCall,
-	type PhpNullableType,
 	type PhpStmt,
 	type PhpStmtClassMethod,
 	type PhpStmtExpression,
@@ -224,9 +223,7 @@ function buildResolveTermHelper(pascalName: string): TaxonomyHelperMethod {
 		{
 			flags: PHP_METHOD_MODIFIER_PRIVATE,
 			params: [buildParam(buildVariable(identityVar.raw))],
-			returnType: buildNode<PhpNullableType>('NullableType', {
-				type: buildName(['WP_Term']),
-			}),
+			returnType: buildNullableType(buildName(['WP_Term'])),
 			stmts: statements,
 		}
 	);

--- a/packages/cli/src/next/builders/php/resource/wpTaxonomy/list.ts
+++ b/packages/cli/src/next/builders/php/resource/wpTaxonomy/list.ts
@@ -4,12 +4,13 @@ import {
 	buildArray,
 	buildArrayItem,
 	buildAssign,
+	buildContinue,
 	buildExpressionStatement,
+	buildForeach,
 	buildFuncCall,
 	buildIdentifier,
 	buildMethodCall,
 	buildName,
-	buildNode,
 	buildReturn,
 	buildScalarBool,
 	buildScalarInt,
@@ -328,11 +329,9 @@ function buildExtraArgsMergeStatements(): PhpStmt[] {
 	);
 
 	statements.push(
-		buildNode<PhpStmtForeach>('Stmt_Foreach', {
-			expr: buildVariable('extra_args'),
+		buildForeach(buildVariable('extra_args'), {
 			valueVar: buildVariable('value'),
 			keyVar: buildVariable('key'),
-			byRef: false,
 			stmts: [guard, assign],
 		})
 	);
@@ -357,19 +356,15 @@ function buildResultsForeach(options: {
 		statements: [appendStatement],
 	});
 
-	return buildNode<PhpStmtForeach>('Stmt_Foreach', {
-		expr: buildVariable('results'),
+	return buildForeach(buildVariable('results'), {
 		valueVar: buildVariable('term'),
 		keyVar: null,
-		byRef: false,
 		stmts: [guard],
 	});
 }
 
 function buildContinueStatement(): PhpStmtContinue {
-	return buildNode<PhpStmtContinue>('Stmt_Continue', {
-		num: null,
-	});
+	return buildContinue();
 }
 
 function buildBlankStatement(): PhpStmt {

--- a/packages/cli/src/next/builders/php/resourceController/stubs.ts
+++ b/packages/cli/src/next/builders/php/resourceController/stubs.ts
@@ -2,12 +2,11 @@ import {
 	buildArg,
 	buildComment,
 	buildName,
-	buildNode,
+	buildNew,
 	buildReturn,
 	buildScalarInt,
 	buildScalarString,
 	buildStmtNop,
-	type PhpExprNew,
 	type PhpStmt,
 } from '@wpkernel/php-json-ast';
 import type { IRRoute } from '../../../../ir/types';
@@ -21,13 +20,10 @@ export function buildNotImplementedStatements(route: IRRoute): PhpStmt[] {
 		],
 	});
 
-	const errorExpr = buildNode<PhpExprNew>('Expr_New', {
-		class: buildName(['WP_Error']),
-		args: [
-			buildArg(buildScalarInt(501)),
-			buildArg(buildScalarString('Not Implemented')),
-		],
-	});
+	const errorExpr = buildNew(buildName(['WP_Error']), [
+		buildArg(buildScalarInt(501)),
+		buildArg(buildScalarString('Not Implemented')),
+	]);
 
 	const returnStatement = buildReturn(errorExpr);
 

--- a/packages/php-json-ast/src/__tests__/nodes.builders.test.ts
+++ b/packages/php-json-ast/src/__tests__/nodes.builders.test.ts
@@ -1,0 +1,90 @@
+import {
+	buildArg,
+	buildBinaryOperation,
+	buildContinue,
+	buildForeach,
+	buildIdentifier,
+	buildName,
+	buildNew,
+	buildNullableType,
+	buildScalarInt,
+	buildScalarString,
+	buildTernary,
+	buildVariable,
+} from '../nodes';
+
+describe('node builders', () => {
+	it('builds new expressions', () => {
+		const expr = buildNew(buildName(['WP_Query']), [
+			buildArg(buildVariable('args')),
+		]);
+
+		expect(expr).toMatchObject({
+			nodeType: 'Expr_New',
+			class: { parts: ['WP_Query'] },
+		});
+		expect(expr.args).toHaveLength(1);
+	});
+
+	it('builds binary operations with canonical node types', () => {
+		const operation = buildBinaryOperation(
+			'Greater',
+			buildVariable('count'),
+			buildScalarInt(0)
+		);
+
+		expect(operation).toMatchObject({
+			nodeType: 'Expr_BinaryOp_Greater',
+			left: { nodeType: 'Expr_Variable', name: 'count' },
+			right: { nodeType: 'Scalar_LNumber', value: 0 },
+		});
+	});
+
+	it('builds ternary expressions', () => {
+		const ternary = buildTernary(
+			buildVariable('condition'),
+			buildScalarString('if'),
+			buildScalarString('else')
+		);
+
+		expect(ternary).toMatchObject({
+			nodeType: 'Expr_Ternary',
+			cond: { nodeType: 'Expr_Variable', name: 'condition' },
+			if: { nodeType: 'Scalar_String', value: 'if' },
+			else: { nodeType: 'Scalar_String', value: 'else' },
+		});
+	});
+
+	it('builds foreach statements', () => {
+		const foreach = buildForeach(buildVariable('items'), {
+			valueVar: buildVariable('item'),
+			keyVar: buildVariable('key'),
+			stmts: [
+				buildForeach(buildVariable('nested'), {
+					valueVar: buildVariable('entry'),
+					stmts: [],
+				}),
+			],
+		});
+
+		expect(foreach).toMatchObject({
+			nodeType: 'Stmt_Foreach',
+			keyVar: { nodeType: 'Expr_Variable', name: 'key' },
+			valueVar: { nodeType: 'Expr_Variable', name: 'item' },
+		});
+		expect(foreach.stmts).toHaveLength(1);
+	});
+
+	it('builds continue statements', () => {
+		const stmt = buildContinue();
+		expect(stmt).toMatchObject({ nodeType: 'Stmt_Continue', num: null });
+	});
+
+	it('builds nullable types', () => {
+		const type = buildNullableType(buildIdentifier('string'));
+		expect(type).toMatchObject({
+			nodeType: 'NullableType',
+			type: { nodeType: 'Identifier', name: 'string' },
+		});
+	});
+});

--- a/packages/php-json-ast/src/nodes/expressions/index.ts
+++ b/packages/php-json-ast/src/nodes/expressions/index.ts
@@ -383,6 +383,18 @@ export function buildFuncCall(
 	);
 }
 
+export function buildNew(
+	className: PhpName | PhpExpr,
+	args: PhpArg[] = [],
+	attributes?: PhpAttributes
+): PhpExprNew {
+	return buildNode<PhpExprNew>(
+		'Expr_New',
+		{ class: className, args },
+		attributes
+	);
+}
+
 export function buildPropertyFetch(
 	variable: PhpExpr,
 	name: PhpIdentifier | PhpExpr,
@@ -416,6 +428,33 @@ export function buildBooleanNot(
 		{ expr },
 		attributes
 	);
+}
+
+export type PhpBinaryOperator =
+	| 'Plus'
+	| 'Minus'
+	| 'Mul'
+	| 'Div'
+	| 'Mod'
+	| 'BooleanAnd'
+	| 'BooleanOr'
+	| 'Smaller'
+	| 'SmallerOrEqual'
+	| 'Greater'
+	| 'GreaterOrEqual'
+	| 'Equal'
+	| 'NotEqual'
+	| 'Identical'
+	| 'NotIdentical';
+
+export function buildBinaryOperation(
+	operator: PhpBinaryOperator,
+	left: PhpExpr,
+	right: PhpExpr,
+	attributes?: PhpAttributes
+): PhpExprBinaryOp {
+	const nodeType = `Expr_BinaryOp_${operator}` as PhpExprBinaryOp['nodeType'];
+	return buildNode<PhpExprBinaryOp>(nodeType, { left, right }, attributes);
 }
 
 export function buildInstanceof(
@@ -517,6 +556,19 @@ export function buildArrowFunction(
 			expr: options.expr,
 			attrGroups: options.attrGroups ?? [],
 		},
+		attributes
+	);
+}
+
+export function buildTernary(
+	cond: PhpExpr,
+	ifExpr: PhpExpr | null,
+	elseExpr: PhpExpr,
+	attributes?: PhpAttributes
+): PhpExprTernary {
+	return buildNode<PhpExprTernary>(
+		'Expr_Ternary',
+		{ cond, if: ifExpr, else: elseExpr },
 		attributes
 	);
 }

--- a/packages/php-json-ast/src/nodes/stmt/index.ts
+++ b/packages/php-json-ast/src/nodes/stmt/index.ts
@@ -388,3 +388,33 @@ export function buildIfStatement(
 		attributes
 	);
 }
+
+export function buildForeach(
+	expr: PhpExpr,
+	options: {
+		valueVar: PhpExpr;
+		keyVar?: PhpExpr | null;
+		byRef?: boolean;
+		stmts?: PhpStmt[];
+	},
+	attributes?: PhpAttributes
+): PhpStmtForeach {
+	return buildNode<PhpStmtForeach>(
+		'Stmt_Foreach',
+		{
+			expr,
+			valueVar: options.valueVar,
+			keyVar: options.keyVar ?? null,
+			byRef: options.byRef ?? false,
+			stmts: options.stmts ?? [],
+		},
+		attributes
+	);
+}
+
+export function buildContinue(
+	num: PhpExpr | null = null,
+	attributes?: PhpAttributes
+): PhpStmtContinue {
+	return buildNode<PhpStmtContinue>('Stmt_Continue', { num }, attributes);
+}

--- a/packages/php-json-ast/src/nodes/types.ts
+++ b/packages/php-json-ast/src/nodes/types.ts
@@ -1,4 +1,4 @@
-import type { PhpNode } from './base';
+import { buildNode, type PhpAttributes, type PhpNode } from './base';
 import type { PhpIdentifier } from './identifier';
 import type { PhpName } from './name';
 
@@ -23,3 +23,10 @@ export type PhpType =
 	| PhpNullableType
 	| PhpUnionType
 	| PhpIntersectionType;
+
+export function buildNullableType(
+	type: PhpType,
+	attributes?: PhpAttributes
+): PhpNullableType {
+	return buildNode<PhpNullableType>('NullableType', { type }, attributes);
+}


### PR DESCRIPTION
## Summary
Task 2: Audit PHP builder helpers — canonical factories, docs, and coverage

**Task IDs:** 2
**Scope:** policy · resource · cli · docs

## Links

- Roadmap section: [Pipeline Integration Tasks](packages/cli/docs/pipeline-integration-tasks.md#task2--audit-php-builder-helpers-for-ast-purity)
- Sprint doc / spec: [CLI MVP Plan](packages/cli/docs/mvp-plan.md#reserved-version-ledger-04x-cycle--before-phase1-minor)
- Related issues: n/a
- Demo/preview (if any): n/a

## Why

Ad-hoc `buildNode('Expr_*')` usage in the next PHP builders made it easy to drift from the canonical AST schema. Shipping dedicated helpers in `@wpkernel/php-json-ast` and swapping the CLI builders to them keeps the pipeline honest and simplifies future audits.

## What

- Added canonical factories for `new`, ternary, foreach, continue, nullable types, and binary ops in `@wpkernel/php-json-ast`, plus regression tests.
- Updated all CLI PHP builders to consume the new helpers instead of hand-built AST node objects.
- Marked Task 2 as shipped in the CLI docs with completion notes covering the helper and test refresh.

## How

Extended the PHP JSON AST surface with new builders, exported them through the CLI helper layer, and replaced every remaining `buildNode('Expr_*')` call with the canonical factories. Documentation now reflects the completed audit and the missing helpers are covered by dedicated unit tests.

## Testing

How reviewers test locally:

1. `pnpm --filter @wpkernel/cli lint`
2. `pnpm --filter @wpkernel/cli typecheck`
3. `pnpm --filter @wpkernel/cli typecheck:tests`
4. `pnpm test:coverage`
   **Expected:** All commands complete without errors.

### Test Matrix (tick what’s covered)

- [x] Unit (pnpm test)
- [ ] E2E (pnpm e2e)
- [x] Types (pnpm typecheck)
- [ ] Docs examples (build/run)
- [ ] WordPress playground / wp-env sanity

## Screenshots / Recordings (if applicable)

n/a

## Breaking Changes

- [x] None

## Affected Packages

Tick any public packages this PR changes functionally.

- [ ] `@wpkernel/core`
- [ ] `@wpkernel/ui`
- [x] `@wpkernel/cli`
- [ ] `@wpkernel/e2e-utils`
- [ ] `@wpkernel/php-driver`
- [x] `@wpkernel/php-json-ast`
- [ ] `@wpkernel/test-utils`

## Release

Choose one and document in CHANGELOG.md files.

- [x] **patch** — bugfixes / alignment (0.x.1)
- [ ] **minor** — feature sprint (default) (0.x.0)
- [ ] **major** — breaking API (x.0.0)

> Update CHANGELOG.md files in affected packages with summary of changes.
> 
> _If infra/docs-only, add label **no-release**._

## Checklist

- [x] No string-based generator was introduced or wrapped (PHP/blocks emitters remain AST-first).
- [x] Tests pass (`pnpm test`, where relevant: `pnpm e2e`)
- [x] Lint passes (`pnpm lint`)
- [x] Types pass (`pnpm typecheck`, `pnpm typecheck:tests`)
- [ ] CHANGELOG.md updated in affected packages (or PR labelled `no-release`)
- [x] Docs updated (site/README)
- [ ] Examples updated (if API changed)
- [x] Documentation under `packages/cli/docs/` (index, migration phases, tasks) updated if behaviour changed.