### PR TITLE
Task 3.3.b: Introduce createPhpWpPostRoutesHelper

### DIFF
--- a/packages/cli/src/next/builders/php/resource/index.ts
+++ b/packages/cli/src/next/builders/php/resource/index.ts
@@ -8,6 +8,8 @@ export * from './errors';
 export * from './mutationContract';
 export * from './wpPost/identity';
 export * from './wpPost/mutations';
+export { createPhpWpPostRoutesHelper } from './wpPost/routes';
+export type { CreatePhpWpPostRoutesHelperOptions } from './wpPost/routes';
 export {
 	buildListForeachStatement,
 	buildListItemsInitialiserStatement,

--- a/packages/cli/src/next/builders/php/resource/wpPost/__tests__/routes.test.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/__tests__/routes.test.ts
@@ -1,0 +1,108 @@
+import {
+	buildWpPostRouteBundle,
+	type ResourceMetadataHost,
+} from '@wpkernel/wp-json-ast';
+import { createPhpWpPostRoutesHelper } from '../routes';
+import type { IRResource } from '../../../../../ir/publicTypes';
+import type { ResolvedIdentity } from '../../../identity';
+
+describe('createPhpWpPostRoutesHelper', () => {
+	const identity: ResolvedIdentity = { type: 'number', param: 'id' };
+	const errorCodeFactory = (suffix: string) => `book_${suffix}`;
+
+	function buildResource(storage?: IRResource['storage']): IRResource {
+		return {
+			name: 'book',
+			schemaKey: 'book',
+			schemaProvenance: 'manual',
+			routes: [],
+			cacheKeys: {
+				list: { segments: [], source: 'default' },
+				get: { segments: [], source: 'default' },
+				create: { segments: [], source: 'default' },
+				update: { segments: [], source: 'default' },
+				remove: { segments: [], source: 'default' },
+			},
+			identity: { type: 'number', param: 'id' },
+			storage,
+			queryParams: undefined,
+			ui: undefined,
+			hash: 'resource-hash',
+			warnings: [],
+		};
+	}
+
+	function buildMetadataHost(): ResourceMetadataHost {
+		return {
+			getMetadata: () => ({
+				kind: 'resource-controller',
+				name: 'book',
+				identity: { type: 'number', param: 'id' },
+				routes: [],
+			}),
+			setMetadata: () => {},
+		} satisfies ResourceMetadataHost;
+	}
+
+	it('returns undefined when storage mode is not wp-post', () => {
+		const resource = buildResource({
+			mode: 'wp-option',
+			option: 'demo_option',
+		});
+
+		expect(
+			createPhpWpPostRoutesHelper({
+				resource,
+				pascalName: 'Book',
+				identity,
+				errorCodeFactory,
+			})
+		).toBeUndefined();
+	});
+
+	it('returns the wp-post route bundle when storage mode is wp-post', () => {
+		const resource = buildResource({
+			mode: 'wp-post',
+			postType: 'book',
+			statuses: [],
+			supports: [],
+			meta: {},
+			taxonomies: {},
+		} as IRResource['storage']);
+
+		const expected = buildWpPostRouteBundle({
+			resource,
+			pascalName: 'Book',
+			identity,
+			errorCodeFactory,
+		});
+
+		const bundle = createPhpWpPostRoutesHelper({
+			resource,
+			pascalName: 'Book',
+			identity,
+			errorCodeFactory,
+		});
+
+		expect(bundle).toBeDefined();
+		expect(bundle?.helperMethods).toEqual(expected.helperMethods);
+		expect(bundle?.mutationMetadata).toEqual(expected.mutationMetadata);
+		expect(Object.keys(bundle?.routeHandlers ?? {})).toEqual(
+			Object.keys(expected.routeHandlers)
+		);
+
+		const routeContext = {
+			metadata: {
+				method: 'GET',
+				path: '/kernel/v1/books',
+				kind: 'list',
+				cacheSegments: [],
+			},
+			metadataHost: buildMetadataHost(),
+		} as const;
+
+		expect(bundle?.routeHandlers.list?.(routeContext)).toEqual(
+			expected.routeHandlers.list?.(routeContext)
+		);
+	});
+});

--- a/packages/cli/src/next/builders/php/resource/wpPost/routes.ts
+++ b/packages/cli/src/next/builders/php/resource/wpPost/routes.ts
@@ -1,0 +1,28 @@
+import {
+	buildWpPostRouteBundle,
+	type WpPostRouteBundle,
+} from '@wpkernel/wp-json-ast';
+import type { IRResource } from '../../../../ir/publicTypes';
+import type { ResolvedIdentity } from '../../identity';
+
+export interface CreatePhpWpPostRoutesHelperOptions {
+	readonly resource: IRResource;
+	readonly pascalName: string;
+	readonly identity: ResolvedIdentity;
+	readonly errorCodeFactory: (suffix: string) => string;
+}
+
+export function createPhpWpPostRoutesHelper(
+	options: CreatePhpWpPostRoutesHelperOptions
+): WpPostRouteBundle | undefined {
+	if (options.resource.storage?.mode !== 'wp-post') {
+		return undefined;
+	}
+
+	return buildWpPostRouteBundle({
+		resource: options.resource,
+		pascalName: options.pascalName,
+		identity: options.identity,
+		errorCodeFactory: options.errorCodeFactory,
+	});
+}

--- a/packages/cli/src/next/builders/php/resourceController.ts
+++ b/packages/cli/src/next/builders/php/resourceController.ts
@@ -11,7 +11,6 @@ import {
 	buildRestControllerModuleFromPlan,
 	buildWpOptionStorageArtifacts,
 	buildTransientStorageArtifacts,
-	buildWpPostRouteBundle,
 	type WpPostRouteBundle,
 	resolveTransientKey,
 	DEFAULT_DOC_HEADER,
@@ -33,6 +32,7 @@ import {
 } from './resource/wpTaxonomy';
 import { renderPhpValue } from './resource/phpValue';
 import { ensureWpOptionStorage } from './resource/wpOption/shared';
+import { createPhpWpPostRoutesHelper } from './resource';
 
 export function createPhpResourceControllerHelper(): BuilderHelper {
 	return createHelper({
@@ -192,16 +192,12 @@ function buildResourcePlan(
 				})
 			: undefined;
 
-	// Keep wp-post route bundle so CLI can still rely on the post-specific bundle surface.
-	const wpPostRouteBundle =
-		resource.storage?.mode === 'wp-post'
-			? buildWpPostRouteBundle({
-					resource,
-					pascalName,
-					identity,
-					errorCodeFactory,
-				})
-			: undefined;
+	const wpPostRouteBundle = createPhpWpPostRoutesHelper({
+		resource,
+		pascalName,
+		identity,
+		errorCodeFactory,
+	});
 
 	// Build helper artifacts (taxonomy / transient / option) and include any wp-post helpers.
 	const helperArtifacts = buildStorageHelperArtifacts({
@@ -306,7 +302,9 @@ function buildStorageHelperArtifacts(
 			break;
 		}
 		case 'transient': {
-			accumulatedMethods.push(...(options.transientArtifacts?.helperMethods ?? []));
+			accumulatedMethods.push(
+				...(options.transientArtifacts?.helperMethods ?? [])
+			);
 			// No signatures for transient artifacts currently
 			break;
 		}

--- a/packages/cli/src/next/builders/php/resourceController/routes/__tests__/buildRouteSetOptions.test.ts
+++ b/packages/cli/src/next/builders/php/resourceController/routes/__tests__/buildRouteSetOptions.test.ts
@@ -1,12 +1,12 @@
 import {
 	buildResourceControllerRouteSet,
 	buildTransientStorageArtifacts,
-	buildWpPostRouteBundle,
 	resolveTransientKey,
 	type ResourceMetadataHost,
 	type ResolvedIdentity,
 } from '@wpkernel/wp-json-ast';
 import type { IRResource, IRRoute } from '../../../../../ir/publicTypes';
+import { createPhpWpPostRoutesHelper } from '../../../resource/wpPost/routes';
 import { buildRouteSetOptions } from '../buildRouteSetOptions';
 
 function buildMetadataHost(): ResourceMetadataHost {
@@ -78,15 +78,12 @@ function buildPlan({
 				})
 			: undefined;
 
-	const wpPostRouteBundle =
-		resource.storage?.mode === 'wp-post'
-			? buildWpPostRouteBundle({
-					resource,
-					pascalName,
-					identity,
-					errorCodeFactory,
-				})
-			: undefined;
+	const wpPostRouteBundle = createPhpWpPostRoutesHelper({
+		resource,
+		pascalName,
+		identity,
+		errorCodeFactory,
+	});
 
 	const options = buildRouteSetOptions({
 		resource,

--- a/packages/wp-json-ast/docs/cli-ast-reduction-plan.md
+++ b/packages/wp-json-ast/docs/cli-ast-reduction-plan.md
@@ -449,6 +449,8 @@ Once the factories above land, the CLI needs matching `create*` adapters so plan
 
 - **Scope:** Provide a pipeline helper that translates WP_Post IR into the configuration expected by the shared wp-post primitives and returns the composed bundle to the resource controller helper.
 
+_Completion:_ ☑ Completed – the CLI now exposes `createPhpWpPostRoutesHelper`, delegating wp-post resources to `buildWpPostRouteBundle` so route planners consume the shared bundle without touching raw AST nodes.
+
 **Subtask 3.3.c – Add storage helpers to the pipeline surface.**
 
 - **Scope:** Create `createPhpWpOptionStorageHelper`, `createPhpTransientStorageHelper`, and `createPhpWpTaxonomyStorageHelper` adapters that marshal IR into the corresponding storage factories and return descriptors for `createPhpResourceControllerHelper`.


### PR DESCRIPTION
## Summary
- add a CLI adapter `createPhpWpPostRoutesHelper` that forwards wp-post resources to the shared `buildWpPostRouteBundle`
- update the resource controller planner and route-set tests to consume the helper and cover the new surface
- mark Subtask 3.3.b complete in the CLI AST reduction plan

## Testing
- pnpm --filter @wpkernel/cli test:coverage *(fails: global function coverage threshold remains at 86.29% but all suites pass)*

------
https://chatgpt.com/codex/tasks/task_e_6904b18593c08331a6440a1602c5a19f