### PR TITLE
Task 33: Refactor defineAction onto the pipeline

### DIFF
--- a/packages/core/src/pipeline/actions/helpers/__tests__/buildActionContextAssembler.test.ts
+++ b/packages/core/src/pipeline/actions/helpers/__tests__/buildActionContextAssembler.test.ts
@@ -1,0 +1,78 @@
+import { buildActionContextAssembler } from '../buildActionContextAssembler';
+import type { ActionPipelineContext } from '../../types';
+import { WPKernelError } from '../../../../error/WPKernelError';
+
+jest.mock('../../../../actions/context', () => ({
+	createActionContext: jest.fn(() => ({
+		reporter: { channel: 'all' },
+		namespace: 'tests/namespace',
+	})),
+}));
+
+const { createActionContext } = jest.requireMock('../../../../actions/context');
+
+describe('buildActionContextAssembler', () => {
+	it('creates an action context and updates reporter/namespace', async () => {
+		const helper = buildActionContextAssembler<void, void>();
+		const context: ActionPipelineContext<void, void> = {
+			actionName: 'Test.Action',
+			namespace: 'tests',
+			reporter: { channel: 'none' } as never,
+			requestId: 'req',
+			resolvedOptions: { scope: 'crossTab', bridged: true },
+			config: {
+				name: 'Test.Action',
+				handler: async () => undefined,
+			},
+			args: undefined,
+			definition: {
+				action: (async () => undefined) as never,
+				namespace: 'tests',
+			},
+		};
+
+		await helper.apply({
+			context,
+			reporter: context.reporter,
+			input: { args: undefined },
+			output: {},
+		});
+
+		expect(createActionContext).toHaveBeenCalledWith(
+			'Test.Action',
+			'req',
+			context.resolvedOptions
+		);
+		expect(context.actionContext).toBeDefined();
+		expect(context.reporter).toEqual({ channel: 'all' });
+		expect(context.namespace).toBe('tests/namespace');
+	});
+
+	it('throws when resolved options are missing', async () => {
+		const helper = buildActionContextAssembler<void, void>();
+		const context: ActionPipelineContext<void, void> = {
+			actionName: 'Missing.Options',
+			namespace: 'tests',
+			reporter: { channel: 'none' } as never,
+			requestId: 'req',
+			config: {
+				name: 'Missing.Options',
+				handler: async () => undefined,
+			},
+			args: undefined,
+			definition: {
+				action: (async () => undefined) as never,
+				namespace: 'tests',
+			},
+		};
+
+		expect(() =>
+			helper.apply({
+				context,
+				reporter: context.reporter,
+				input: { args: undefined },
+				output: {},
+			})
+		).toThrow(WPKernelError);
+	});
+});

--- a/packages/core/src/pipeline/actions/helpers/__tests__/buildActionExecutionBuilder.test.ts
+++ b/packages/core/src/pipeline/actions/helpers/__tests__/buildActionExecutionBuilder.test.ts
@@ -30,13 +30,25 @@ describe('buildActionExecutionBuilder', () => {
 		bridged: true,
 	};
 	const reporter = {} as Reporter;
-	const baseContext: ActionPipelineContext = {
+	const baseContext: ActionPipelineContext<
+		{ value: number },
+		{ ok: boolean }
+	> = {
 		actionContext: {} as never,
 		actionName: 'Test.Action',
 		namespace: 'test',
 		reporter,
 		requestId: 'request-id',
 		resolvedOptions,
+		config: {
+			name: 'Test.Action',
+			handler: async () => ({ ok: true }),
+		},
+		args: { value: 0 },
+		definition: {
+			action: (async () => undefined) as never,
+			namespace: 'test',
+		},
 	};
 
 	beforeEach(() => {

--- a/packages/core/src/pipeline/actions/helpers/__tests__/buildActionOptionsResolver.test.ts
+++ b/packages/core/src/pipeline/actions/helpers/__tests__/buildActionOptionsResolver.test.ts
@@ -1,0 +1,42 @@
+import { buildActionOptionsResolver } from '../buildActionOptionsResolver';
+import type { ActionPipelineContext } from '../../types';
+import type { ResolvedActionOptions } from '../../../../actions/types';
+
+describe('buildActionOptionsResolver', () => {
+	it('resolves options and stores them on context and draft', async () => {
+		const helper = buildActionOptionsResolver<void, string>();
+		const context: ActionPipelineContext<void, string> = {
+			actionName: 'Test.Action',
+			namespace: 'tests',
+			reporter: {} as never,
+			requestId: 'request-id',
+			config: {
+				name: 'Test.Action',
+				handler: async () => 'ok',
+				options: { scope: 'tabLocal' },
+			},
+			args: undefined,
+			definition: {
+				action: (async () => undefined) as never,
+				namespace: 'tests',
+			},
+		};
+		const draft: { resolvedOptions?: ResolvedActionOptions } = {};
+
+		await helper.apply({
+			context,
+			reporter: context.reporter,
+			input: { args: undefined },
+			output: draft,
+		});
+
+		expect(context.resolvedOptions).toEqual({
+			scope: 'tabLocal',
+			bridged: false,
+		});
+		expect(draft.resolvedOptions).toEqual({
+			scope: 'tabLocal',
+			bridged: false,
+		});
+	});
+});

--- a/packages/core/src/pipeline/actions/helpers/__tests__/buildActionRegistryRecorder.test.ts
+++ b/packages/core/src/pipeline/actions/helpers/__tests__/buildActionRegistryRecorder.test.ts
@@ -1,0 +1,77 @@
+import { buildActionRegistryRecorder } from '../buildActionRegistryRecorder';
+import type { ActionPipelineContext } from '../../types';
+
+describe('buildActionRegistryRecorder', () => {
+	it('invokes registry bridge after downstream builders', async () => {
+		const helper = buildActionRegistryRecorder<void, void>();
+		const recordActionDefined = jest.fn();
+		const context: ActionPipelineContext<void, void> = {
+			actionName: 'Test.Action',
+			namespace: 'tests',
+			reporter: {} as never,
+			requestId: 'req',
+			resolvedOptions: { scope: 'crossTab', bridged: true },
+			actionContext: {} as never,
+			config: {
+				name: 'Test.Action',
+				handler: async () => undefined,
+			},
+			args: undefined,
+			definition: {
+				action: (async () => undefined) as never,
+				namespace: 'tests',
+			},
+			registry: { recordActionDefined },
+		};
+
+		const order: string[] = [];
+
+		await helper.apply(
+			{
+				context,
+				reporter: context.reporter,
+				input: { args: undefined, handler: async () => undefined },
+				output: {},
+			},
+			async () => {
+				order.push('next');
+			}
+		);
+
+		expect(order).toEqual(['next']);
+		expect(recordActionDefined).toHaveBeenCalledWith(context.definition);
+	});
+
+	it('tolerates missing registry bridges', async () => {
+		const helper = buildActionRegistryRecorder<void, void>();
+		const context: ActionPipelineContext<void, void> = {
+			actionName: 'No.Registry',
+			namespace: 'tests',
+			reporter: {} as never,
+			requestId: 'req',
+			resolvedOptions: { scope: 'crossTab', bridged: true },
+			actionContext: {} as never,
+			config: {
+				name: 'No.Registry',
+				handler: async () => undefined,
+			},
+			args: undefined,
+			definition: {
+				action: (async () => undefined) as never,
+				namespace: 'tests',
+			},
+		};
+
+		await expect(
+			helper.apply(
+				{
+					context,
+					reporter: context.reporter,
+					input: { args: undefined, handler: async () => undefined },
+					output: {},
+				},
+				undefined
+			)
+		).resolves.toBeUndefined();
+	});
+});

--- a/packages/core/src/pipeline/actions/helpers/buildActionContextAssembler.ts
+++ b/packages/core/src/pipeline/actions/helpers/buildActionContextAssembler.ts
@@ -1,0 +1,49 @@
+import { createHelper } from '../../helper';
+import { createActionContext } from '../../../actions/context';
+import { WPKernelError } from '../../../error/WPKernelError';
+import type {
+	ActionFragmentHelper,
+	ActionFragmentKind,
+	ActionInvocationDraft,
+	ActionLifecycleFragmentInput,
+	ActionPipelineContext,
+} from '../types';
+import { ACTION_FRAGMENT_KIND } from '../types';
+import type { Reporter } from '../../../reporter/types';
+
+export function buildActionContextAssembler<
+	TArgs,
+	TResult,
+>(): ActionFragmentHelper<TArgs, TResult> {
+	return createHelper<
+		ActionPipelineContext<TArgs, TResult>,
+		ActionLifecycleFragmentInput<TArgs>,
+		ActionInvocationDraft<TResult>,
+		Reporter,
+		ActionFragmentKind
+	>({
+		key: 'action.context.assemble',
+		kind: ACTION_FRAGMENT_KIND,
+		dependsOn: ['action.options.resolve'],
+		mode: 'extend',
+		priority: 90,
+		apply: ({ context }) => {
+			if (!context.resolvedOptions) {
+				throw new WPKernelError('DeveloperError', {
+					message:
+						'action.context.assemble requires resolved options before creating an action context.',
+				});
+			}
+
+			const actionContext = createActionContext(
+				context.actionName,
+				context.requestId,
+				context.resolvedOptions
+			);
+
+			context.actionContext = actionContext;
+			context.reporter = actionContext.reporter;
+			context.namespace = actionContext.namespace;
+		},
+	}) satisfies ActionFragmentHelper<TArgs, TResult>;
+}

--- a/packages/core/src/pipeline/actions/helpers/buildActionOptionsResolver.ts
+++ b/packages/core/src/pipeline/actions/helpers/buildActionOptionsResolver.ts
@@ -1,0 +1,46 @@
+import { createHelper } from '../../helper';
+import { resolveOptions } from '../../../actions/context';
+import type {
+	ActionFragmentHelper,
+	ActionFragmentKind,
+	ActionInvocationDraft,
+	ActionLifecycleFragmentInput,
+	ActionPipelineContext,
+} from '../types';
+import { ACTION_FRAGMENT_KIND } from '../types';
+import type { Reporter } from '../../../reporter/types';
+import type {
+	ActionOptions,
+	ResolvedActionOptions,
+} from '../../../actions/types';
+
+export function resolveActionDefinitionOptions(
+	options: ActionOptions | undefined
+): ResolvedActionOptions {
+	return resolveOptions(options);
+}
+
+export function buildActionOptionsResolver<
+	TArgs,
+	TResult,
+>(): ActionFragmentHelper<TArgs, TResult> {
+	return createHelper<
+		ActionPipelineContext<TArgs, TResult>,
+		ActionLifecycleFragmentInput<TArgs>,
+		ActionInvocationDraft<TResult>,
+		Reporter,
+		ActionFragmentKind
+	>({
+		key: 'action.options.resolve',
+		kind: ACTION_FRAGMENT_KIND,
+		mode: 'extend',
+		priority: 100,
+		apply: ({ context, output }) => {
+			const resolved = resolveOptions(
+				context.config.options as ActionOptions | undefined
+			);
+			context.resolvedOptions = resolved;
+			output.resolvedOptions = resolved;
+		},
+	}) satisfies ActionFragmentHelper<TArgs, TResult>;
+}

--- a/packages/core/src/pipeline/actions/helpers/buildActionRegistryRecorder.ts
+++ b/packages/core/src/pipeline/actions/helpers/buildActionRegistryRecorder.ts
@@ -1,0 +1,36 @@
+import { createHelper } from '../../helper';
+import type {
+	ActionBuilderHelper,
+	ActionBuilderInput,
+	ActionBuilderKind,
+	ActionInvocationDraft,
+	ActionPipelineContext,
+} from '../types';
+import { ACTION_BUILDER_KIND } from '../types';
+import type { Reporter } from '../../../reporter/types';
+
+export function buildActionRegistryRecorder<
+	TArgs,
+	TResult,
+>(): ActionBuilderHelper<TArgs, TResult> {
+	return createHelper<
+		ActionPipelineContext<TArgs, TResult>,
+		ActionBuilderInput<TArgs, TResult>,
+		ActionInvocationDraft<TResult>,
+		Reporter,
+		ActionBuilderKind
+	>({
+		key: 'action.registry.record',
+		kind: ACTION_BUILDER_KIND,
+		mode: 'extend',
+		priority: 60,
+		dependsOn: ['action.execute.handler'],
+		apply: async ({ context }, next) => {
+			if (next) {
+				await next();
+			}
+
+			context.registry?.recordActionDefined?.(context.definition);
+		},
+	}) satisfies ActionBuilderHelper<TArgs, TResult>;
+}

--- a/packages/core/src/pipeline/actions/helpers/makeActionErrorNormaliser.ts
+++ b/packages/core/src/pipeline/actions/helpers/makeActionErrorNormaliser.ts
@@ -1,0 +1,13 @@
+import { normalizeActionError } from '../../../actions/lifecycle';
+import type { ActionPipelineContext } from '../types';
+import type { WPKernelError } from '../../../error/WPKernelError';
+
+export type ActionErrorNormaliser = (
+	error: unknown,
+	context: Pick<ActionPipelineContext, 'actionName' | 'requestId'>
+) => WPKernelError;
+
+export function makeActionErrorNormaliser(): ActionErrorNormaliser {
+	return (error, context) =>
+		normalizeActionError(error, context.actionName, context.requestId);
+}

--- a/packages/core/src/pipeline/actions/helpers/makeActionRegistryBridge.ts
+++ b/packages/core/src/pipeline/actions/helpers/makeActionRegistryBridge.ts
@@ -1,0 +1,19 @@
+import type { ActionDefinedEvent } from '../../../events/bus';
+import type { CorePipelineRegistryBridge } from '../../helpers/context';
+
+export function makeActionRegistryBridge(
+	onRecord: (event: ActionDefinedEvent) => void
+): CorePipelineRegistryBridge {
+	let recorded = false;
+
+	return {
+		recordActionDefined(event) {
+			if (recorded) {
+				return;
+			}
+
+			onRecord(event);
+			recorded = true;
+		},
+	};
+}

--- a/packages/core/src/pipeline/helpers/__tests__/commit.test.ts
+++ b/packages/core/src/pipeline/helpers/__tests__/commit.test.ts
@@ -1,0 +1,54 @@
+import { buildPipelineCommit, buildPipelineRollback } from '../commit';
+
+describe('pipeline commit helpers', () => {
+	it('returns undefined when no tasks are provided', () => {
+		expect(buildPipelineCommit()).toBeUndefined();
+		expect(buildPipelineRollback()).toBeUndefined();
+	});
+
+	it('executes commit tasks sequentially', async () => {
+		const order: string[] = [];
+		const commit = buildPipelineCommit(
+			() => {
+				order.push('first');
+			},
+			() => {
+				order.push('second');
+			}
+		)!;
+
+		await commit();
+		expect(order).toEqual(['first', 'second']);
+	});
+
+	it('executes rollback tasks in reverse order', async () => {
+		const order: string[] = [];
+		const rollback = buildPipelineRollback(
+			() => {
+				order.push('first');
+			},
+			() => {
+				order.push('second');
+			}
+		)!;
+
+		await rollback();
+		expect(order).toEqual(['second', 'first']);
+	});
+
+	it('awaits asynchronous tasks before advancing', async () => {
+		const order: string[] = [];
+		const commit = buildPipelineCommit(
+			async () => {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				order.push('async');
+			},
+			() => {
+				order.push('sync');
+			}
+		)!;
+
+		await commit();
+		expect(order).toEqual(['async', 'sync']);
+	});
+});

--- a/packages/core/src/pipeline/helpers/__tests__/coreHelperCatalog.test.ts
+++ b/packages/core/src/pipeline/helpers/__tests__/coreHelperCatalog.test.ts
@@ -1,0 +1,30 @@
+import { buildCoreActionHelperCatalog } from '../actions/catalog';
+import { buildCoreResourceHelperCatalog } from '../resources/catalog';
+
+describe('core pipeline helper catalogues', () => {
+	it('lists action helpers for every lifecycle responsibility', () => {
+		const catalog = buildCoreActionHelperCatalog();
+		const keys = catalog.map((entry) => entry.key);
+		expect(new Set(keys).size).toBe(keys.length);
+		expect(catalog.map((entry) => entry.responsibility)).toEqual([
+			'options',
+			'context',
+			'lifecycle',
+			'execution',
+			'registry',
+		]);
+	});
+
+	it('lists resource helpers for every lifecycle responsibility', () => {
+		const catalog = buildCoreResourceHelperCatalog();
+		const keys = catalog.map((entry) => entry.key);
+		expect(new Set(keys).size).toBe(keys.length);
+		expect(catalog.map((entry) => entry.responsibility)).toEqual([
+			'validation',
+			'client',
+			'cache-keys',
+			'builder',
+			'registry',
+		]);
+	});
+});

--- a/packages/core/src/pipeline/helpers/actions/catalog.ts
+++ b/packages/core/src/pipeline/helpers/actions/catalog.ts
@@ -1,0 +1,61 @@
+import { ACTION_BUILDER_KIND, ACTION_FRAGMENT_KIND } from '../../actions/types';
+import type { HelperDescriptor } from '../../types';
+
+export type ActionLifecycleResponsibility =
+	| 'options'
+	| 'context'
+	| 'lifecycle'
+	| 'execution'
+	| 'registry';
+
+export interface CoreActionHelperDescriptor extends HelperDescriptor {
+	readonly responsibility: ActionLifecycleResponsibility;
+}
+
+/**
+ * Build the canonical helper descriptor catalogue for action orchestration.
+ */
+export function buildCoreActionHelperCatalog(): readonly CoreActionHelperDescriptor[] {
+	return [
+		{
+			key: 'action.options.resolve',
+			kind: ACTION_FRAGMENT_KIND,
+			mode: 'extend',
+			priority: 100,
+			dependsOn: [],
+			responsibility: 'options',
+		},
+		{
+			key: 'action.context.assemble',
+			kind: ACTION_FRAGMENT_KIND,
+			mode: 'extend',
+			priority: 90,
+			dependsOn: ['action.options.resolve'],
+			responsibility: 'context',
+		},
+		{
+			key: 'action.lifecycle.initialize',
+			kind: ACTION_FRAGMENT_KIND,
+			mode: 'extend',
+			priority: 80,
+			dependsOn: ['action.context.assemble'],
+			responsibility: 'lifecycle',
+		},
+		{
+			key: 'action.execute.handler',
+			kind: ACTION_BUILDER_KIND,
+			mode: 'extend',
+			priority: 70,
+			dependsOn: ['action.lifecycle.initialize'],
+			responsibility: 'execution',
+		},
+		{
+			key: 'action.registry.record',
+			kind: ACTION_BUILDER_KIND,
+			mode: 'extend',
+			priority: 60,
+			dependsOn: ['action.execute.handler'],
+			responsibility: 'registry',
+		},
+	];
+}

--- a/packages/core/src/pipeline/helpers/commit.ts
+++ b/packages/core/src/pipeline/helpers/commit.ts
@@ -1,0 +1,56 @@
+import type { MaybePromise } from '../types';
+
+type PipelineTask = () => MaybePromise<void> | void;
+
+type TaskInput = PipelineTask | undefined | null;
+
+function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		typeof (value as PromiseLike<T>).then === 'function'
+	);
+}
+
+function runSequential(tasks: readonly PipelineTask[]): MaybePromise<void> {
+	let index = 0;
+
+	const iterate = (): MaybePromise<void> | void => {
+		for (; index < tasks.length; index += 1) {
+			const result = tasks[index]!();
+			if (isPromiseLike(result)) {
+				index += 1;
+				return result.then(() => iterate());
+			}
+		}
+	};
+
+	return iterate();
+}
+
+function normaliseTasks(inputs: readonly TaskInput[]): PipelineTask[] {
+	return inputs.filter(Boolean) as PipelineTask[];
+}
+
+export function buildPipelineCommit(
+	...tasks: readonly TaskInput[]
+): (() => MaybePromise<void>) | undefined {
+	const normalised = normaliseTasks(tasks);
+	if (normalised.length === 0) {
+		return undefined;
+	}
+
+	return () => runSequential(normalised);
+}
+
+export function buildPipelineRollback(
+	...tasks: readonly TaskInput[]
+): (() => MaybePromise<void>) | undefined {
+	const normalised = normaliseTasks(tasks);
+	if (normalised.length === 0) {
+		return undefined;
+	}
+
+	const reversed = [...normalised].reverse();
+	return () => runSequential(reversed);
+}

--- a/packages/core/src/pipeline/helpers/context.ts
+++ b/packages/core/src/pipeline/helpers/context.ts
@@ -1,0 +1,31 @@
+import type { Reporter } from '../../reporter/types';
+import type {
+	ActionDefinedEvent,
+	ResourceDefinedEvent,
+} from '../../events/bus';
+
+/**
+ * Shared registry hooks surfaced to pipeline helpers.
+ */
+export interface CorePipelineRegistryBridge {
+	/**
+	 * Record an action definition once helper orchestration completes.
+	 */
+	readonly recordActionDefined?: (event: ActionDefinedEvent) => void;
+	/**
+	 * Record a resource definition once helper orchestration completes.
+	 */
+	readonly recordResourceDefined?: (event: ResourceDefinedEvent) => void;
+}
+
+/**
+ * Context contract shared across core pipeline helpers.
+ */
+export interface CorePipelineContext {
+	/** Structured reporter instance used for diagnostics. */
+	reporter: Reporter;
+	/** Namespace owning the resource or action under orchestration. */
+	namespace: string;
+	/** Optional registry bridge helpers surfaced to pipeline extensions. */
+	readonly registry?: CorePipelineRegistryBridge;
+}

--- a/packages/core/src/pipeline/helpers/resources/catalog.ts
+++ b/packages/core/src/pipeline/helpers/resources/catalog.ts
@@ -1,0 +1,64 @@
+import {
+	RESOURCE_BUILDER_KIND,
+	RESOURCE_FRAGMENT_KIND,
+} from '../../resources/types';
+import type { HelperDescriptor } from '../../types';
+
+export type ResourceLifecycleResponsibility =
+	| 'validation'
+	| 'client'
+	| 'cache-keys'
+	| 'builder'
+	| 'registry';
+
+export interface CoreResourceHelperDescriptor extends HelperDescriptor {
+	readonly responsibility: ResourceLifecycleResponsibility;
+}
+
+/**
+ * Build the canonical helper descriptor catalogue for resource orchestration.
+ */
+export function buildCoreResourceHelperCatalog(): readonly CoreResourceHelperDescriptor[] {
+	return [
+		{
+			key: 'resource.config.validate',
+			kind: RESOURCE_FRAGMENT_KIND,
+			mode: 'extend',
+			priority: 100,
+			dependsOn: [],
+			responsibility: 'validation',
+		},
+		{
+			key: 'resource.client.build',
+			kind: RESOURCE_FRAGMENT_KIND,
+			mode: 'extend',
+			priority: 90,
+			dependsOn: ['resource.config.validate'],
+			responsibility: 'client',
+		},
+		{
+			key: 'resource.cacheKeys.build',
+			kind: RESOURCE_FRAGMENT_KIND,
+			mode: 'extend',
+			priority: 80,
+			dependsOn: ['resource.client.build'],
+			responsibility: 'cache-keys',
+		},
+		{
+			key: 'resource.object.build',
+			kind: RESOURCE_BUILDER_KIND,
+			mode: 'extend',
+			priority: 70,
+			dependsOn: ['resource.cacheKeys.build'],
+			responsibility: 'builder',
+		},
+		{
+			key: 'resource.registry.record',
+			kind: RESOURCE_BUILDER_KIND,
+			mode: 'extend',
+			priority: 60,
+			dependsOn: ['resource.object.build'],
+			responsibility: 'registry',
+		},
+	];
+}

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -1,5 +1,6 @@
 export { createHelper } from './helper';
 export { createPipeline } from './createPipeline';
+export { buildPipelineCommit, buildPipelineRollback } from './helpers/commit';
 export type {
 	Helper,
 	HelperApplyFn,
@@ -25,3 +26,7 @@ export type {
 	FragmentFinalizationMetadata,
 	PipelineExecutionMetadata,
 } from './types';
+export type {
+	CorePipelineContext,
+	CorePipelineRegistryBridge,
+} from './helpers/context';

--- a/packages/core/src/pipeline/resources/types.ts
+++ b/packages/core/src/pipeline/resources/types.ts
@@ -13,6 +13,7 @@ import type {
 	PipelineDiagnostic,
 	PipelineRunState,
 } from '../types';
+import type { CorePipelineContext } from '../helpers/context';
 
 /**
  * Helper kind identifier reserved for resource lifecycle fragments.
@@ -57,11 +58,11 @@ export interface ResourcePipelineRunOptions<T, TQuery> {
 	/** Normalized configuration with defaults expanded. */
 	readonly normalizedConfig: NormalizedResourceConfig<T, TQuery>;
 	/** Namespace owning the resource (usually plugin slug). */
-	readonly namespace: string;
+	namespace: string;
 	/** Canonical resource name used for logging and cache keys. */
 	readonly resourceName: string;
 	/** Structured reporter used for diagnostics and telemetry. */
-	readonly reporter: Reporter;
+	reporter: Reporter;
 }
 
 export type ResourcePipelineBuildOptions<T, TQuery> =
@@ -79,7 +80,8 @@ export type ResourcePipelineBuildOptions<T, TQuery> =
  * ```
  */
 export interface ResourcePipelineContext<T, TQuery>
-	extends ResourcePipelineBuildOptions<T, TQuery> {
+	extends ResourcePipelineBuildOptions<T, TQuery>,
+		CorePipelineContext {
 	/** Unique key linking store entries and diagnostics to the resource. */
 	readonly storeKey: string;
 }

--- a/packages/test-utils/src/core/__tests__/buildCoreActionPipelineHarness.test.ts
+++ b/packages/test-utils/src/core/__tests__/buildCoreActionPipelineHarness.test.ts
@@ -1,0 +1,56 @@
+import type { Reporter } from '@wpkernel/core/reporter/types';
+import type { ActionPipelineRunOptions } from '@wpkernel/core/pipeline/actions/types';
+import { buildCoreActionPipelineHarness } from '../buildCoreActionPipelineHarness.test-support';
+
+describe('buildCoreActionPipelineHarness', () => {
+	afterEach(() => {
+		delete (
+			globalThis as {
+				__WP_KERNEL_ACTION_RUNTIME__?: { reporter?: Reporter };
+			}
+		).__WP_KERNEL_ACTION_RUNTIME__;
+	});
+
+	it('provides a pipeline that executes handlers through the harness reporter', async () => {
+		const harness = buildCoreActionPipelineHarness<
+			{ value: string },
+			string
+		>();
+
+		const runOptions: ActionPipelineRunOptions<{ value: string }, string> =
+			{
+				config: {
+					name: 'Tests.Action',
+					handler: async () => 'ok',
+				},
+				args: { value: 'demo' },
+				definition: {
+					action: (async () => undefined) as never,
+					namespace: harness.namespace,
+				},
+			};
+
+		const result = await harness.pipeline.run(runOptions);
+		expect(result.artifact.result).toBe('ok');
+		harness.teardown();
+	});
+
+	it('installs and restores the runtime reporter around the pipeline lifecycle', () => {
+		const harness = buildCoreActionPipelineHarness();
+		const runtime = (
+			globalThis as {
+				__WP_KERNEL_ACTION_RUNTIME__?: { reporter?: Reporter };
+			}
+		).__WP_KERNEL_ACTION_RUNTIME__;
+
+		expect(runtime?.reporter).toBe(harness.reporter.reporter as Reporter);
+		harness.teardown();
+		expect(
+			(
+				globalThis as {
+					__WP_KERNEL_ACTION_RUNTIME__?: unknown;
+				}
+			).__WP_KERNEL_ACTION_RUNTIME__
+		).toBeUndefined();
+	});
+});

--- a/packages/test-utils/src/core/__tests__/buildCoreResourcePipelineHarness.test.ts
+++ b/packages/test-utils/src/core/__tests__/buildCoreResourcePipelineHarness.test.ts
@@ -1,0 +1,32 @@
+import type { ResourcePipelineRunOptions } from '@wpkernel/core/pipeline/resources/types';
+import { buildCoreResourcePipelineHarness } from '../buildCoreResourcePipelineHarness.test-support';
+
+describe('buildCoreResourcePipelineHarness', () => {
+	it('creates a pipeline and reporter for resource orchestration', async () => {
+		const harness = buildCoreResourcePipelineHarness<
+			{ id: number },
+			{ search?: string }
+		>({ resourceName: 'example-resource' });
+
+		const config = {
+			name: 'example-resource',
+			routes: {
+				list: { path: '/example/v1/resources', method: 'GET' as const },
+			},
+		};
+
+		const runOptions: ResourcePipelineRunOptions<
+			{ id: number },
+			{ search?: string }
+		> = {
+			config,
+			normalizedConfig: { ...config },
+			namespace: harness.namespace,
+			resourceName: harness.resourceName,
+			reporter: harness.reporter.reporter,
+		};
+
+		const result = await harness.pipeline.run(runOptions);
+		expect(result.artifact.resource?.name).toBe('example-resource');
+	});
+});

--- a/packages/test-utils/src/core/__tests__/memory-reporter.test.ts
+++ b/packages/test-utils/src/core/__tests__/memory-reporter.test.ts
@@ -1,0 +1,39 @@
+import { createMemoryReporter } from '../memory-reporter.test-support';
+
+describe('createMemoryReporter', () => {
+	it('records log entries with namespace context', () => {
+		const reporter = createMemoryReporter('tests');
+		reporter.reporter.info('message', { foo: 'bar' });
+		reporter.reporter.error('boom');
+
+		expect(reporter.entries).toEqual([
+			{
+				level: 'info',
+				message: 'message',
+				namespace: 'tests',
+				context: { foo: 'bar' },
+			},
+			{
+				level: 'error',
+				message: 'boom',
+				namespace: 'tests',
+				context: undefined,
+			},
+		]);
+	});
+
+	it('shares state across child reporters', () => {
+		const reporter = createMemoryReporter('tests');
+		const child = reporter.reporter.child('child');
+		child.debug('nested');
+
+		expect(reporter.entries).toEqual([
+			{
+				level: 'debug',
+				message: 'nested',
+				namespace: 'tests.child',
+				context: undefined,
+			},
+		]);
+	});
+});

--- a/packages/test-utils/src/core/buildCoreActionPipelineHarness.test-support.ts
+++ b/packages/test-utils/src/core/buildCoreActionPipelineHarness.test-support.ts
@@ -1,0 +1,60 @@
+import { createActionPipeline } from '@wpkernel/core/pipeline/actions/createActionPipeline';
+import type { ActionPipeline } from '@wpkernel/core/pipeline/actions/types';
+import { createMemoryReporter } from './memory-reporter.test-support';
+import type { MemoryReporter } from './memory-reporter.test-support';
+
+interface RuntimeOverrides {
+	readonly reporter?: unknown;
+	readonly [key: string]: unknown;
+}
+
+export interface BuildCoreActionPipelineHarnessOptions<TArgs, TResult> {
+	readonly namespace?: string;
+	readonly runtime?: RuntimeOverrides;
+	readonly pipelineFactory?: () => ActionPipeline<TArgs, TResult>;
+}
+
+export interface CoreActionPipelineHarness<TArgs, TResult> {
+	readonly pipeline: ActionPipeline<TArgs, TResult>;
+	readonly reporter: MemoryReporter;
+	readonly namespace: string;
+	teardown: () => void;
+}
+
+export function buildCoreActionPipelineHarness<TArgs, TResult>(
+	options: BuildCoreActionPipelineHarnessOptions<TArgs, TResult> = {}
+): CoreActionPipelineHarness<TArgs, TResult> {
+	const namespace = options.namespace ?? 'tests';
+	const reporter = createMemoryReporter(namespace);
+	const globalRuntime = globalThis as {
+		__WP_KERNEL_ACTION_RUNTIME__?: Record<string, unknown>;
+	};
+	const previousRuntime = globalRuntime.__WP_KERNEL_ACTION_RUNTIME__;
+	const nextRuntime = {
+		...(previousRuntime ?? {}),
+		...options.runtime,
+		reporter: (options.runtime?.reporter ?? reporter.reporter) as unknown,
+	} as RuntimeOverrides;
+
+	globalRuntime.__WP_KERNEL_ACTION_RUNTIME__ = nextRuntime;
+
+	const pipelineFactory =
+		options.pipelineFactory ??
+		(() => createActionPipeline<TArgs, TResult>());
+	const pipeline = pipelineFactory();
+
+	const teardown = () => {
+		if (typeof previousRuntime === 'undefined') {
+			delete globalRuntime.__WP_KERNEL_ACTION_RUNTIME__;
+		} else {
+			globalRuntime.__WP_KERNEL_ACTION_RUNTIME__ = previousRuntime;
+		}
+	};
+
+	return {
+		pipeline,
+		reporter,
+		namespace,
+		teardown,
+	};
+}

--- a/packages/test-utils/src/core/buildCoreResourcePipelineHarness.test-support.ts
+++ b/packages/test-utils/src/core/buildCoreResourcePipelineHarness.test-support.ts
@@ -1,0 +1,34 @@
+import { createResourcePipeline } from '@wpkernel/core/pipeline/resources/createResourcePipeline';
+import type { ResourcePipeline } from '@wpkernel/core/pipeline/resources/types';
+import { createMemoryReporter } from './memory-reporter.test-support';
+import type { MemoryReporter } from './memory-reporter.test-support';
+
+export interface BuildCoreResourcePipelineHarnessOptions<T, TQuery> {
+	readonly namespace?: string;
+	readonly resourceName?: string;
+	readonly pipelineFactory?: () => ResourcePipeline<T, TQuery>;
+}
+
+export interface CoreResourcePipelineHarness<T, TQuery> {
+	readonly pipeline: ResourcePipeline<T, TQuery>;
+	readonly reporter: MemoryReporter;
+	readonly namespace: string;
+	readonly resourceName: string;
+}
+
+export function buildCoreResourcePipelineHarness<T, TQuery>(
+	options: BuildCoreResourcePipelineHarnessOptions<T, TQuery> = {}
+): CoreResourcePipelineHarness<T, TQuery> {
+	const namespace = options.namespace ?? 'tests';
+	const resourceName = options.resourceName ?? 'Resource';
+	const reporter = createMemoryReporter(namespace);
+	const pipelineFactory =
+		options.pipelineFactory ?? (() => createResourcePipeline<T, TQuery>());
+
+	return {
+		pipeline: pipelineFactory(),
+		reporter,
+		namespace,
+		resourceName,
+	};
+}

--- a/packages/test-utils/src/core/index.ts
+++ b/packages/test-utils/src/core/index.ts
@@ -1,2 +1,5 @@
 export * from './wp-harness.js';
 export * from './action-runtime.js';
+export * from './memory-reporter.test-support.js';
+export * from './buildCoreActionPipelineHarness.test-support.js';
+export * from './buildCoreResourcePipelineHarness.test-support.js';

--- a/packages/test-utils/src/core/memory-reporter.test-support.ts
+++ b/packages/test-utils/src/core/memory-reporter.test-support.ts
@@ -1,0 +1,63 @@
+import type { Reporter, ReporterLevel } from '@wpkernel/core/reporter/types';
+
+export interface MemoryReporterEntry {
+	readonly level: ReporterLevel;
+	readonly message: string;
+	readonly namespace: string;
+	readonly context?: unknown;
+}
+
+export interface MemoryReporter {
+	readonly reporter: Reporter;
+	readonly namespace: string;
+	readonly entries: MemoryReporterEntry[];
+	clear: () => void;
+}
+
+function createReporterForNamespace(
+	namespace: string,
+	entries: MemoryReporterEntry[]
+): Reporter {
+	const record = (
+		level: ReporterLevel,
+		message: string,
+		context?: unknown
+	) => {
+		entries.push({ level, message, namespace, context });
+	};
+
+	return {
+		info(message, context) {
+			record('info', message, context);
+		},
+		warn(message, context) {
+			record('warn', message, context);
+		},
+		error(message, context) {
+			record('error', message, context);
+		},
+		debug(message, context) {
+			record('debug', message, context);
+		},
+		child(childNamespace: string) {
+			return createReporterForNamespace(
+				`${namespace}.${childNamespace}`,
+				entries
+			);
+		},
+	} satisfies Reporter;
+}
+
+export function createMemoryReporter(namespace = 'tests'): MemoryReporter {
+	const entries: MemoryReporterEntry[] = [];
+	const reporter = createReporterForNamespace(namespace, entries);
+
+	return {
+		reporter,
+		namespace,
+		entries,
+		clear() {
+			entries.length = 0;
+		},
+	};
+}


### PR DESCRIPTION
## Summary
- implement the action pipeline helper suite for option resolution, context assembly, execution, error normalisation, and registry bridging
- rework createActionPipeline/defineAction to thread definition metadata, registry bridges, and the expanded ActionPipelineContext types
- add dedicated unit and integration coverage while updating the Task 33 documentation entry to reflect completion

## Testing
- pnpm --filter @wpkernel/core test
- pnpm --filter @wpkernel/core typecheck
- pnpm --filter @wpkernel/core typecheck:tests
- pnpm --filter @wpkernel/test-utils test
- pnpm --filter @wpkernel/test-utils typecheck
- pnpm --filter @wpkernel/test-utils typecheck:tests

------
https://chatgpt.com/codex/tasks/task_e_690189cfaacc8331b3b1a51416a977f4