### PR TITLE
Enhance pipeline rollback diagnostics

### DIFF
--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -16,6 +16,7 @@ export type {
 	PipelineExtensionHook,
 	PipelineExtensionHookOptions,
 	PipelineExtensionHookResult,
+	PipelineExtensionRollbackErrorMetadata,
 	PipelineRunState,
 	PipelineStep,
 	CreatePipelineOptions,

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -121,6 +121,13 @@ export interface PipelineExtensionHookResult<TArtifact> {
 	readonly rollback?: () => Promise<void>;
 }
 
+export interface PipelineExtensionRollbackErrorMetadata {
+	readonly name?: string;
+	readonly message?: string;
+	readonly stack?: string;
+	readonly cause?: unknown;
+}
+
 export type PipelineExtensionHook<TContext, TOptions, TArtifact> = (
 	options: PipelineExtensionHookOptions<TContext, TOptions, TArtifact>
 ) => Promise<PipelineExtensionHookResult<TArtifact> | void>;
@@ -233,6 +240,8 @@ export interface CreatePipelineOptions<
 	readonly onExtensionRollbackError?: (options: {
 		readonly error: unknown;
 		readonly extensionKeys: readonly string[];
+		readonly hookSequence: readonly string[];
+		readonly errorMetadata: PipelineExtensionRollbackErrorMetadata;
 		readonly context: TContext;
 	}) => void;
 	readonly createConflictDiagnostic?: (options: {


### PR DESCRIPTION
## Summary
- include error metadata and hook sequence when pipeline extension rollbacks fail
- surface the enriched rollback payload to custom handlers
- add reporter-driven tests that assert the rollback payload contents

## Testing
- pnpm --filter @wpkernel/core test
- pnpm typecheck
- pnpm typecheck:tests

------
https://chatgpt.com/codex/tasks/task_e_68fe588ac5ec8331b3e017615d4b047e