### PR TITLE
Task 3: Document manual framework release workflow

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -83,17 +83,18 @@ pnpm e2e --project chromium
 
 ## 🔧 Core Scripts Cheat Sheet
 
-| Task           | Script           | VS Code Task                  | Purpose                                        |
-| -------------- | ---------------- | ----------------------------- | ---------------------------------------------- |
-| **Setup**      | `pnpm install`   | Tasks: Install                | Install all dependencies                       |
-| **Build**      | `pnpm build`     | Tasks: Build All              | One-shot production build                      |
-| **Dev mode**   | `pnpm dev`       | Tasks: Dev: Watch All         | Rebuild packages on changes                    |
-| **WordPress**  | `pnpm wp:fresh`  | Tasks: WordPress: Fresh Start | Start WP + seed test data                      |
-| **Unit tests** | `pnpm test`      | Tasks: Test: Unit Tests       | Jest tests (no WordPress)                      |
-| **E2E tests**  | `pnpm e2e`       | Tasks: Test: E2E Tests        | Playwright (headless) - **run from root only** |
-| **E2E debug**  | `pnpm e2e:ui`    | Tasks: Test: E2E Tests (UI)   | Playwright with UI - **run from root only**    |
-| **Format**     | `pnpm format`    | Tasks: Format                 | Prettier code formatting                       |
-| **Type check** | `pnpm typecheck` | Tasks: TypeCheck: All         | TypeScript validation                          |
+| Task             | Script                | VS Code Task                  | Purpose                                         |
+| ---------------- | --------------------- | ----------------------------- | ----------------------------------------------- |
+| **Setup**        | `pnpm install`        | Tasks: Install                | Install all dependencies                        |
+| **Build**        | `pnpm build`          | Tasks: Build All              | One-shot production build                       |
+| **Dev mode**     | `pnpm dev`            | Tasks: Dev: Watch All         | Rebuild packages on changes                     |
+| **WordPress**    | `pnpm wp:fresh`       | Tasks: WordPress: Fresh Start | Start WP + seed test data                       |
+| **Unit tests**   | `pnpm test`           | Tasks: Test: Unit Tests       | Jest tests (no WordPress)                       |
+| **E2E tests**    | `pnpm e2e`            | Tasks: Test: E2E Tests        | Playwright (headless) - **run from root only**  |
+| **E2E debug**    | `pnpm e2e:ui`         | Tasks: Test: E2E Tests (UI)   | Playwright with UI - **run from root only**     |
+| **Format**       | `pnpm format`         | Tasks: Format                 | Prettier code formatting                        |
+| **Type check**   | `pnpm typecheck`      | Tasks: TypeCheck: All         | TypeScript validation                           |
+| **Release gate** | `pnpm release:verify` | Tasks: Release: Verify        | Preflight release readiness check (maintainers) |
 
 > **💡 Pro Tip**: Use VS Code tasks (`Cmd+Shift+P` → "Run Task") - they're pre-configured and more reliable than remembering scripts!
 
@@ -322,6 +323,10 @@ pnpm e2e
 # Ensure clean build
 pnpm build
 ```
+
+## 🚢 Release workflow
+
+Releases remain a manual process while we finish the automation work in `RELEASE_PREPARATION.md`. Maintainers should follow the [Framework Release Playbook](docs/releases/framework-release-playbook.md) and run `pnpm release:verify` alongside the usual lint/typecheck/test/build scripts before tagging. The script reads every publishable workspace manifest to confirm the version matches the root package and that the required `build`, `typecheck`, and `typecheck:tests` scripts are present. Treat a failing check as a blocker and address it in a regular branch before returning to the release cut.
 
 ## 🔗 Key Files
 

--- a/RELEASE_PREPARATION.md
+++ b/RELEASE_PREPARATION.md
@@ -12,8 +12,8 @@ WP Kernel is approaching its first coordinated framework release without `releas
        Completed – shared presets (`tsconfig.lib.json`, `tsconfig.tests.json`, `tsconfig.tests.cli.json`) are in place, package configs extend them, Jest helpers live under `scripts/config/create-wpk-jest-config.ts`, the `scripts/register-workspace.ts` CLI wires new workspaces, and docs cover the workflow in `docs/guide/adding-workspace-dependencies.md` plus `DEVELOPMENT.md`.
 - [x] **Task 2 – Centralize framework peer dependency policy and validation**  
        Completed – `scripts/config/framework-peers.ts` defines the canonical versions, `scripts/check-framework-peers.ts` validates every package, `package.json` exposes `pnpm lint:peers`, `vite.config.base.ts` reads the map for Rollup externals, and package READMEs document the policy.
-- [ ] **Task 3 – Document manual framework release workflow**  
-       _Completion notes:_ _(update with summary, links, and required checks when finished.)_
+- [x] **Task 3 – Document manual framework release workflow**
+      Completed – Authored `docs/releases/framework-release-playbook.md`, updated `RELEASING.md`/`DEVELOPMENT.md` to point at the manual flow, added `scripts/check-release-readiness.ts` plus the `pnpm release:verify` hook, and verified the readiness check covers all publishable workspaces.
 - [ ] **Task 4 – Automate documentation version sync and release tagging**  
        _Completion notes:_ _(update with summary, links, and required checks when finished.)_
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,20 +1,20 @@
 # Release Model & Workflow
 
-> **WP Kernel uses manual semantic versioning with fixed versioning across all public packages.**
+> **WP Kernel uses manual semantic versioning with fixed versioning across all public packages.** The retired `release-please` automation remains disabled until we finish the follow-up automation tasks.
 
-**Model**: Sprint-driven releases with manual version management.
+**Model**: Sprint-driven releases with manual version management backed by the [Framework Release Playbook](docs/releases/framework-release-playbook.md).
 
 ---
 
 ## Quick Reference
 
-| Action            | Process                                 |
-| ----------------- | --------------------------------------- |
-| **New Sprint PR** | Update CHANGELOG.md with sprint changes |
-| **Version Bump**  | Update package.json versions manually   |
-| **Release**       | Tag and publish to npm manually         |
+| Action            | Process                                                                |
+| ----------------- | ---------------------------------------------------------------------- |
+| **New Sprint PR** | Update CHANGELOG.md with sprint changes                                |
+| **Version Bump**  | Update package.json versions manually                                  |
+| **Release**       | Follow the framework playbook, run `pnpm release:verify`, tag, publish |
 
-**Current train**: unified **v0.5.x (pre-1.0)** across every publishable package.
+**Current train**: unified **v0.7.x (pre-1.0)** across every publishable package.
 
 ---
 
@@ -85,23 +85,12 @@ Every Sprint PR must link to:
 
 ### Preparing a Release
 
-1. **Update versions** in all package.json files (fixed versioning)
-2. **Update CHANGELOG.md** - Change `[Unreleased]` to version and date
-3. **Commit and tag**:
-    ```bash
-    git add .
-    git commit -m "chore(release): v0.x.0"
-    git tag v0.x.0
-    git push origin main --tags
-    ```
-4. **Build and publish**:
-    ```bash
-    pnpm build
-    npm publish --workspace packages/core
-    npm publish --workspace packages/ui
-    npm publish --workspace packages/cli
-    npm publish --workspace packages/e2e-utils
-    ```
+Walk through the [Framework Release Playbook](docs/releases/framework-release-playbook.md) for the authoritative checklist. At a minimum:
+
+1. **Run the verification suite** – `pnpm lint --fix`, `pnpm typecheck`, `pnpm typecheck:tests`, `pnpm test`, `pnpm build`, and finally `pnpm release:verify` to confirm every publishable workspace declares the required scripts and shares the root version.
+2. **Update versions** in all `package.json` files (fixed versioning across every published workspace) and refresh the root/package changelog entries.
+3. **Commit and tag** using annotated tags only after every package publishes successfully.
+4. **Publish packages** individually (core, ui, cli, e2e-utils, php-driver, php-json-ast, test-utils) so any failure is obvious and easy to retry.
 
 ---
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -37,6 +37,7 @@ Additional references:
 - [`LICENSING.md`](https://github.com/theGeekist/wp-kernel/blob/main/LICENSING.md) - decision log for licensing choices.
 - [`information/Roadmap`](https://github.com/theGeekist/wp-kernel/blob/main/information/Roadmap%20PO%20%E2%80%A2%20v1.0.md) - product roadmap.
 - [`examples/showcase/README.md`](https://github.com/theGeekist/wp-kernel/blob/main/examples/showcase/README.md) - detailed walkthrough of the showcase plugin.
+- [Framework Release Playbook](../releases/framework-release-playbook.md) - manual release checklist and verification steps.
 
 ## Standards and testing
 

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -2,7 +2,7 @@
 
 Guide to submitting pull requests to WP Kernel.
 
-> **📖 For release workflow and versioning**, see `RELEASING.md` in project root (canonical source).
+> **📖 For release workflow and versioning**, see `RELEASING.md` in project root and the [Framework Release Playbook](../releases/framework-release-playbook.md).
 
 ## Before You Start
 

--- a/docs/releases/framework-release-playbook.md
+++ b/docs/releases/framework-release-playbook.md
@@ -1,0 +1,61 @@
+# Framework Release Playbook
+
+WP Kernel ships every package from a single source of truth. Releases are manual today-the old `release-please` workflow is on hold until we can automate the checks in this playbook. Follow the sequence below every time you cut a new version so the framework, showcase plugin, and documentation stay in sync.
+
+## Preflight checklist
+
+Start by confirming the repository is healthy:
+
+- Verify `main` is green in CI and that the coverage gates (≥95% statements/lines, ≥98% functions) still pass locally.
+- Run the full validation suite from the repository root: `pnpm lint --fix`, `pnpm typecheck`, `pnpm typecheck:tests`, `pnpm test`, and `pnpm build`.
+- Execute `pnpm release:verify` to run `scripts/check-release-readiness.ts`. It ensures every publishable workspace exposes `build`, `typecheck`, and `typecheck:tests` scripts and that all package versions match the root manifest before you tag.
+- Review open pull requests to confirm no pending work needs to land in the same release window.
+
+If any check fails, stop here and fix it in a regular feature branch. Releases only proceed once the tree is clean and reproducible.
+
+## Align versions and changelog entries
+
+WP Kernel uses fixed versioning across publishable packages. Update the root `package.json` version, then mirror the same number in each workspace manifest under `packages/*`. Update `CHANGELOG.md` entries at the root and in the affected package directories: move notes out of the `Unreleased` section, add the release date, and confirm highlights describe every merged feature.
+
+When the code touches documentation, refresh the relevant guides under `/docs` in the same pull request. VitePress builds should still succeed after your edits.
+
+## Build artifacts and dry-run publication
+
+With versions and changelog entries staged:
+
+1. Re-run `pnpm build` from the repository root. This step compiles each package and confirms the artifacts are present under `dist/`.
+2. Optionally run `pnpm --filter @wpkernel/* pack --dry-run` to inspect which files will publish. The dry run catches missing README/LICENSE files or stale build outputs.
+3. Verify the showcase plugin still boots against the new build by running `pnpm wp:fresh` locally.
+
+## Publish to npm and tag the release
+
+Publish packages one at a time so failures are easy to roll back:
+
+```bash
+npm publish --workspace packages/core
+npm publish --workspace packages/ui
+npm publish --workspace packages/cli
+npm publish --workspace packages/e2e-utils
+npm publish --workspace packages/php-driver
+npm publish --workspace packages/php-json-ast
+npm publish --workspace packages/test-utils
+```
+
+Push tags only after every package succeeds:
+
+```bash
+git tag -a vX.Y.Z -m "WP Kernel vX.Y.Z"
+git push origin main --tags
+```
+
+If you cut a prerelease, pass `--tag beta` (or similar) to each `npm publish` command and annotate the tag accordingly.
+
+## Post-release verification
+
+- Install each package in a clean project with `npm install @wpkernel/core@X.Y.Z` (repeat for every workspace) to confirm the published tarballs resolve.
+- Run through the Quick Start in the documentation to ensure the CLI and generated assets still work with the released build.
+- Announce the release internally with a link to the changelog entry, the annotated tag, and any migration callouts.
+
+## Future automation
+
+Automated npm publication remains a follow-up task. Once we trust this manual flow, the next step is a release script that runs the preflight checks, rebuilds docs, creates a release PR, and tags after a second maintainer approves. Track that effort under Task 4 of `RELEASE_PREPARATION.md` so the plan stays visible.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"lint:fix": "eslint packages/ examples/ --fix",
 		"lint:branching": "eslint --rulesdir ./eslint-rules --rule 'no-else-return:error' packages/ examples/",
 		"lint:peers": "pnpm exec tsx scripts/check-framework-peers.ts",
+		"release:verify": "pnpm exec tsx scripts/check-release-readiness.ts",
 		"format": "prettier --write '**/*.{js,ts,tsx,json,md,yml,yaml}' && node scripts/normalize-punctuation.js",
 		"format:check": "prettier --check '**/*.{js,ts,tsx,json,md,yml,yaml}'",
 		"typecheck": "pnpm --recursive --filter './packages/*' --filter './examples/*' run typecheck",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,16 +323,16 @@ importers:
         specifier: '>=2.3.0'
         version: 2.3.4
       '@wordpress/api-fetch':
-        specifier: '>=7.0.0'
+        specifier: '>=7.32.0'
         version: 7.32.0
       '@wordpress/data':
-        specifier: '>=10.0.0'
+        specifier: '>=10.32.0'
         version: 10.32.0(react@18.3.1)
       '@wordpress/element':
-        specifier: '>=6.0.0'
+        specifier: '>=6.32.0'
         version: 6.32.0
       '@wordpress/hooks':
-        specifier: '>=4.0.0'
+        specifier: '>=4.32.0'
         version: 4.32.0
       loglayer:
         specifier: '>=6.7.2'
@@ -389,16 +389,16 @@ importers:
         specifier: '>=16.3.0'
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/components':
-        specifier: '>=28.0.0'
+        specifier: '>=30.5.0'
         version: 30.5.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data':
-        specifier: '>=10.0.0'
+        specifier: '>=10.32.0'
         version: 10.32.0(react@18.3.1)
       '@wordpress/dataviews':
         specifier: '>=9.1.0'
         version: 9.1.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element':
-        specifier: '>=6.0.0'
+        specifier: '>=6.32.0'
         version: 6.32.0
       '@wpkernel/core':
         specifier: workspace:*

--- a/scripts/check-release-readiness.ts
+++ b/scripts/check-release-readiness.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+type PackageScripts = Record<string, string | undefined>;
+
+interface PackageJson {
+	readonly name?: string;
+	readonly version?: string;
+	readonly private?: boolean;
+	readonly scripts?: PackageScripts;
+}
+
+const REQUIRED_SCRIPTS: readonly string[] = [
+	'build',
+	'typecheck',
+	'typecheck:tests',
+];
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function readJsonFile<T>(filePath: string): T {
+	const contents = fs.readFileSync(filePath, 'utf8');
+	return JSON.parse(contents) as T;
+}
+
+function gatherWorkspacePackageJsonFiles(): readonly string[] {
+	const packagesDir = path.join(REPO_ROOT, 'packages');
+	if (!fs.existsSync(packagesDir)) {
+		return [];
+	}
+
+	return fs
+		.readdirSync(packagesDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => path.join(packagesDir, entry.name, 'package.json'))
+		.filter((filePath) => fs.existsSync(filePath));
+}
+
+function isPublishablePackage(
+	manifest: PackageJson
+): manifest is Required<Pick<PackageJson, 'name'>> {
+	return manifest.private !== true && typeof manifest.name === 'string';
+}
+
+function collectScriptErrors(
+	name: string,
+	scripts: PackageScripts | undefined
+): string[] {
+	const packageScripts = scripts ?? {};
+
+	return REQUIRED_SCRIPTS.reduce<string[]>((errors, scriptName) => {
+		if (!packageScripts[scriptName]) {
+			errors.push(`${name} is missing the \"${scriptName}\" script.`);
+		}
+		return errors;
+	}, []);
+}
+
+function collectVersionErrors(
+	name: string,
+	version: string | undefined,
+	rootVersion: string
+): string[] {
+	if (!version) {
+		return [`${name} does not declare a version.`];
+	}
+
+	if (version !== rootVersion) {
+		return [
+			`${name} declares version ${version} (expected ${rootVersion}).`,
+		];
+	}
+
+	return [];
+}
+
+function main(): void {
+	const rootPackagePath = path.join(REPO_ROOT, 'package.json');
+	const rootManifest = readJsonFile<PackageJson>(rootPackagePath);
+	const rootVersion = rootManifest.version;
+
+	if (!rootVersion) {
+		console.error('Root package.json is missing a version.');
+		process.exit(1);
+	}
+
+	const packageJsonFiles = gatherWorkspacePackageJsonFiles();
+	const errors: string[] = [];
+
+	for (const filePath of packageJsonFiles) {
+		const manifest = readJsonFile<PackageJson>(filePath);
+		if (!isPublishablePackage(manifest)) {
+			continue;
+		}
+
+		const name = manifest.name;
+		errors.push(
+			...collectVersionErrors(name, manifest.version, rootVersion),
+			...collectScriptErrors(name, manifest.scripts)
+		);
+	}
+
+	if (errors.length > 0) {
+		console.error('Release readiness check failed:');
+		for (const message of errors) {
+			console.error(` - ${message}`);
+		}
+		process.exit(1);
+	}
+
+	console.log(
+		`All publishable workspaces share version ${rootVersion} and expose the required build scripts.`
+	);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add the framework release playbook and link it from maintainer guides
- introduce a release readiness script with a `pnpm release:verify` hook and wire it into package tooling
- mark Task 3 complete in the release preparation plan and refresh dependency policy metadata

## Testing
- pnpm lint --fix
- pnpm build
- pnpm typecheck
- pnpm typecheck:tests
- pnpm test
- pnpm release:verify

------
https://chatgpt.com/codex/tasks/task_e_68ff14f9a9e88331894a6c5a17d41b46