### PR TITLE
Bug 6: Enforce pipeline finalization invariants

### DIFF
--- a/packages/cli/src/next/ir/__tests__/finalizeIrDraft.test.ts
+++ b/packages/cli/src/next/ir/__tests__/finalizeIrDraft.test.ts
@@ -1,0 +1,96 @@
+import { finalizeIrDraft, buildIrDraft, type MutableIr } from '../types';
+import { KernelError } from '@wpkernel/core/error';
+import type { FragmentFinalizationMetadata } from '@wpkernel/core/pipeline';
+import { makeKernelConfigFixture } from '@wpkernel/test-utils/next/printers.test-support';
+
+function createHelpersMetadata(
+	executed: readonly string[],
+	missing: readonly string[]
+): FragmentFinalizationMetadata<'fragment'> {
+	return {
+		fragments: {
+			kind: 'fragment',
+			registered: Array.from(new Set([...executed, ...missing])),
+			executed: [...executed],
+			missing: [...missing],
+		},
+	};
+}
+
+function buildDraft(): MutableIr {
+	const config = makeKernelConfigFixture();
+	const draft = buildIrDraft({
+		config,
+		namespace: config.namespace,
+		origin: 'typescript',
+		sourcePath: '/tmp/kernel.config.ts',
+	});
+
+	draft.meta = {
+		version: 1,
+		namespace: config.namespace,
+		sourcePath: '/tmp/kernel.config.ts',
+		origin: 'typescript',
+		sanitizedNamespace: 'TestNamespace',
+	};
+	draft.policyMap = {
+		sourcePath: undefined,
+		definitions: [],
+		fallback: {
+			capability: 'manage_options',
+			appliesTo: 'object',
+		},
+		missing: [],
+		unused: [],
+		warnings: [],
+	};
+	draft.php = {
+		namespace: 'TestNamespace',
+		autoload: 'inc/',
+		outputDir: '.generated/php',
+	};
+
+	return draft;
+}
+
+describe('finalizeIrDraft', () => {
+	const REQUIRED = [
+		'ir.meta.core',
+		'ir.schemas.core',
+		'ir.resources.core',
+		'ir.policies.core',
+		'ir.policy-map.core',
+		'ir.diagnostics.core',
+		'ir.blocks.core',
+		'ir.ordering.core',
+		'ir.validation.core',
+	] as const;
+
+	it('returns a completed IR when all core fragments executed', () => {
+		const draft = buildDraft();
+		const helpers = createHelpersMetadata(REQUIRED, []);
+
+		const ir = finalizeIrDraft(draft, helpers);
+
+		expect(ir.meta.namespace).toBe(draft.meta!.namespace);
+		expect(ir.policyMap).toBe(draft.policyMap);
+		expect(ir.php).toBe(draft.php);
+	});
+
+	it('throws when any required fragment did not execute', () => {
+		const draft = buildDraft();
+		const helpers = createHelpersMetadata(
+			REQUIRED.filter((key) => key !== 'ir.policy-map.core'),
+			['ir.policy-map.core']
+		);
+
+		expect(() => finalizeIrDraft(draft, helpers)).toThrow(KernelError);
+	});
+
+	it('throws when metadata reports missing fragments even if executed list contains them', () => {
+		const draft = buildDraft();
+		const helpers = createHelpersMetadata(REQUIRED, ['ir.resources.core']);
+
+		expect(() => finalizeIrDraft(draft, helpers)).toThrow(KernelError);
+	});
+});

--- a/packages/cli/src/next/runtime/createPipeline.ts
+++ b/packages/cli/src/next/runtime/createPipeline.ts
@@ -83,8 +83,8 @@ export function createPipeline(): Pipeline {
 				reporter: context.reporter,
 			} satisfies Parameters<FragmentHelper['apply']>[0];
 		},
-		finalizeFragmentState({ draft }) {
-			return finalizeIrDraft(draft);
+		finalizeFragmentState({ draft, helpers }) {
+			return finalizeIrDraft(draft, helpers);
 		},
 		createBuilderArgs({ context, buildOptions, artifact }) {
 			return {

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -21,4 +21,7 @@ export type {
 	PipelineStep,
 	CreatePipelineOptions,
 	ConflictDiagnostic,
+	HelperExecutionSnapshot,
+	FragmentFinalizationMetadata,
+	PipelineExecutionMetadata,
 } from './types';

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -109,6 +109,28 @@ export interface PipelineRunState<
 	readonly steps: readonly PipelineStep[];
 }
 
+export interface HelperExecutionSnapshot<
+	TKind extends HelperKind = HelperKind,
+> {
+	readonly kind: TKind;
+	readonly registered: readonly string[];
+	readonly executed: readonly string[];
+	readonly missing: readonly string[];
+}
+
+export interface FragmentFinalizationMetadata<
+	TFragmentKind extends HelperKind = HelperKind,
+> {
+	readonly fragments: HelperExecutionSnapshot<TFragmentKind>;
+}
+
+export interface PipelineExecutionMetadata<
+	TFragmentKind extends HelperKind = HelperKind,
+	TBuilderKind extends HelperKind = HelperKind,
+> extends FragmentFinalizationMetadata<TFragmentKind> {
+	readonly builders: HelperExecutionSnapshot<TBuilderKind>;
+}
+
 export interface PipelineExtensionHookOptions<TContext, TOptions, TArtifact> {
 	readonly context: TContext;
 	readonly options: TOptions;
@@ -210,6 +232,7 @@ export interface CreatePipelineOptions<
 		readonly options: TRunOptions;
 		readonly context: TContext;
 		readonly buildOptions: TBuildOptions;
+		readonly helpers: FragmentFinalizationMetadata<TFragmentKind>;
 	}) => TArtifact;
 	readonly createBuilderArgs: (options: {
 		readonly helper: TBuilderHelper;
@@ -230,6 +253,10 @@ export interface CreatePipelineOptions<
 		readonly context: TContext;
 		readonly buildOptions: TBuildOptions;
 		readonly options: TRunOptions;
+		readonly helpers: PipelineExecutionMetadata<
+			TFragmentKind,
+			TBuilderKind
+		>;
 	}) => TRunResult;
 	readonly createExtensionHookOptions?: (options: {
 		readonly context: TContext;


### PR DESCRIPTION
## Summary
Bug 6: Enforce pipeline finalization invariants — pipeline metadata snapshots and IR coverage checks.

**Task IDs:** 6
**Scope:** core · cli

## Links

- Roadmap section: N/A
- Sprint doc / spec: N/A
- Related issues: N/A
- Demo/preview (if any): N/A

## Why

Finalization previously allowed pipelines to complete without verifying that every registered fragment and builder executed, letting the CLI finalize incomplete IR artifacts.

## What

- Snapshot fragment and builder execution inside the core pipeline, enforcing that every registered helper runs and threading the metadata into finalizers and run results.
- Surface execution metadata to CLI IR finalization and require core fragment coverage before completing the draft.
- Add regression tests that cover the new metadata plumbing and IR finalization failure modes.

## How

Track helper registration/execution as the pipeline runs, assert nothing is missing before finalization, and forward the snapshot so downstream consumers (CLI IR finalizer) can reject incomplete drafts. CLI tests exercise the new invariants to guard against regressions.

## Testing

How reviewers test locally:

1. `pnpm --filter @wpkernel/core test -- --runTestsByPath packages/core/tests/__tests__/pipeline.test.ts`
   **Expected:** All pipeline unit tests, including the execution metadata regression, pass.
2. `pnpm --filter @wpkernel/cli test -- --runTestsByPath packages/cli/src/next/ir/__tests__/finalizeIrDraft.test.ts`
   **Expected:** IR finalization invariants pass and failure cases throw `KernelError`.

### Test Matrix (tick what’s covered)

- [x] Unit (pnpm test)
- [ ] E2E (pnpm e2e)
- [ ] Types (pnpm typecheck)
- [ ] Docs examples (build/run)
- [ ] WordPress playground / wp-env sanity

## Screenshots / Recordings (if applicable)

N/A

## Breaking Changes

- [ ] None
       If any, list migration steps with code snippets.

## Affected Packages

Tick any public packages this PR changes functionally.

- [x] `@wpkernel/core`
- [ ] `@wpkernel/ui`
- [x] `@wpkernel/cli`
- [ ] `@wpkernel/e2e-utils`
- [ ] `@wpkernel/php-driver`
- [ ] `@wpkernel/php-json-ast`
- [ ] `@wpkernel/test-utils`

## Release

Choose one and document in CHANGELOG.md files.

- [x] **patch** — bugfixes / alignment (0.x.1)
- [ ] **minor** — feature sprint (default) (0.x.0)
- [ ] **major** — breaking API (x.0.0)

> Update CHANGELOG.md files in affected packages with summary of changes.
> 
> _If infra/docs-only, add label **no-release**._

## Checklist

- [x] No string-based generator was introduced or wrapped (PHP/blocks emitters remain AST-first).
- [x] Tests pass (`pnpm test`, where relevant: `pnpm e2e`)
- [x] Lint passes (`pnpm lint`)
- [ ] Types pass (`pnpm typecheck`, `pnpm typecheck:tests`)
- [ ] CHANGELOG.md updated in affected packages (or PR labelled `no-release`)
- [ ] Docs updated (site/README)
- [ ] Examples updated (if API changed)
- [ ] Documentation under `packages/cli/docs/` (index, migration phases, tasks) updated if behaviour changed.


------
https://chatgpt.com/codex/tasks/task_e_68fe60e4122c8331af2e6835329a47a4