### PR TITLE
Document php-json-ast WordPress-agnostic invariant

### DIFF
--- a/packages/php-json-ast/AGENTS.md
+++ b/packages/php-json-ast/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md - @wpkernel/php-json-ast
+
+## Scope
+
+This guidance applies to all files within the `packages/php-json-ast/` directory tree.
+
+## Package Invariants
+
+- This package provides a **pure PHP AST transport layer**. It must remain WordPress-agnostic.
+- Do **not** introduce WordPress-specific constructs, helpers, naming conventions, or types in this package.
+- Any WordPress-specific behaviours or schema extensions belong in `packages/wp-json-ast/`.
+- Keep shared tooling and error handling generic so it can be reused by non-WordPress consumers.
+
+## Contributor Notes
+
+- Update this file if additional invariants for the PHP AST layer are established.
+- When in doubt about cross-package responsibilities, prefer adding abstractions in `@wpkernel/core` or higher-level packages instead of coupling to WordPress semantics here.


### PR DESCRIPTION
## Summary
- confirmed `@wpkernel/php-json-ast` contains only generic PHP AST constructs with no WordPress-specific helpers
- added `AGENTS.md` to codify the package invariant that WordPress-aware logic belongs in `packages/wp-json-ast`

## Testing
- pnpm --filter @wpkernel/php-json-ast typecheck
- pnpm --filter @wpkernel/php-json-ast typecheck:tests
- pnpm test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68ffd264a7308331bdcb52c9261afe0a