### PR TITLE
Task: Complete Phase 3.1 capability tasks

### DIFF
--- a/packages/cli/src/next/builders/php/resourceController.ts
+++ b/packages/cli/src/next/builders/php/resourceController.ts
@@ -57,7 +57,7 @@ export function createPhpResourceControllerHelper(): BuilderHelper {
 				origin: ir.meta.origin,
 				pluginNamespace: ir.php.namespace,
 				sanitizedNamespace: ir.meta.sanitizedNamespace,
-				capabilityClass: `${ir.php.namespace}\\Capability\\Capability`,
+				capabilityClass: `${ir.php.namespace}\\Generated\\Capability\\Capability`,
 				resources: buildResourcePlans(ir),
 				includeBaseController: false,
 			});

--- a/packages/cli/src/next/builders/php/test-support/capabilityProtectedResource.test-support.ts
+++ b/packages/cli/src/next/builders/php/test-support/capabilityProtectedResource.test-support.ts
@@ -1,0 +1,15 @@
+import type { IRResource } from '../../../../ir/publicTypes';
+import {
+	makeWpPostResource,
+	makeWpPostRoutes,
+} from '@wpkernel/test-utils/next/builders/php/resources.test-support';
+
+export function makeCapabilityProtectedResource(): IRResource {
+	const routes = makeWpPostRoutes().map((route) =>
+		route.method === 'POST'
+			? { ...route, capability: 'manage_books' }
+			: route
+	);
+
+	return makeWpPostResource({ routes }) as unknown as IRResource;
+}


### PR DESCRIPTION
## Summary
- align the REST controller helper with the generated capability namespace emitted by the capability module
- add a capability-protected resource fixture and CLI integration test that verifies the generated import, metadata, and planner entry
- mark Subtasks 3.1.d and 3.1.e complete in the AST reduction plan

## Testing
- pnpm --filter @wpkernel/cli test -- resourceController

------
https://chatgpt.com/codex/tasks/task_e_69035687f86883319e3443bef0f1c9ba