### PR TITLE
Ensure new workspaces expose required scripts

### DIFF
--- a/tests/__tests__/register-workspace.test.ts
+++ b/tests/__tests__/register-workspace.test.ts
@@ -66,6 +66,38 @@ function createPackage(rootDir: string, packageName: string): string {
 }
 
 describe('register-workspace', () => {
+	it('ensures package manifests expose default scripts', () => {
+		const { rootDir, cleanup } = setupRepository();
+		const logger = createLogger();
+
+		try {
+			const alphaDir = createPackage(rootDir, 'alpha');
+
+			registerWorkspace({
+				workspaceInput: 'packages/alpha',
+				cwd: rootDir,
+				logger,
+			});
+
+			const manifest = JSON.parse(
+				fs.readFileSync(path.join(alphaDir, 'package.json'), 'utf8')
+			) as { scripts?: Record<string, string> };
+
+			expect(manifest.scripts).toMatchObject({
+				build: 'vite build && tsc --noEmit',
+				lint: 'eslint src/',
+				'lint:fix': 'eslint src/ --fix',
+				test: 'jest --passWithNoTests --watchman=false',
+				'test:coverage': 'jest --coverage --watchman=false',
+				'test:watch': 'jest --watch',
+				typecheck: 'tsc --noEmit',
+				'typecheck:tests': 'tsc --project tsconfig.tests.json --noEmit',
+			});
+		} finally {
+			cleanup();
+		}
+	});
+
 	it('adds TypeScript references for declared dependencies', () => {
 		const { rootDir, cleanup } = setupRepository();
 		const logger = createLogger();


### PR DESCRIPTION
## Summary
- seed new workspaces with default lint, typecheck, test, and build scripts so filtered pnpm commands stay available
- sort generated script entries to keep manifests stable and add regression test coverage for the script defaults

## Testing
- pnpm test -- register-workspace

------
https://chatgpt.com/codex/tasks/task_e_68ff576d12288331ba2abb5ee69b3c99