### PR TITLE
Task 19: Ship v0.7.0 release

### DIFF
--- a/packages/cli/src/next/builders/php/blocks/registrar/methods/register.ts
+++ b/packages/cli/src/next/builders/php/blocks/registrar/methods/register.ts
@@ -35,12 +35,16 @@ export function buildRegisterMethod(): PhpStmtClassMethod {
 
 	const stmts: PhpStmt[] = [
 		buildVariableAssignment(
+			normaliseVariableReference(pluginRootVariable),
+			buildFunctionCall('dirname', [
+				buildArg(buildConstFetchExpr('__DIR__')),
+				buildArg(buildScalarInt(3)),
+			])
+		),
+		buildVariableAssignment(
 			normaliseVariableReference(manifestVariable),
 			buildConcat(
-				buildFunctionCall('dirname', [
-					buildArg(buildConstFetchExpr('__DIR__')),
-					buildArg(buildScalarInt(2)),
-				]),
+				buildVariable(pluginRootVariable),
 				buildScalarString('/build/blocks-manifest.php')
 			)
 		),
@@ -66,13 +70,6 @@ export function buildRegisterMethod(): PhpStmtClassMethod {
 			),
 			statements: [buildReturn(null)],
 		}),
-		buildVariableAssignment(
-			normaliseVariableReference(pluginRootVariable),
-			buildFunctionCall('dirname', [
-				buildArg(buildConstFetchExpr('__DIR__')),
-				buildArg(buildScalarInt(2)),
-			])
-		),
 		buildForeachStatement({
 			iterable: buildVariable(entriesVariable),
 			key: buildVariable('block'),


### PR DESCRIPTION
## Summary
- unify the monorepo on v0.7.0 by bumping every package, template, and showcase manifest and regenerating build artefacts
- document the Phase 3 wrap-up: mark Tasks 16-19 shipped, record the v0.7.0 cadence across the roadmap, current state, and versioning ledgers, and refresh typed API docs
- stabilize the release narrative by updating roadmap/current-state timestamps to match the 0.7.0 cut
- ensure SSR block registration resolves metadata paths relative to the real plugin root

**Task IDs:** 16, 17, 18, 19
**Scope:** actions · policy · resource · data · reporter · ui · cli · e2e

## Links

- Roadmap section: https://theGeekist.github.io/wp-kernel/contributing/roadmap/
- Sprint doc / spec: packages/cli/docs/mvp-plan.md
- Related issues: <!-- #123, #456 -->
- Demo/preview (if any): <!-- URL -->

## Why

Phase 3 (blocks parity) is complete after fixing the manifest cache P1. Cutting v0.7.0 keeps versioned packages, docs, and generated artefacts aligned so downstream developers consume the corrected builders without drift.

## What

- Bump the root and workspace package versions to 0.7.0, refresh changelog narratives, and regenerate CLI/php-json-ast distributables plus showcase artefacts.
- Rebuild typed API docs via `pnpm docs:build`, updating CLI/core/test-utils/php-json-ast references to the new release.
- Mark Phase 3 tasks as shipped across CLI docs, roadmap, and current-state ledgers, including fresh “Last updated” timestamps.
- Fix the PHP block registrar to derive the plugin root from the actual plugin directory so manifest entries resolve correctly for SSR blocks.

## How

Followed the release checklist: updated package versions, refreshed changelog narratives, reran CLI/php-json-ast builds, rebuilt typedocs/site, and regenerated showcase outputs. Finalized documentation ledgers (MVP plan, migration phases, roadmap, current-state) to reflect the 0.7.0 milestone and refreshed timestamps for auditability.

## Testing

How reviewers test locally:

1. `pnpm docs:api`
2. `CI=1 pnpm docs:site -- --logLevel error`
   **Expected:** typed API docs regenerated and VitePress site builds without warnings beyond existing chunk size notices.
3. `pnpm --filter @wpkernel/cli typecheck`
4. `pnpm --filter @wpkernel/cli test:coverage`
   **Expected:** Jest suites and coverage succeed across CLI.


------
https://chatgpt.com/codex/tasks/task_e_68ff06045bc88331a0a74222fffd4f30