### PR TITLE
feat: add pipeline and ir packages

### DIFF
--- a/packages/intermediate-representation/CHANGELOG.md
+++ b/packages/intermediate-representation/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @wpkernel/intermediate-representation
+
+## Unreleased
+
+### Added
+
+- Initial workspace scaffold defining the shared intermediate representation data model.

--- a/packages/intermediate-representation/LICENSE
+++ b/packages/intermediate-representation/LICENSE
@@ -1,0 +1,1 @@
+This package is licensed under the EUPL-1.2. See the repository root LICENSE file for the full text.

--- a/packages/intermediate-representation/README.md
+++ b/packages/intermediate-representation/README.md
@@ -1,0 +1,7 @@
+# @wpkernel/intermediate-representation
+
+Shared intermediate representation (IR) types that describe the structures emitted by kernel compilation passes. The package centralises IR contracts so transports, optimisers, and emitters can collaborate without tight coupling.
+
+## Status
+
+The initial release focuses on the core data model. Transformations and validation helpers will follow.

--- a/packages/intermediate-representation/package.json
+++ b/packages/intermediate-representation/package.json
@@ -1,0 +1,57 @@
+{
+	"name": "@wpkernel/intermediate-representation",
+	"version": "0.9.0",
+	"description": "Shared intermediate representation (IR) model for kernel compiler pipelines.",
+	"license": "EUPL-1.2",
+	"type": "module",
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/theGeekist/wp-kernel.git",
+		"directory": "packages/intermediate-representation"
+	},
+	"homepage": "https://github.com/theGeekist/wp-kernel#readme",
+	"bugs": {
+		"url": "https://github.com/theGeekist/wp-kernel/issues"
+	},
+	"keywords": [
+		"wordpress",
+		"compiler",
+		"ir",
+		"representation"
+	],
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"files": [
+		"dist",
+		"README.md",
+		"LICENSE"
+	],
+	"scripts": {
+		"build": "vite build && tsc --noEmit",
+		"lint": "eslint src/",
+		"lint:fix": "eslint src/ --fix",
+		"test": "jest --passWithNoTests --watchman=false",
+		"test:coverage": "jest --coverage --watchman=false",
+		"test:watch": "jest --watch",
+		"typecheck": "tsc --noEmit",
+		"typecheck:tests": "tsc --project tsconfig.tests.json --noEmit"
+	},
+	"devDependencies": {
+		"@wpkernel/scripts": "workspace:*"
+	},
+	"peerDependencies": {},
+	"dependencies": {},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/intermediate-representation/src/index.ts
+++ b/packages/intermediate-representation/src/index.ts
@@ -1,0 +1,100 @@
+export type IntermediateScalar = string | number | boolean | null;
+
+export interface IntermediateAttributeMap {
+	readonly [key: string]:
+		| IntermediateScalar
+		| IntermediateAttributeMap
+		| IntermediateScalar[];
+}
+
+export interface IntermediateNode<
+	Kind extends string = string,
+	Metadata extends IntermediateAttributeMap = IntermediateAttributeMap,
+> {
+	readonly id: string;
+	readonly kind: Kind;
+	readonly attributes: Metadata;
+}
+
+export interface IntermediateEdge<
+	Kind extends string = string,
+	Metadata extends IntermediateAttributeMap = IntermediateAttributeMap,
+> {
+	readonly id: string;
+	readonly from: string;
+	readonly to: string;
+	readonly kind: Kind;
+	readonly attributes: Metadata;
+}
+
+export interface IntermediateRepresentation<
+	NodeKind extends string = string,
+	EdgeKind extends string = string,
+	NodeMetadata extends IntermediateAttributeMap = IntermediateAttributeMap,
+	EdgeMetadata extends IntermediateAttributeMap = IntermediateAttributeMap,
+> {
+	readonly nodes: readonly IntermediateNode<NodeKind, NodeMetadata>[];
+	readonly edges: readonly IntermediateEdge<EdgeKind, EdgeMetadata>[];
+	readonly metadata?: IntermediateAttributeMap;
+}
+
+export interface IntermediateRepresentationDraft<
+	NodeKind extends string = string,
+	EdgeKind extends string = string,
+	NodeMetadata extends IntermediateAttributeMap = IntermediateAttributeMap,
+	EdgeMetadata extends IntermediateAttributeMap = IntermediateAttributeMap,
+> {
+	readonly nodes?: IntermediateNode<NodeKind, NodeMetadata>[];
+	readonly edges?: IntermediateEdge<EdgeKind, EdgeMetadata>[];
+	readonly metadata?: IntermediateAttributeMap;
+}
+
+export function createIntermediateRepresentation<
+	NodeKind extends string,
+	EdgeKind extends string,
+	NodeMetadata extends IntermediateAttributeMap,
+	EdgeMetadata extends IntermediateAttributeMap,
+>(
+	draft: IntermediateRepresentationDraft<
+		NodeKind,
+		EdgeKind,
+		NodeMetadata,
+		EdgeMetadata
+	>
+): IntermediateRepresentation<NodeKind, EdgeKind, NodeMetadata, EdgeMetadata> {
+	return {
+		nodes: draft.nodes ?? [],
+		edges: draft.edges ?? [],
+		metadata: draft.metadata,
+	};
+}
+
+export function isIntermediateNode(value: unknown): value is IntermediateNode {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	const candidate = value as Partial<IntermediateNode>;
+	return (
+		typeof candidate.id === 'string' &&
+		typeof candidate.kind === 'string' &&
+		typeof candidate.attributes === 'object' &&
+		candidate.attributes !== null
+	);
+}
+
+export function isIntermediateEdge(value: unknown): value is IntermediateEdge {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	const candidate = value as Partial<IntermediateEdge>;
+	return (
+		typeof candidate.id === 'string' &&
+		typeof candidate.kind === 'string' &&
+		typeof candidate.from === 'string' &&
+		typeof candidate.to === 'string' &&
+		typeof candidate.attributes === 'object' &&
+		candidate.attributes !== null
+	);
+}

--- a/packages/intermediate-representation/tsconfig.json
+++ b/packages/intermediate-representation/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist"
+	},
+	"include": ["src/**/*"],
+	"exclude": [
+		"node_modules",
+		"dist",
+		"**/*.test.ts",
+		"**/*.test.tsx",
+		"**/*.test-support.ts",
+		"**/*.test-support.tsx"
+	]
+}

--- a/packages/intermediate-representation/tsconfig.tests.json
+++ b/packages/intermediate-representation/tsconfig.tests.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": "../../tsconfig.tests.json",
+	"compilerOptions": {
+		"rootDir": "../..",
+		"outDir": "./dist-tests"
+	},
+	"include": ["src/**/*", "tests/**/*"],
+	"exclude": [
+		"node_modules",
+		"dist",
+		"dist-tests",
+		"**/dist",
+		"**/*.test-support.d.ts"
+	]
+}

--- a/packages/pipeline/CHANGELOG.md
+++ b/packages/pipeline/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @wpkernel/pipeline
+
+## Unreleased
+
+### Added
+
+- Initial workspace scaffold with foundational pipeline builder primitives.

--- a/packages/pipeline/LICENSE
+++ b/packages/pipeline/LICENSE
@@ -1,0 +1,1 @@
+This package is licensed under the EUPL-1.2. See the repository root LICENSE file for the full text.

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -1,0 +1,7 @@
+# @wpkernel/pipeline
+
+Composable execution primitives for coordinating WPKernel workloads. This package extracts the reusable pipeline scaffolding so other workspaces can orchestrate staged behaviours without depending on the entire core runtime.
+
+## Status
+
+The package currently provides lightweight builder utilities. Additional behaviours will land as the pipeline is extracted from `@wpkernel/core`.

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -1,0 +1,57 @@
+{
+	"name": "@wpkernel/pipeline",
+	"version": "0.9.0",
+	"description": "Composable execution pipelines for coordinating WPKernel workloads.",
+	"license": "EUPL-1.2",
+	"type": "module",
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/theGeekist/wp-kernel.git",
+		"directory": "packages/pipeline"
+	},
+	"homepage": "https://github.com/theGeekist/wp-kernel#readme",
+	"bugs": {
+		"url": "https://github.com/theGeekist/wp-kernel/issues"
+	},
+	"keywords": [
+		"wordpress",
+		"pipeline",
+		"workflow",
+		"tasks"
+	],
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"files": [
+		"dist",
+		"README.md",
+		"LICENSE"
+	],
+	"scripts": {
+		"build": "vite build && tsc --noEmit",
+		"lint": "eslint src/",
+		"lint:fix": "eslint src/ --fix",
+		"test": "jest --passWithNoTests --watchman=false",
+		"test:coverage": "jest --coverage --watchman=false",
+		"test:watch": "jest --watch",
+		"typecheck": "tsc --noEmit",
+		"typecheck:tests": "tsc --project tsconfig.tests.json --noEmit"
+	},
+	"devDependencies": {
+		"@wpkernel/scripts": "workspace:*"
+	},
+	"peerDependencies": {},
+	"dependencies": {},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -1,0 +1,101 @@
+export type StageResult<Output> = Output | Promise<Output>;
+
+export interface PipelineContext<Shared> {
+	readonly shared: Shared;
+}
+
+export interface PipelineStage<Input, Output, Shared = void> {
+	readonly name: string;
+	readonly run: (
+		input: Input,
+		context: PipelineContext<Shared>
+	) => StageResult<Output>;
+}
+
+export interface Pipeline<InitialInput, FinalOutput, Shared = void> {
+	readonly stages: readonly PipelineStage<unknown, unknown, Shared>[];
+	run: (input: InitialInput, shared: Shared) => Promise<FinalOutput>;
+}
+
+class DefaultPipeline<InitialInput, FinalOutput, Shared>
+	implements Pipeline<InitialInput, FinalOutput, Shared>
+{
+	public constructor(
+		public readonly stages: readonly PipelineStage<
+			unknown,
+			unknown,
+			Shared
+		>[],
+		private readonly runner: (
+			input: InitialInput,
+			shared: Shared
+		) => Promise<FinalOutput>
+	) {}
+
+	public async run(
+		input: InitialInput,
+		shared: Shared
+	): Promise<FinalOutput> {
+		return this.runner(input, shared);
+	}
+}
+
+export class PipelineBuilder<InitialInput, CurrentOutput, Shared = void> {
+	private constructor(
+		private readonly stages: readonly PipelineStage<
+			unknown,
+			unknown,
+			Shared
+		>[],
+		private readonly executor: (
+			input: InitialInput,
+			shared: Shared
+		) => Promise<CurrentOutput>
+	) {}
+
+	public static start<InitialInput, FirstOutput, Shared = void>(
+		stage: PipelineStage<InitialInput, FirstOutput, Shared>
+	): PipelineBuilder<InitialInput, FirstOutput, Shared> {
+		const stages: PipelineStage<unknown, unknown, Shared>[] = [
+			stage as PipelineStage<unknown, unknown, Shared>,
+		];
+		const executor = async (
+			input: InitialInput,
+			shared: Shared
+		): Promise<FirstOutput> => {
+			const context: PipelineContext<Shared> = { shared };
+			return stage.run(input, context);
+		};
+
+		return new PipelineBuilder(stages, executor);
+	}
+
+	public addStage<NextOutput>(
+		stage: PipelineStage<CurrentOutput, NextOutput, Shared>
+	): PipelineBuilder<InitialInput, NextOutput, Shared> {
+		const stages: PipelineStage<unknown, unknown, Shared>[] = [
+			...this.stages,
+			stage as PipelineStage<unknown, unknown, Shared>,
+		];
+		const executor = async (
+			input: InitialInput,
+			shared: Shared
+		): Promise<NextOutput> => {
+			const context: PipelineContext<Shared> = { shared };
+			const current = await this.executor(input, shared);
+			return stage.run(current, context);
+		};
+
+		return new PipelineBuilder(stages, executor);
+	}
+
+	public build(): Pipeline<InitialInput, CurrentOutput, Shared> {
+		return new DefaultPipeline(this.stages, this.executor);
+	}
+}
+
+export function createPipeline<InitialInput, FirstOutput, Shared = void>(
+	stage: PipelineStage<InitialInput, FirstOutput, Shared>
+): PipelineBuilder<InitialInput, FirstOutput, Shared> {
+	return PipelineBuilder.start(stage);
+}

--- a/packages/pipeline/tsconfig.json
+++ b/packages/pipeline/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist"
+	},
+	"include": ["src/**/*"],
+	"exclude": [
+		"node_modules",
+		"dist",
+		"**/*.test.ts",
+		"**/*.test.tsx",
+		"**/*.test-support.ts",
+		"**/*.test-support.tsx"
+	]
+}

--- a/packages/pipeline/tsconfig.tests.json
+++ b/packages/pipeline/tsconfig.tests.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": "../../tsconfig.tests.json",
+	"compilerOptions": {
+		"rootDir": "../..",
+		"outDir": "./dist-tests"
+	},
+	"include": ["src/**/*", "tests/**/*"],
+	"exclude": [
+		"node_modules",
+		"dist",
+		"dist-tests",
+		"**/dist",
+		"**/*.test-support.d.ts"
+	]
+}

--- a/scripts/pre-commit.ts
+++ b/scripts/pre-commit.ts
@@ -57,6 +57,18 @@ const TYPECHECK_TARGETS = {
 		packageName: '@wpkernel/create-wpk',
 		directory: 'packages/create-wpk/',
 	},
+	'intermediate-representation': {
+		label: 'Intermediate representation workspace',
+		filter: '@wpkernel/intermediate-representation',
+		packageName: '@wpkernel/intermediate-representation',
+		directory: 'packages/intermediate-representation/',
+	},
+	pipeline: {
+		label: 'Pipeline workspace',
+		filter: '@wpkernel/pipeline',
+		packageName: '@wpkernel/pipeline',
+		directory: 'packages/pipeline/',
+	},
 	ui: {
 		label: 'UI workspace',
 		filter: '@wpkernel/ui',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -36,7 +36,15 @@
 			"@wpkernel/wp-json-ast": ["./packages/wp-json-ast/src/index.ts"],
 			"@wpkernel/wp-json-ast/*": ["./packages/wp-json-ast/src/*"],
 			"@wpkernel/create-wpk": ["./packages/create-wpk/src/index.ts"],
-			"@wpkernel/create-wpk/*": ["./packages/create-wpk/src/*"]
+			"@wpkernel/create-wpk/*": ["./packages/create-wpk/src/*"],
+			"@wpkernel/pipeline": ["./packages/pipeline/src/index.ts"],
+			"@wpkernel/pipeline/*": ["./packages/pipeline/src/*"],
+			"@wpkernel/intermediate-representation": [
+				"./packages/intermediate-representation/src/index.ts"
+			],
+			"@wpkernel/intermediate-representation/*": [
+				"./packages/intermediate-representation/src/*"
+			]
 		},
 
 		// Type Checking (Strict Mode)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,6 +50,18 @@
 		},
 		{
 			"path": "./packages/create-wpk/tsconfig.tests.json"
+		},
+		{
+			"path": "./packages/pipeline"
+		},
+		{
+			"path": "./packages/pipeline/tsconfig.tests.json"
+		},
+		{
+			"path": "./packages/intermediate-representation"
+		},
+		{
+			"path": "./packages/intermediate-representation/tsconfig.tests.json"
 		}
 	]
 }


### PR DESCRIPTION
## Summary
- scaffold new `@wpkernel/pipeline` workspace with initial pipeline builder utilities, metadata, and changelog
- add `@wpkernel/intermediate-representation` workspace with shared IR types and documentation
- register both packages across TypeScript configs and the pre-commit hook's typecheck targets

## Testing
- `pnpm --filter @wpkernel/pipeline typecheck`
- `pnpm --filter @wpkernel/intermediate-representation typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6902a6d8e5088331b4ca8d095de2c3d8