### PR TITLE
Task 2.4: Break CLI ↔ test-utils cycle

### DIFF
--- a/packages/cli/src/next/builders/__tests__/ts.admin-screen.test.ts
+++ b/packages/cli/src/next/builders/__tests__/ts.admin-screen.test.ts
@@ -5,7 +5,7 @@ import {
 	buildDataViewFixtureCreator,
 } from '../ts';
 import {
-	withWorkspace,
+	withWorkspace as baseWithWorkspace,
 	buildWPKernelConfigSource,
 	buildDataViewsConfig,
 	buildBuilderArtifacts,
@@ -13,11 +13,19 @@ import {
 	buildOutput,
 	normalise,
 	prefixRelative,
+	type BuilderHarnessContext,
 } from '@wpkernel/test-utils/next/builders/tests/ts.test-support';
+import { buildWorkspace } from '../../workspace';
+import type { Workspace } from '../../workspace';
 
 jest.mock('../../../commands/run-generate/validation', () => ({
 	validateGeneratedImports: jest.fn().mockResolvedValue(undefined),
 }));
+
+const withWorkspace = (
+	run: (context: BuilderHarnessContext<Workspace>) => Promise<void>
+) =>
+	baseWithWorkspace(run, { createWorkspace: (root) => buildWorkspace(root) });
 
 describe('createTsBuilder - admin screen creator', () => {
 	it('generates admin screens with resolved relative imports', async () => {

--- a/packages/cli/src/next/builders/__tests__/ts.builder.test.ts
+++ b/packages/cli/src/next/builders/__tests__/ts.builder.test.ts
@@ -7,14 +7,22 @@ import {
 	type TsBuilderCreator,
 } from '../ts';
 import {
-	withWorkspace,
+	withWorkspace as baseWithWorkspace,
 	buildWPKernelConfigSource,
 	buildDataViewsConfig,
 	buildBuilderArtifacts,
 	buildReporter,
 	buildOutput,
+	type BuilderHarnessContext,
 } from '@wpkernel/test-utils/next/builders/tests/ts.test-support';
+import { buildWorkspace } from '../../workspace';
+import type { Workspace } from '../../workspace';
 import { validateGeneratedImports } from '../../../commands/run-generate/validation';
+
+const withWorkspace = (
+	run: (context: BuilderHarnessContext<Workspace>) => Promise<void>
+) =>
+	baseWithWorkspace(run, { createWorkspace: (root) => buildWorkspace(root) });
 
 jest.mock('../../../commands/run-generate/validation', () => ({
 	validateGeneratedImports: jest.fn().mockResolvedValue(undefined),

--- a/packages/cli/src/next/builders/__tests__/ts.dataview-fixture.test.ts
+++ b/packages/cli/src/next/builders/__tests__/ts.dataview-fixture.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { createTsBuilder } from '../ts';
 import {
-	withWorkspace,
+	withWorkspace as baseWithWorkspace,
 	buildWPKernelConfigSource,
 	buildDataViewsConfig,
 	buildBuilderArtifacts,
@@ -10,11 +10,19 @@ import {
 	buildOutput,
 	prefixRelative,
 	normalise,
+	type BuilderHarnessContext,
 } from '@wpkernel/test-utils/next/builders/tests/ts.test-support';
+import { buildWorkspace } from '../../workspace';
+import type { Workspace } from '../../workspace';
 
 jest.mock('../../../commands/run-generate/validation', () => ({
 	validateGeneratedImports: jest.fn().mockResolvedValue(undefined),
 }));
+
+const withWorkspace = (
+	run: (context: BuilderHarnessContext<Workspace>) => Promise<void>
+) =>
+	baseWithWorkspace(run, { createWorkspace: (root) => buildWorkspace(root) });
 
 describe('createTsBuilder - DataView fixture creator', () => {
 	it('generates fixtures referencing the kernel config via a relative path', async () => {

--- a/packages/cli/src/next/builders/blocks/__tests__/manifest.test.ts
+++ b/packages/cli/src/next/builders/blocks/__tests__/manifest.test.ts
@@ -1,7 +1,17 @@
 import path from 'node:path';
-import { withWorkspace } from '@wpkernel/test-utils/next/builders/tests/ts.test-support';
+import {
+	withWorkspace as baseWithWorkspace,
+	type BuilderHarnessContext,
+} from '@wpkernel/test-utils/next/builders/tests/ts.test-support';
+import { buildWorkspace } from '../../../workspace';
+import type { Workspace } from '../../../workspace';
 import type { IRBlock } from '../../../ir/publicTypes';
 import { collectBlockManifests } from '../manifest';
+
+const withWorkspace = (
+	run: (context: BuilderHarnessContext<Workspace>) => Promise<void>
+) =>
+	baseWithWorkspace(run, { createWorkspace: (root) => buildWorkspace(root) });
 
 describe('collectBlockManifests', () => {
 	it('returns manifest entries and render metadata for blocks with declared render files', async () => {

--- a/packages/cli/src/next/builders/php/__tests__/blocks.test.ts
+++ b/packages/cli/src/next/builders/php/__tests__/blocks.test.ts
@@ -3,13 +3,21 @@ import { createPhpBlocksHelper } from '../blocks';
 import { getPhpBuilderChannel, resetPhpBuilderChannel } from '../channel';
 import type { IRv1 } from '../../../ir/publicTypes';
 import {
-	withWorkspace,
+	withWorkspace as baseWithWorkspace,
 	buildWPKernelConfigSource,
 	buildBuilderArtifacts,
 	buildReporter,
 	buildOutput,
 	normalise,
+	type BuilderHarnessContext,
 } from '@wpkernel/test-utils/next/builders/tests/ts.test-support';
+import { buildWorkspace } from '../../../workspace';
+import type { Workspace } from '../../../workspace';
+
+const withWorkspace = (
+	run: (context: BuilderHarnessContext<Workspace>) => Promise<void>
+) =>
+	baseWithWorkspace(run, { createWorkspace: (root) => buildWorkspace(root) });
 
 describe('createPhpBlocksHelper', () => {
 	it('emits manifest, registrar, and render stub for SSR blocks', async () => {

--- a/packages/cli/src/next/builders/ts/__tests__/blocks.test.ts
+++ b/packages/cli/src/next/builders/ts/__tests__/blocks.test.ts
@@ -2,13 +2,21 @@ import path from 'node:path';
 import { createJsBlocksBuilder } from '../blocks';
 import type { IRResource, IRSchema, IRv1 } from '../../../ir/publicTypes';
 import {
-	withWorkspace,
+	withWorkspace as baseWithWorkspace,
 	buildWPKernelConfigSource,
 	buildBuilderArtifacts,
 	buildReporter,
 	buildOutput,
 	normalise,
+	type BuilderHarnessContext,
 } from '@wpkernel/test-utils/next/builders/tests/ts.test-support';
+import { buildWorkspace } from '../../../workspace';
+import type { Workspace } from '../../../workspace';
+
+const withWorkspace = (
+	run: (context: BuilderHarnessContext<Workspace>) => Promise<void>
+) =>
+	baseWithWorkspace(run, { createWorkspace: (root) => buildWorkspace(root) });
 
 describe('createJsBlocksBuilder', () => {
 	it('emits registrar and stubs for js-only blocks', async () => {

--- a/packages/cli/src/next/builders/ts/shared/__tests__/shared.test.ts
+++ b/packages/cli/src/next/builders/ts/shared/__tests__/shared.test.ts
@@ -10,7 +10,17 @@ import {
 	toCamelCase,
 	toPascalCase,
 } from '..';
-import { withWorkspace } from '@wpkernel/test-utils/next/builders/tests/ts.test-support';
+import {
+	withWorkspace as baseWithWorkspace,
+	type BuilderHarnessContext,
+} from '@wpkernel/test-utils/next/builders/tests/ts.test-support';
+import { buildWorkspace } from '../../../../workspace';
+import type { Workspace } from '../../../../workspace';
+
+const withWorkspace = (
+	run: (context: BuilderHarnessContext<Workspace>) => Promise<void>
+) =>
+	baseWithWorkspace(run, { createWorkspace: (root) => buildWorkspace(root) });
 
 describe('ts shared helpers', () => {
 	describe('module specifiers', () => {

--- a/packages/cli/tests/test-support/php-builder.test-support.ts
+++ b/packages/cli/tests/test-support/php-builder.test-support.ts
@@ -1,5 +1,4 @@
 /* eslint-env jest */
-import path from 'node:path';
 import type { Reporter } from '@wpkernel/core/reporter';
 import type {
 	BuilderInput,
@@ -9,6 +8,7 @@ import type {
 import type { IRv1 } from '../../src/next/ir/publicTypes';
 import type { WPKernelConfigV1 } from '../../src/config/types';
 import { makeWorkspaceMock } from '../workspace.test-support';
+import type { Workspace } from '../../src/next/workspace/types';
 
 const DEFAULT_CONFIG_SOURCE = 'tests.config.ts';
 
@@ -25,12 +25,8 @@ export function createReporter(): Reporter {
 export function createPipelineContext(
 	overrides?: Partial<PipelineContext>
 ): PipelineContext {
-	const workspace = makeWorkspaceMock({
+	const workspace = makeWorkspaceMock<Workspace>({
 		root: '/workspace',
-		cwd: () => '/workspace',
-		resolve: (...parts: string[]) => path.join('/workspace', ...parts),
-		write: jest.fn(async () => undefined),
-		writeJson: jest.fn(async () => undefined),
 	});
 
 	const base: PipelineContext = {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -117,7 +117,6 @@
 		"test:coverage": "jest --coverage --watchman=false"
 	},
 	"peerDependencies": {
-		"@wpkernel/cli": "workspace:*",
 		"@wpkernel/core": "workspace:*",
 		"@wpkernel/ui": "workspace:*",
 		"react": ">=18.0.0"

--- a/packages/test-utils/src/core/action-runtime.ts
+++ b/packages/test-utils/src/core/action-runtime.ts
@@ -1,5 +1,9 @@
 import type { ActionRuntime } from '@wpkernel/core/actions/types.js';
 
+declare global {
+	var __WP_KERNEL_ACTION_RUNTIME__: ActionRuntime | undefined;
+}
+
 export interface ActionRuntimeOverrides {
 	runtime?: Partial<ActionRuntime>;
 	policy?: ActionRuntime['policy'];

--- a/packages/test-utils/src/next/types.ts
+++ b/packages/test-utils/src/next/types.ts
@@ -1,0 +1,204 @@
+export interface KernelConfigV1Like<
+	TSchemas extends Record<string, unknown> = Record<string, unknown>,
+	TResources extends Record<string, unknown> = Record<string, unknown>,
+	TAdapters = unknown,
+> {
+	readonly version: number;
+	readonly namespace: string;
+	readonly schemas: TSchemas;
+	readonly resources: TResources;
+	readonly adapters?: TAdapters;
+}
+
+export interface LoadedKernelConfigLike<
+	TConfig extends KernelConfigV1Like = KernelConfigV1Like,
+	TOrigin extends string = string,
+	TComposerCheck extends string = string,
+> {
+	readonly config: TConfig;
+	readonly sourcePath: string;
+	readonly configOrigin: TOrigin;
+	readonly composerCheck: TComposerCheck;
+	readonly namespace: string;
+}
+
+export interface IRRouteLike<
+	TMethod extends string = string,
+	TTransport extends string = string,
+	TPolicy = string | undefined,
+> {
+	readonly method: TMethod;
+	readonly path: string;
+	readonly policy?: TPolicy;
+	readonly hash: string;
+	readonly transport: TTransport;
+}
+
+export interface IRResourceCacheKeyLike<
+	TSegments extends readonly unknown[] = readonly unknown[],
+	TSource extends string = string,
+> {
+	readonly segments: TSegments;
+	readonly source: TSource;
+}
+
+export interface IRWarningLike<
+	TContext extends Record<string, unknown> = Record<string, unknown>,
+> {
+	readonly code: string;
+	readonly message: string;
+	readonly context?: TContext;
+}
+
+export interface IRResourceLike<
+	TRoute extends IRRouteLike = IRRouteLike,
+	TCacheKey extends IRResourceCacheKeyLike = IRResourceCacheKeyLike,
+	TIdentity = unknown,
+	TStorage = unknown,
+	TQueryParams = unknown,
+	TUi = unknown,
+	TWarning extends IRWarningLike = IRWarningLike,
+> {
+	readonly name: string;
+	readonly schemaKey: string;
+	readonly schemaProvenance: string;
+	readonly routes: readonly TRoute[];
+	readonly cacheKeys: {
+		readonly list: TCacheKey;
+		readonly get: TCacheKey;
+		readonly create?: TCacheKey;
+		readonly update?: TCacheKey;
+		readonly remove?: TCacheKey;
+	};
+	readonly identity?: TIdentity;
+	readonly storage?: TStorage;
+	readonly queryParams?: TQueryParams;
+	readonly ui?: TUi;
+	readonly hash: string;
+	readonly warnings: readonly TWarning[];
+}
+
+export interface IRMetaLike<TVersion extends number = number> {
+	readonly version: TVersion;
+	readonly namespace: string;
+	readonly sourcePath: string;
+	readonly origin: string;
+	readonly sanitizedNamespace: string;
+}
+
+export interface IRv1Like<
+	TConfig = KernelConfigV1Like,
+	TSchema = unknown,
+	TRoute extends IRRouteLike = IRRouteLike,
+	TResource extends IRResourceLike<TRoute> = IRResourceLike<TRoute>,
+	TPolicyHint = unknown,
+	TPolicyMap = unknown,
+	TBlock = unknown,
+	TPhpProject = unknown,
+	TDiagnostic = IRWarningLike,
+> {
+	readonly meta: IRMetaLike;
+	readonly config: TConfig;
+	readonly schemas: readonly TSchema[];
+	readonly resources: readonly TResource[];
+	readonly policies: readonly TPolicyHint[];
+	readonly policyMap: TPolicyMap;
+	readonly blocks: readonly TBlock[];
+	readonly php: TPhpProject;
+	readonly diagnostics?: readonly TDiagnostic[];
+}
+
+export interface BuildIrOptionsLike<TConfig = KernelConfigV1Like> {
+	readonly config: TConfig;
+	readonly namespace: string;
+	readonly origin: string;
+	readonly sourcePath: string;
+}
+
+export interface WorkspaceFileManifestLike {
+	readonly writes: readonly string[];
+	readonly deletes: readonly string[];
+}
+
+export interface WorkspaceWriteOptionsLike {
+	readonly mode?: number;
+	readonly ensureDir?: boolean;
+	readonly [key: string]: unknown;
+}
+
+export interface WorkspaceWriteJsonOptionsLike
+	extends WorkspaceWriteOptionsLike {
+	readonly pretty?: boolean;
+}
+
+export interface WorkspaceRemoveOptionsLike {
+	readonly recursive?: boolean;
+	readonly force?: boolean;
+	readonly [key: string]: unknown;
+}
+
+export interface WorkspaceMergeMarkersLike {
+	readonly start: string;
+	readonly mid: string;
+	readonly end: string;
+}
+
+export interface WorkspaceMergeOptionsLike {
+	readonly markers?: WorkspaceMergeMarkersLike;
+	readonly [key: string]: unknown;
+}
+
+export interface WorkspaceLike<
+	TFileManifest extends WorkspaceFileManifestLike = WorkspaceFileManifestLike,
+	TWriteOptions extends WorkspaceWriteOptionsLike = WorkspaceWriteOptionsLike,
+	TWriteJsonOptions extends
+		WorkspaceWriteJsonOptionsLike = WorkspaceWriteJsonOptionsLike,
+	TRemoveOptions extends
+		WorkspaceRemoveOptionsLike = WorkspaceRemoveOptionsLike,
+	TMergeOptions extends WorkspaceMergeOptionsLike = WorkspaceMergeOptionsLike,
+> {
+	readonly root: string;
+	cwd: () => string;
+	read: (file: string) => Promise<Buffer | null>;
+	readText: (file: string) => Promise<string | null>;
+	write: (
+		file: string,
+		data: Buffer | string,
+		options?: TWriteOptions
+	) => Promise<void>;
+	writeJson: <T>(
+		file: string,
+		value: T,
+		options?: TWriteJsonOptions
+	) => Promise<void>;
+	exists: (target: string) => Promise<boolean>;
+	rm: (target: string, options?: TRemoveOptions) => Promise<void>;
+	glob: (pattern: string | readonly string[]) => Promise<string[]>;
+	threeWayMerge: (
+		file: string,
+		base: string,
+		current: string,
+		incoming: string,
+		options?: TMergeOptions
+	) => Promise<'clean' | 'conflict'>;
+	begin: (label?: string) => void;
+	commit: (label?: string) => Promise<TFileManifest>;
+	rollback: (label?: string) => Promise<TFileManifest>;
+	dryRun: <T>(
+		fn: () => Promise<T>
+	) => Promise<{ result: T; manifest: TFileManifest }>;
+	tmpDir: (prefix?: string) => Promise<string>;
+	resolve: (...parts: string[]) => string;
+}
+
+export interface BuilderWriteActionLike<TContents = Buffer | string> {
+	readonly file: string;
+	readonly contents: TContents;
+}
+
+export interface BuilderOutputLike<
+	TAction extends BuilderWriteActionLike = BuilderWriteActionLike,
+> {
+	readonly actions: TAction[];
+	queueWrite: (action: TAction) => void;
+}

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -8,5 +8,5 @@
 	},
 	"include": ["src/**/*", "../../types/**/*.d.ts"],
 	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"],
-	"references": [{ "path": "../cli" }, { "path": "../core" }]
+	"references": [{ "path": "../core" }]
 }

--- a/packages/test-utils/tsconfig.tests.json
+++ b/packages/test-utils/tsconfig.tests.json
@@ -7,5 +7,5 @@
 		"types": ["node", "jest"]
 	},
 	"include": ["src/**/*.test.ts", "src/**/*.test.tsx"],
-	"references": [{ "path": "../cli" }, { "path": "../core" }]
+	"references": [{ "path": "../core" }]
 }


### PR DESCRIPTION
## Summary
Task 2.4: Break CLI ↔ test-utils cycle — drop CLI references from test-utils configs.

**Task IDs:** 2.4
**Scope:** cli · test-utils

## Links

- Roadmap section: N/A
- Sprint doc / spec: N/A
- Related issues: N/A
- Demo/preview (if any): N/A

## Why

Removing the lingering CLI dependency surfaces lets `@wpkernel/test-utils` compile without pulling in the CLI package, eliminating the cyclic dependency that blocked isolated builds.

## What

- Removed the `@wpkernel/cli` peer dependency from `@wpkernel/test-utils`.
- Dropped project references to the CLI package from the library and test tsconfig files so TypeScript no longer traverses the CLI sources when checking test-utils.

## How

By relying on the newly introduced generics in `@wpkernel/test-utils`, we no longer need to import CLI-specific types. Removing the peer dependency and TypeScript project references breaks the cycle while preserving core integrations via the shared type contracts.

## Testing

How reviewers test locally:

1. `pnpm --filter @wpkernel/test-utils typecheck`
   **Expected:** TypeScript exits cleanly with no errors.
2. `pnpm --filter @wpkernel/test-utils typecheck:tests`
   **Expected:** Test TypeScript project completes without errors.
3. `pnpm --filter @wpkernel/cli typecheck:tests`
   **Expected:** CLI test typechecks still succeed.

### Test Matrix (tick what’s covered)

- [ ] Unit (pnpm test)
- [ ] E2E (pnpm e2e)
- [x] Types (pnpm typecheck)
- [ ] Docs examples (build/run)
- [ ] WordPress playground / wp-env sanity

## Screenshots / Recordings (if applicable)

N/A

## Breaking Changes

- [x] None

## Affected Packages

- [ ] `@wpkernel/core`
- [ ] `@wpkernel/ui`
- [ ] `@wpkernel/cli`
- [ ] `@wpkernel/e2e-utils`
- [ ] `@wpkernel/php-driver`
- [ ] `@wpkernel/php-json-ast`
- [x] `@wpkernel/test-utils`

## Release

- [x] **patch** — bugfixes / alignment (0.x.1)
- [ ] **minor** — feature sprint (default) (0.x.0)
- [ ] **major** — breaking API (x.0.0)

## Checklist

- [x] No string-based generator was introduced or wrapped (PHP/blocks emitters remain AST-first).
- [ ] Tests pass (`pnpm test`, where relevant: `pnpm e2e`)
- [ ] Lint passes (`pnpm lint`)
- [x] Types pass (`pnpm typecheck`, `pnpm typecheck:tests`)
- [ ] CHANGELOG.md updated in affected packages (or PR labelled `no-release`)
- [ ] Docs updated (site/README)
- [ ] Examples updated (if API changed)
- [ ] Documentation under `packages/cli/docs/` (index, migration phases, tasks) updated if behaviour changed.


------
https://chatgpt.com/codex/tasks/task_e_69007f6a45bc8331aa426c7b4ec5d873