### PR TITLE
Improve CLI PHP builder coverage

### DIFF
--- a/packages/cli/src/next/builders/php/__tests__/baseController.test.ts
+++ b/packages/cli/src/next/builders/php/__tests__/baseController.test.ts
@@ -1,0 +1,75 @@
+import { createPhpBaseControllerHelper } from '../baseController';
+import { getPhpBuilderChannel, resetPhpBuilderChannel } from '../channel';
+import { resetPhpAstChannel } from '@wpkernel/php-json-ast';
+import {
+	createBuilderInput,
+	createBuilderOutput,
+	createMinimalIr,
+	createPipelineContext,
+} from '../../../../../tests/test-support/php-builder.test-support';
+
+describe('createPhpBaseControllerHelper', () => {
+	it('skips generation when the IR artifact is not available', async () => {
+		const context = createPipelineContext();
+		resetPhpBuilderChannel(context);
+		resetPhpAstChannel(context);
+
+		const helper = createPhpBaseControllerHelper();
+		const next = jest.fn();
+		const output = createBuilderOutput();
+
+		await helper.apply(
+			{
+				context,
+				input: createBuilderInput({ ir: null }),
+				output,
+				reporter: context.reporter,
+			},
+			next
+		);
+
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(getPhpBuilderChannel(context).pending()).toHaveLength(0);
+	});
+
+	it('generates a base controller file when an IR artifact is provided', async () => {
+		const context = createPipelineContext();
+		resetPhpBuilderChannel(context);
+		resetPhpAstChannel(context);
+
+		const helper = createPhpBaseControllerHelper();
+		const ir = createMinimalIr({
+			meta: {
+				sanitizedNamespace: 'DemoPlugin',
+				origin: 'wpk.config.ts',
+			},
+			php: {
+				namespace: 'Demo\\Plugin',
+				outputDir: '.generated/php',
+				autoload: 'inc/',
+			},
+		});
+
+		await helper.apply(
+			{
+				context,
+				input: createBuilderInput({ ir }),
+				output: createBuilderOutput(),
+				reporter: context.reporter,
+			},
+			undefined
+		);
+
+		const pending = getPhpBuilderChannel(context).pending();
+		const entry = pending.find(
+			(candidate) => candidate.metadata.kind === 'base-controller'
+		);
+
+		expect(entry).toBeDefined();
+		expect(entry?.docblock).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining('namespace: DemoPlugin'),
+			])
+		);
+	});
+});

--- a/packages/cli/src/next/builders/php/__tests__/indexFile.test.ts
+++ b/packages/cli/src/next/builders/php/__tests__/indexFile.test.ts
@@ -1,0 +1,115 @@
+import { createPhpIndexFileHelper } from '../indexFile';
+import { getPhpBuilderChannel, resetPhpBuilderChannel } from '../channel';
+import { resetPhpAstChannel } from '@wpkernel/php-json-ast';
+import type { IRResource } from '../../../ir/publicTypes';
+import {
+	createBuilderInput,
+	createBuilderOutput,
+	createMinimalIr,
+	createPipelineContext,
+} from '../../../../../tests/test-support/php-builder.test-support';
+
+describe('createPhpIndexFileHelper', () => {
+	it('skips generation when no IR is present', async () => {
+		const context = createPipelineContext();
+		resetPhpBuilderChannel(context);
+		resetPhpAstChannel(context);
+
+		const helper = createPhpIndexFileHelper();
+		const next = jest.fn();
+
+		await helper.apply(
+			{
+				context,
+				input: createBuilderInput({ ir: null }),
+				output: createBuilderOutput(),
+				reporter: context.reporter,
+			},
+			next
+		);
+
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(getPhpBuilderChannel(context).pending()).toHaveLength(0);
+	});
+
+	it('indexes base controllers and resource controllers', async () => {
+		const context = createPipelineContext();
+		resetPhpBuilderChannel(context);
+		resetPhpAstChannel(context);
+
+		const helper = createPhpIndexFileHelper();
+		const resources: IRResource[] = [
+			makeResource('books'),
+			makeResource('authors'),
+		];
+
+		const ir = createMinimalIr({
+			resources,
+			php: {
+				namespace: 'Demo\\Plugin',
+				outputDir: '.generated/php',
+				autoload: 'inc/',
+			},
+		});
+
+		await helper.apply(
+			{
+				context,
+				input: createBuilderInput({ ir }),
+				output: createBuilderOutput(),
+				reporter: context.reporter,
+			},
+			undefined
+		);
+
+		const pending = getPhpBuilderChannel(context).pending();
+		const entry = pending.find(
+			(candidate) => candidate.metadata.kind === 'index-file'
+		);
+
+		expect(entry).toBeDefined();
+		const namespaceStmt = entry?.program.find(
+			(stmt: any) => stmt?.nodeType === 'Stmt_Namespace'
+		) as { stmts?: any[] } | undefined;
+		const returnStatement = namespaceStmt?.stmts?.find(
+			(stmt: any) => stmt?.nodeType === 'Stmt_Return'
+		) as { expr?: any } | undefined;
+
+		expect(returnStatement?.expr?.items).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					key: expect.objectContaining({
+						value: 'Demo\\Plugin\\Rest\\BooksController',
+					}),
+				}),
+				expect.objectContaining({
+					key: expect.objectContaining({
+						value: 'Demo\\Plugin\\Rest\\AuthorsController',
+					}),
+				}),
+			])
+		);
+	});
+});
+
+function makeResource(name: string): IRResource {
+	return {
+		name,
+		schemaKey: `${name}.schema`,
+		schemaProvenance: 'manual',
+		routes: [
+			{
+				method: 'GET',
+				path: `/kernel/v1/${name}`,
+				transport: 'local',
+				hash: `${name}-get`,
+			},
+		],
+		cacheKeys: {
+			list: { segments: [], source: 'default' },
+			get: { segments: [], source: 'default' },
+		},
+		hash: `${name}-hash`,
+		warnings: [],
+	};
+}

--- a/packages/cli/src/next/builders/php/__tests__/persistenceRegistry.test.ts
+++ b/packages/cli/src/next/builders/php/__tests__/persistenceRegistry.test.ts
@@ -1,0 +1,162 @@
+import {
+	buildPersistencePayload,
+	createPhpPersistenceRegistryHelper,
+} from '../persistenceRegistry';
+import { getPhpBuilderChannel, resetPhpBuilderChannel } from '../channel';
+import { resetPhpAstChannel } from '@wpkernel/php-json-ast';
+import type { IRResource } from '../../../ir/publicTypes';
+import {
+	createBuilderInput,
+	createBuilderOutput,
+	createMinimalIr,
+	createPipelineContext,
+} from '../../../../../tests/test-support/php-builder.test-support';
+
+describe('createPhpPersistenceRegistryHelper', () => {
+	it('skips generation when the IR is unavailable', async () => {
+		const context = createPipelineContext();
+		resetPhpBuilderChannel(context);
+		resetPhpAstChannel(context);
+
+		const helper = createPhpPersistenceRegistryHelper();
+		const next = jest.fn();
+
+		await helper.apply(
+			{
+				context,
+				input: createBuilderInput({ ir: null }),
+				output: createBuilderOutput(),
+				reporter: context.reporter,
+			},
+			next
+		);
+
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(getPhpBuilderChannel(context).pending()).toHaveLength(0);
+	});
+
+	it('queues a registry with sanitised persistence metadata', async () => {
+		const context = createPipelineContext();
+		resetPhpBuilderChannel(context);
+		resetPhpAstChannel(context);
+
+		const resources: IRResource[] = [
+			makeResource('books', {
+				storage: { driver: 'wp', options: { table: 'posts' } },
+				identity: { type: 'primary', field: 'ID' },
+			}),
+			makeResource('drafts', {
+				storage: { driver: 'wp', options: { table: 'posts' } },
+			}),
+			makeResource('ignored'),
+		];
+
+		const helper = createPhpPersistenceRegistryHelper();
+		const ir = createMinimalIr({ resources });
+
+		await helper.apply(
+			{
+				context,
+				input: createBuilderInput({ ir }),
+				output: createBuilderOutput(),
+				reporter: context.reporter,
+			},
+			undefined
+		);
+
+		const pending = getPhpBuilderChannel(context).pending();
+		const entry = pending.find(
+			(candidate) => candidate.metadata.kind === 'persistence-registry'
+		);
+
+		expect(entry).toBeDefined();
+		const namespaceStmt = entry?.program.find(
+			(stmt: any) => stmt?.nodeType === 'Stmt_Namespace'
+		) as { stmts?: any[] } | undefined;
+		const classStmt = namespaceStmt?.stmts?.find(
+			(stmt: any) => stmt?.nodeType === 'Stmt_Class'
+		) as { stmts?: any[] } | undefined;
+		const method = classStmt?.stmts?.find(
+			(stmt: any) =>
+				stmt?.nodeType === 'Stmt_ClassMethod' &&
+				stmt?.name?.name === 'get_config'
+		) as { stmts?: any[] } | undefined;
+		const returnStmt = method?.stmts?.find(
+			(stmt: any) => stmt?.nodeType === 'Stmt_Return'
+		) as { expr?: any } | undefined;
+
+		expect(returnStmt?.expr?.items).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					key: expect.objectContaining({ value: 'resources' }),
+				}),
+			])
+		);
+
+		const resourcesArray = returnStmt?.expr?.items?.[0]?.value;
+		expect(resourcesArray?.items).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					key: expect.objectContaining({ value: 'books' }),
+				}),
+				expect.objectContaining({
+					key: expect.objectContaining({ value: 'drafts' }),
+				}),
+			])
+		);
+	});
+});
+
+describe('buildPersistencePayload', () => {
+	it('omits resources without persistence metadata and fills null defaults', () => {
+		const resources: IRResource[] = [
+			makeResource('books', {
+				storage: { driver: 'wp', options: { table: 'posts' } },
+				identity: { type: 'primary', field: 'ID' },
+			}),
+			makeResource('drafts', {
+				storage: { driver: 'wp', options: { table: 'posts' } },
+			}),
+			makeResource('ignored'),
+		];
+
+		const payload = buildPersistencePayload(resources);
+		expect(payload.resources).toMatchObject({
+			books: {
+				storage: { driver: 'wp', options: { table: 'posts' } },
+				identity: { type: 'primary', field: 'ID' },
+			},
+			drafts: {
+				storage: { driver: 'wp', options: { table: 'posts' } },
+				identity: null,
+			},
+		});
+		expect(payload.resources).not.toHaveProperty('ignored');
+	});
+});
+
+function makeResource(
+	name: string,
+	overrides?: Partial<Pick<IRResource, 'storage' | 'identity'>>
+): IRResource {
+	return {
+		...overrides,
+		name,
+		schemaKey: `${name}.schema`,
+		schemaProvenance: 'manual',
+		routes: [
+			{
+				method: 'GET',
+				path: `/kernel/v1/${name}`,
+				transport: 'local',
+				hash: `${name}-get`,
+			},
+		],
+		cacheKeys: {
+			list: { segments: [], source: 'default' },
+			get: { segments: [], source: 'default' },
+		},
+		hash: `${name}-hash`,
+		warnings: [],
+	} as IRResource;
+}

--- a/packages/cli/src/next/builders/php/__tests__/policy.test.ts
+++ b/packages/cli/src/next/builders/php/__tests__/policy.test.ts
@@ -1,0 +1,158 @@
+import { createPhpPolicyHelper, reportPolicyWarnings } from '../policy';
+import { getPhpBuilderChannel, resetPhpBuilderChannel } from '../channel';
+import { resetPhpAstChannel } from '@wpkernel/php-json-ast';
+import type { IRPolicyDefinition } from '../../../ir/publicTypes';
+import {
+	createBuilderInput,
+	createBuilderOutput,
+	createMinimalIr,
+	createPipelineContext,
+	createReporter,
+} from '../../../../../tests/test-support/php-builder.test-support';
+
+describe('createPhpPolicyHelper', () => {
+	it('skips generation when the IR artifact is missing', async () => {
+		const context = createPipelineContext();
+		resetPhpBuilderChannel(context);
+		resetPhpAstChannel(context);
+
+		const helper = createPhpPolicyHelper();
+		const next = jest.fn();
+
+		await helper.apply(
+			{
+				context,
+				input: createBuilderInput({ ir: null }),
+				output: createBuilderOutput(),
+				reporter: context.reporter,
+			},
+			next
+		);
+
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(getPhpBuilderChannel(context).pending()).toHaveLength(0);
+	});
+
+	it('builds a policy helper that returns definition metadata', async () => {
+		const definitions: IRPolicyDefinition[] = [
+			{
+				key: 'resource.read',
+				capability: 'read_posts',
+				appliesTo: 'resource',
+				source: 'map',
+			},
+			{
+				key: 'resource.update',
+				capability: 'edit_post',
+				appliesTo: 'object',
+				binding: 'post',
+				source: 'map',
+			},
+		];
+
+		const context = createPipelineContext();
+		resetPhpBuilderChannel(context);
+		resetPhpAstChannel(context);
+
+		const ir = createMinimalIr({
+			policyMap: {
+				definitions,
+				fallback: { capability: 'manage_demo', appliesTo: 'resource' },
+				missing: ['resource.delete'],
+				unused: [],
+				warnings: [
+					{
+						code: 'demo',
+						message: 'Example warning',
+					},
+				],
+			},
+		});
+
+		const helper = createPhpPolicyHelper();
+		await helper.apply(
+			{
+				context,
+				input: createBuilderInput({ ir }),
+				output: createBuilderOutput(),
+				reporter: context.reporter,
+			},
+			undefined
+		);
+
+		const pending = getPhpBuilderChannel(context).pending();
+		const entry = pending.find(
+			(candidate) => candidate.metadata.kind === 'policy-helper'
+		);
+		expect(entry).toBeDefined();
+
+		const namespaceStmt = entry?.program.find(
+			(stmt: any) => stmt?.nodeType === 'Stmt_Namespace'
+		) as { stmts?: any[] } | undefined;
+		const classStmt = namespaceStmt?.stmts?.find(
+			(stmt: any) => stmt?.nodeType === 'Stmt_Class'
+		) as { stmts?: any[] } | undefined;
+
+		const methodNames =
+			classStmt?.stmts
+				?.filter((stmt: any) => stmt?.nodeType === 'Stmt_ClassMethod')
+				.map((method: any) => method?.name?.name) ?? [];
+		expect(methodNames).toEqual(
+			expect.arrayContaining([
+				'policy_map',
+				'fallback',
+				'enforce',
+				'create_error',
+			])
+		);
+
+		const policyMapMethod = classStmt?.stmts?.find(
+			(stmt: any) =>
+				stmt?.nodeType === 'Stmt_ClassMethod' &&
+				stmt?.name?.name === 'policy_map'
+		) as { stmts?: any[] } | undefined;
+		const returnStmt = policyMapMethod?.stmts?.find(
+			(stmt: any) => stmt?.nodeType === 'Stmt_Return'
+		) as { expr?: any } | undefined;
+
+		expect(returnStmt?.expr?.items).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					key: expect.objectContaining({ value: 'resource.read' }),
+				}),
+				expect.objectContaining({
+					key: expect.objectContaining({ value: 'resource.update' }),
+				}),
+			])
+		);
+	});
+});
+
+describe('reportPolicyWarnings', () => {
+	it('forwards warnings and missing policies to the reporter', () => {
+		const reporter = createReporter();
+		reportPolicyWarnings(reporter, {
+			definitions: [],
+			fallback: { capability: 'manage_demo', appliesTo: 'resource' },
+			missing: ['resource.delete'],
+			unused: [],
+			warnings: [
+				{
+					code: 'demo',
+					message: 'Example warning',
+					context: { scope: 'policy' },
+				},
+			],
+			sourcePath: 'policy-map.json',
+		});
+
+		expect(reporter.warn).toHaveBeenCalledWith(
+			'Policy helper warning emitted.',
+			expect.objectContaining({ code: 'demo' })
+		);
+		expect(reporter.warn).toHaveBeenCalledWith(
+			'Policies falling back to default capability.',
+			expect.objectContaining({ policies: ['resource.delete'] })
+		);
+	});
+});

--- a/packages/cli/src/next/builders/php/persistenceRegistry.ts
+++ b/packages/cli/src/next/builders/php/persistenceRegistry.ts
@@ -83,7 +83,7 @@ function buildPersistenceRegistry(
 	builder.appendProgramStatement(classNode);
 }
 
-function buildPersistencePayload(
+export function buildPersistencePayload(
 	resources: readonly IRResource[]
 ): Record<string, unknown> {
 	const entries: Record<string, unknown> = {};

--- a/packages/cli/src/next/builders/php/policy.ts
+++ b/packages/cli/src/next/builders/php/policy.ts
@@ -120,7 +120,7 @@ function buildPolicyHelper(builder: PhpAstBuilderAdapter, ir: IRv1): void {
 	builder.appendProgramStatement(classNode);
 }
 
-function reportPolicyWarnings(
+export function reportPolicyWarnings(
 	reporter: Reporter,
 	policyMap: IRv1['policyMap']
 ): void {

--- a/packages/cli/tests/test-support/php-builder.test-support.ts
+++ b/packages/cli/tests/test-support/php-builder.test-support.ts
@@ -1,0 +1,159 @@
+/* eslint-env jest */
+import path from 'node:path';
+import type { Reporter } from '@wpkernel/core/reporter';
+import type {
+	BuilderInput,
+	BuilderOutput,
+	PipelineContext,
+} from '../../src/next/runtime/types';
+import type { IRv1 } from '../../src/next/ir/publicTypes';
+import type { WPKernelConfigV1 } from '../../src/config/types';
+import { makeWorkspaceMock } from '../workspace.test-support';
+
+const DEFAULT_CONFIG_SOURCE = 'tests.config.ts';
+
+export function createReporter(): Reporter {
+	return {
+		debug: jest.fn(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		child: jest.fn().mockReturnThis(),
+	};
+}
+
+export function createPipelineContext(
+	overrides?: Partial<PipelineContext>
+): PipelineContext {
+	const workspace = makeWorkspaceMock({
+		root: '/workspace',
+		cwd: () => '/workspace',
+		resolve: (...parts: string[]) => path.join('/workspace', ...parts),
+		write: jest.fn(async () => undefined),
+		writeJson: jest.fn(async () => undefined),
+	});
+
+	const base: PipelineContext = {
+		workspace,
+		reporter: createReporter(),
+		phase: 'generate',
+	};
+
+	return {
+		...base,
+		...overrides,
+		workspace: overrides?.workspace ?? base.workspace,
+		reporter: overrides?.reporter ?? base.reporter,
+		phase: overrides?.phase ?? base.phase,
+	};
+}
+
+export function createBuilderInput(
+	overrides?: Partial<BuilderInput>
+): BuilderInput {
+	const namespace =
+		overrides?.options?.namespace ??
+		overrides?.options?.config?.namespace ??
+		'demo-plugin';
+	const config: WPKernelConfigV1 =
+		overrides?.options?.config ??
+		({
+			version: 1,
+			namespace,
+			resources: {},
+			schemas: {},
+		} satisfies WPKernelConfigV1);
+
+	const base: BuilderInput = {
+		phase: 'generate',
+		options: {
+			config,
+			namespace,
+			origin: DEFAULT_CONFIG_SOURCE,
+			sourcePath: DEFAULT_CONFIG_SOURCE,
+		},
+		ir: null,
+	};
+
+	return {
+		...base,
+		...overrides,
+		options: {
+			...base.options,
+			...overrides?.options,
+			config,
+			namespace,
+		},
+	};
+}
+
+export function createBuilderOutput(): BuilderOutput {
+	return {
+		actions: [],
+		queueWrite: jest.fn(),
+	};
+}
+
+export function createMinimalIr(overrides?: Partial<IRv1>): IRv1 {
+	const namespace = overrides?.meta?.namespace ?? 'DemoPlugin';
+
+	const baseConfig: WPKernelConfigV1 = overrides?.config ?? {
+		version: 1,
+		namespace,
+		resources: {},
+		schemas: {},
+	};
+
+	const base: IRv1 = {
+		meta: {
+			version: 1,
+			namespace,
+			sourcePath: overrides?.meta?.sourcePath ?? DEFAULT_CONFIG_SOURCE,
+			origin: overrides?.meta?.origin ?? 'typescript',
+			sanitizedNamespace:
+				overrides?.meta?.sanitizedNamespace ??
+				namespace.replace(/[^A-Za-z0-9]+/gu, ''),
+		},
+		config: baseConfig,
+		schemas: overrides?.schemas ?? [],
+		resources: overrides?.resources ?? [],
+		policies: overrides?.policies ?? [],
+		policyMap: {
+			definitions: overrides?.policyMap?.definitions ?? [],
+			fallback: {
+				capability:
+					overrides?.policyMap?.fallback?.capability ??
+					`manage_${namespace.toLowerCase()}`,
+				appliesTo:
+					overrides?.policyMap?.fallback?.appliesTo ?? 'resource',
+			},
+			missing: overrides?.policyMap?.missing ?? [],
+			unused: overrides?.policyMap?.unused ?? [],
+			warnings: overrides?.policyMap?.warnings ?? [],
+			sourcePath: overrides?.policyMap?.sourcePath,
+		},
+		blocks: overrides?.blocks ?? [],
+		php: {
+			namespace: overrides?.php?.namespace ?? namespace,
+			autoload: overrides?.php?.autoload ?? 'inc/',
+			outputDir: overrides?.php?.outputDir ?? '.generated/php',
+		},
+		diagnostics: overrides?.diagnostics ?? [],
+	};
+
+	return {
+		...base,
+		...overrides,
+		meta: { ...base.meta, ...overrides?.meta },
+		config: overrides?.config ?? baseConfig,
+		policyMap: {
+			...base.policyMap,
+			...overrides?.policyMap,
+			fallback: {
+				...base.policyMap.fallback,
+				...overrides?.policyMap?.fallback,
+			},
+		},
+		php: { ...base.php, ...overrides?.php },
+	};
+}


### PR DESCRIPTION
## Summary
- add shared PHP builder test utilities for the CLI
- expand CLI builder test suites to exercise persistence, policy, routing, and error paths
- expose persistence and policy helpers so tests can assert branch behavior

## Testing
- pnpm --filter @wpkernel/cli typecheck
- pnpm --filter @wpkernel/cli test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68ffa15fe6308331a8db98a1243af15e