### PR TITLE
Align next CLI types with shared PHP packages

### DIFF
--- a/packages/cli/src/next/runtime/types.ts
+++ b/packages/cli/src/next/runtime/types.ts
@@ -1,15 +1,24 @@
 import type { Reporter } from '@wpkernel/core/reporter';
-import type { BuildIrOptions, IRv1 } from '../../ir/types';
 import type { Helper, HelperDescriptor } from '@wpkernel/core/pipeline';
+import type {
+	BuilderHelper as PhpBuilderHelper,
+	BuilderInput as PhpBuilderInput,
+	BuilderOutput as PhpBuilderOutput,
+	BuilderWriteAction as PhpBuilderWriteAction,
+	PipelineContext as PhpPipelineContext,
+	PipelinePhase,
+} from '@wpkernel/php-json-ast';
+import type { BuildIrOptions, IRv1 } from '../../ir/types';
 import type { MutableIr } from '../ir/types';
 import type { Workspace } from '../workspace/types';
 
-export type PipelinePhase = 'init' | 'generate' | 'apply' | `custom:${string}`;
+type BasePipelineContext = PhpPipelineContext;
 
-export interface PipelineContext {
+export type { PipelinePhase };
+
+export interface PipelineContext
+	extends Omit<BasePipelineContext, 'workspace'> {
 	readonly workspace: Workspace;
-	readonly phase: PipelinePhase;
-	readonly reporter: Reporter;
 }
 
 export interface PipelineRunOptions {
@@ -61,28 +70,21 @@ export interface FragmentOutput {
 	assign: (partial: Partial<MutableIr>) => void;
 }
 
-export interface BuilderInput {
-	readonly phase: PipelinePhase;
+type BaseBuilderInput = PhpBuilderInput;
+
+export interface BuilderInput extends Omit<BaseBuilderInput, 'options' | 'ir'> {
 	readonly options: BuildIrOptions;
 	readonly ir: IRv1 | null;
 }
 
-export interface BuilderWriteAction {
-	readonly file: string;
-	readonly contents: Buffer | string;
-}
+export type BuilderWriteAction = PhpBuilderWriteAction;
 
-export interface BuilderOutput {
-	readonly actions: BuilderWriteAction[];
-	queueWrite: (action: BuilderWriteAction) => void;
-}
+export type BuilderOutput = PhpBuilderOutput;
 
-export type BuilderHelper = Helper<
+export type BuilderHelper = PhpBuilderHelper<
 	PipelineContext,
 	BuilderInput,
-	BuilderOutput,
-	PipelineContext['reporter'],
-	'builder'
+	BuilderOutput
 >;
 
 export interface PipelineExtensionHookOptions {

--- a/packages/cli/src/next/workspace/types.ts
+++ b/packages/cli/src/next/workspace/types.ts
@@ -1,12 +1,12 @@
+import type { WorkspaceWriteOptions } from '@wpkernel/php-json-ast';
+import type { WorkspaceLike } from '@wpkernel/php-driver';
+
 export interface FileManifest {
 	readonly writes: readonly string[];
 	readonly deletes: readonly string[];
 }
 
-export interface WriteOptions {
-	readonly mode?: number;
-	readonly ensureDir?: boolean;
-}
+export type WriteOptions = WorkspaceWriteOptions;
 
 export interface WriteJsonOptions extends WriteOptions {
 	readonly pretty?: boolean;
@@ -26,8 +26,7 @@ export interface MergeOptions {
 	readonly markers?: MergeMarkers;
 }
 
-export interface Workspace {
-	readonly root: string;
+export interface Workspace extends WorkspaceLike {
 	cwd: () => string;
 	read: (file: string) => Promise<Buffer | null>;
 	readText: (file: string) => Promise<string | null>;
@@ -41,7 +40,6 @@ export interface Workspace {
 		value: T,
 		options?: WriteJsonOptions
 	) => Promise<void>;
-	exists: (target: string) => Promise<boolean>;
 	rm: (target: string, options?: RemoveOptions) => Promise<void>;
 	glob: (pattern: string | readonly string[]) => Promise<string[]>;
 	threeWayMerge: (
@@ -58,5 +56,4 @@ export interface Workspace {
 		fn: () => Promise<T>
 	) => Promise<{ result: T; manifest: FileManifest }>;
 	tmpDir: (prefix?: string) => Promise<string>;
-	resolve: (...parts: string[]) => string;
 }


### PR DESCRIPTION
## Summary
- reuse the php-json-ast pipeline helper types for the next-gen CLI pipeline to eliminate local duplicates
- align the CLI workspace surface with the php-driver workspace contract and reuse the shared write options

## Testing
- pnpm --filter @wpkernel/cli typecheck
- pnpm --filter @wpkernel/cli test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68fe7f3dde808331b7d0a5364f3bb08e