### PR TITLE
Align @wpkernel/core terminology with WP prefix

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -72,7 +72,7 @@
 
 ### Breaking Changes
 
-- Removed the `withKernel()` export. Registry middleware is now wired directly
+- Removed the `withWPKernel()` export. Registry middleware is now wired directly
   through `configureWPKernel()`, and teardown happens via the returned instance.
 - `defineAction()` and `defineCapability()` now accept configuration objects
   (`{ name, handler, options }` / `{ map, options }`) rather than positional
@@ -80,27 +80,27 @@
 
 ### Minor Changes
 
-- Introduced `kernel.attachUIBindings()`, `kernel.getUIRuntime()`, and
-  `kernel.hasUIRuntime()` to manage UI adapters without global mutation.
+- Introduced `wpk.attachUIBindings()`, `wpk.getUIRuntime()`, and
+  `wpk.hasUIRuntime()` to manage UI adapters without global mutation.
 - `defineResource()` now registers resources with the runtime via
   `trackUIResource()` instead of relying on queued globals.
-- Added `WPKernelEventBus` with `kernel.events` so lifecycle events surface through
+- Added `WPKernelEventBus` with `wpk.events` so lifecycle events surface through
   a typed subscription interface while continuing to bridge into `wp.hooks`.
   Action and cache events now emit through the bus, enabling UI runtimes and
   adapters to subscribe without global shims.
 - Published a dedicated `@wpkernel/core/events` barrel export so consumers
   can rely on the event bus without importing from the package root.
-- Resource reporters inherit from the kernel instance. Client methods and store
+- Resource reporters inherit from the WP Kernel instance. Client methods and store
   resolvers emit structured `debug`/`info`/`error` logs and every resource now
   exposes a `reporter` property for custom instrumentation.
 - **DataViews Phase 3**: `configureWPKernel` preserves resource UI metadata,
   forwards DataViews options to UI attachments, and emits `ui:dataviews:*`
   events end-to-end with new integration coverage.
 - **DataViews Phase 4**: `ResourceConfig`/`ResourceObject` expose typed
-  `ui.admin.dataviews` metadata (screen + menu), keeping CLI/kernel parity for
+  `ui.admin.dataviews` metadata (screen + menu), keeping CLI/WP Kernel parity for
   declarative DataViews scaffolding.
 - Cache invalidation helpers and the transport layer accept reporter metadata,
-  emitting `cache.invalidate.*` and `transport.*` events with kernel-scoped
+  emitting `cache.invalidate.*` and `transport.*` events with WP Kernel-scoped
   defaults so cache/REST lifecycles share correlation IDs.
 
 ### Technical Details
@@ -132,7 +132,7 @@
     This is the initial release establishing the complete development environment and tooling infrastructure for the WP Kernel framework.
 
     **Monorepo Structure**:
-    - pnpm workspaces with 4 packages (kernel, ui, cli, e2e-utils)
+    - pnpm workspaces with 4 packages (wp-kernel, ui, cli, e2e-utils)
     - TypeScript 5.9.2 strict mode with composite builds
     - Path aliases configured (@wpkernel/\*)
 
@@ -185,7 +185,7 @@
     Complete development environment, tooling, and CI/CD pipeline for WP Kernel framework.
 
     ## Infrastructure ✓
-    - **Monorepo**: pnpm workspaces with 5 packages (kernel, ui, cli, e2e-utils, showcase-plugin)
+    - **Monorepo**: pnpm workspaces with 5 packages (wp-kernel, ui, cli, e2e-utils, showcase-plugin)
     - **TypeScript**: Strict mode, project references, path aliases
     - **Build**: Webpack + @wordpress/scripts, watch mode
     - **Lint**: ESLint 9 flat config, Prettier, deep-import rules

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -7,7 +7,7 @@ import { VERSION } from '../index';
 const SEMVER_PATTERN =
 	/^\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?(?:\+[a-zA-Z0-9.-]+)?$/;
 
-describe('Kernel package entry points', () => {
+describe('WP Kernel package entry points', () => {
 	it('exposes a valid pre-release VERSION string', () => {
 		expect(typeof VERSION).toBe('string');
 		expect(VERSION).toMatch(SEMVER_PATTERN);
@@ -15,7 +15,7 @@ describe('Kernel package entry points', () => {
 	});
 
 	it('re-exports VERSION from the package root', async () => {
-		const kernelExports = await import('../index');
-		expect(kernelExports.VERSION).toBe(VERSION);
+		const wpKernelExports = await import('../index');
+		expect(wpKernelExports.VERSION).toBe(VERSION);
 	});
 });

--- a/packages/core/src/actions/__tests__/context.test.ts
+++ b/packages/core/src/actions/__tests__/context.test.ts
@@ -110,7 +110,7 @@ describe('Action Context', () => {
 				});
 			});
 
-			it('falls back to the kernel reporter when no runtime reporter provided', () => {
+			it('falls back to the WP Kernel reporter when no runtime reporter provided', () => {
 				global.__WP_KERNEL_ACTION_RUNTIME__ = undefined;
 
 				resetResolvedActionReporters();

--- a/packages/core/src/actions/__tests__/middleware.test.ts
+++ b/packages/core/src/actions/__tests__/middleware.test.ts
@@ -30,7 +30,7 @@ describe('createActionMiddleware', () => {
 		expect(next).not.toHaveBeenCalled();
 	});
 
-	it('forwards non-kernel actions to next middleware', () => {
+	it('forwards non-WP Kernel actions to next middleware', () => {
 		const middleware = createActionMiddleware();
 		const api = { dispatch: jest.fn(), getState: jest.fn() };
 		const next = jest.fn();

--- a/packages/core/src/actions/lifecycle.ts
+++ b/packages/core/src/actions/lifecycle.ts
@@ -44,7 +44,7 @@ export function normalizeActionError(
 }
 
 /**
- * Create a structured lifecycle event payload for broadcast via the kernel
+ * Create a structured lifecycle event payload for broadcast via the WP Kernel
  * event bus.
  *
  * @param phase      - Lifecycle phase being emitted (start/complete/error).

--- a/packages/core/src/actions/middleware.ts
+++ b/packages/core/src/actions/middleware.ts
@@ -7,10 +7,10 @@
  *
  * ## Key Concepts
  *
- * - **Action Envelope**: A special Redux action wrapper that carries a kernel action
+ * - **Action Envelope**: A special Redux action wrapper that carries a WP Kernel action
  *   and its arguments through the middleware pipeline.
  * - **Middleware Interception**: The middleware intercepts action envelopes, executes
- *   the underlying kernel action, and returns the result (bypassing the reducer).
+ *   the underlying WP Kernel action, and returns the result (bypassing the reducer).
  * - **Seamless Integration**: Works with existing Redux middleware chains and doesn't
  *   interfere with standard Redux actions.
  *
@@ -37,7 +37,7 @@
 import type { DefinedAction, ReduxDispatch, ReduxMiddleware } from './types';
 
 /**
- * Internal marker used to identify kernel action envelopes in the Redux pipeline.
+ * Internal marker used to identify WP Kernel action envelopes in the Redux pipeline.
  *
  * This type constant ensures that action envelopes don't collide with standard
  * Redux actions. The `@@` prefix follows Redux's convention for internal actions.
@@ -50,7 +50,7 @@ const EXECUTE_ACTION_TYPE = '@@wp-kernel/EXECUTE_ACTION';
 /**
  * Shape of the action envelope dispatched through Redux middleware.
  *
- * Action envelopes wrap kernel actions in a Redux-compatible format, carrying:
+ * Action envelopes wrap WP Kernel actions in a Redux-compatible format, carrying:
  * - The action function itself (`payload.action`)
  * - The arguments to invoke it with (`payload.args`)
  * - Optional metadata for middleware coordination (`meta`)
@@ -72,11 +72,11 @@ export type ActionEnvelope<TArgs, TResult> = {
 /**
  * Type guard to identify action envelopes at runtime.
  *
- * Checks if a Redux action is actually a kernel action envelope by verifying:
+ * Checks if a Redux action is actually a WP Kernel action envelope by verifying:
  * 1. It's an object with the correct `type` constant
  * 2. It has the `__kernelAction` marker flag
  *
- * This enables the middleware to selectively intercept kernel actions while
+ * This enables the middleware to selectively intercept WP Kernel actions while
  * allowing standard Redux actions to pass through untouched.
  *
  * @param value - Potential action envelope
@@ -95,7 +95,7 @@ function isActionEnvelope<TArgs, TResult>(
 }
 
 /**
- * Create a Redux-compatible middleware that intercepts and executes kernel actions.
+ * Create a Redux-compatible middleware that intercepts and executes WP Kernel actions.
  *
  * This middleware enables actions to be dispatched through Redux/`@wordpress/data` stores.
  * When an action envelope is dispatched, the middleware:
@@ -155,9 +155,9 @@ export function createActionMiddleware<
 }
 
 /**
- * Create an action envelope for dispatching a kernel action through Redux.
+ * Create an action envelope for dispatching a WP Kernel action through Redux.
  *
- * This function wraps a kernel action and its arguments in a Redux-compatible format
+ * This function wraps a WP Kernel action and its arguments in a Redux-compatible format
  * that the action middleware can intercept and execute. The resulting envelope can be
  * passed to `store.dispatch()` just like any standard Redux action.
  *
@@ -170,7 +170,7 @@ export function createActionMiddleware<
  *
  * @template TArgs - Input type for the action
  * @template TResult - Return type from the action
- * @param    action - The defined kernel action to execute
+ * @param    action - The defined WP Kernel action to execute
  * @param    args   - Arguments to pass to the action function
  * @param    meta   - Optional metadata for middleware coordination
  * @return Action envelope ready for Redux dispatch

--- a/packages/core/src/actions/types.ts
+++ b/packages/core/src/actions/types.ts
@@ -8,7 +8,7 @@
  * - **Integration Surfaces**: Reporter, jobs, and capability helpers
  * - **Redux Middleware**: Type-safe Redux/`@wordpress/data` integration
  *
- * These types form the contract between action implementations and the kernel runtime,
+ * These types form the contract between action implementations and the WP Kernel runtime,
  * enabling type-safe orchestration with IDE autocomplete and compile-time validation.
  *
  * @module actions/types

--- a/packages/core/src/contracts/__tests__/serializeKernelError.test.ts
+++ b/packages/core/src/contracts/__tests__/serializeKernelError.test.ts
@@ -22,7 +22,7 @@ describe('serializeWPKernelError', () => {
 		});
 	});
 
-	it('supports wrapped non-kernel errors', () => {
+	it('supports wrapped non-WP Kernel errors', () => {
 		const wrapped = WPKernelError.wrap(new Error('boom'), 'UnknownError', {
 			operation: 'contract-test',
 		});

--- a/packages/core/src/contracts/index.ts
+++ b/packages/core/src/contracts/index.ts
@@ -53,7 +53,7 @@ export const WPK_EXIT_CODES = {
 } as const;
 
 /**
- * Union of supported kernel exit code values.
+ * Union of supported WP Kernel exit code values.
  */
 export type WPKExitCode = (typeof WPK_EXIT_CODES)[keyof typeof WPK_EXIT_CODES];
 

--- a/packages/core/src/data/__tests__/configure-kernel.test.ts
+++ b/packages/core/src/data/__tests__/configure-kernel.test.ts
@@ -110,7 +110,7 @@ describe('configureWPKernel', () => {
 			__experimentalUseMiddleware: jest.Mock;
 		};
 
-		const kernel = configureWPKernel({
+		const wpk = configureWPKernel({
 			namespace: 'acme',
 			registry,
 			middleware: [customMiddleware],
@@ -131,7 +131,7 @@ describe('configureWPKernel', () => {
 		const [installedEvents] = eventsFactory();
 		expect(installedEvents).toBe(eventMiddleware);
 
-		kernel.teardown();
+		wpk.teardown();
 		expect(detachActions).toHaveBeenCalled();
 		expect(detachEvents).toHaveBeenCalled();
 		expect(eventMiddleware.destroy).toHaveBeenCalled();
@@ -142,14 +142,14 @@ describe('configureWPKernel', () => {
 			dispatch: jest.fn(),
 		} as unknown as WPKernelRegistry;
 
-		const kernel = configureWPKernel({ namespace: 'acme', registry });
+		const wpk = configureWPKernel({ namespace: 'acme', registry });
 
 		expect(
 			(registry as { __experimentalUseMiddleware?: unknown })
 				.__experimentalUseMiddleware
 		).toBeUndefined();
 
-		expect(() => kernel.teardown()).not.toThrow();
+		expect(() => wpk.teardown()).not.toThrow();
 	});
 
 	it('falls back to global registry when not provided', () => {
@@ -171,9 +171,9 @@ describe('configureWPKernel', () => {
 	it('handles missing global registry helpers gracefully', () => {
 		delete (globalThis as { getWPData?: unknown }).getWPData;
 
-		const kernel = configureWPKernel({ namespace: 'acme' });
+		const wpk = configureWPKernel({ namespace: 'acme' });
 
-		expect(kernel.getRegistry()).toBeUndefined();
+		expect(wpk.getRegistry()).toBeUndefined();
 	});
 
 	it('delegates invalidate calls to resource cache with registry context', () => {
@@ -184,10 +184,10 @@ describe('configureWPKernel', () => {
 			dispatch: jest.fn(),
 		} as unknown as WPKernelRegistry;
 
-		const kernel = configureWPKernel({ namespace: 'acme', registry });
+		const wpk = configureWPKernel({ namespace: 'acme', registry });
 		const patterns = ['post', 'list'];
 
-		kernel.invalidate(patterns);
+		wpk.invalidate(patterns);
 		expect(invalidateCache).toHaveBeenCalledWith(
 			patterns,
 			expect.objectContaining({
@@ -199,7 +199,7 @@ describe('configureWPKernel', () => {
 			})
 		);
 
-		kernel.invalidate(patterns, { emitEvent: false });
+		wpk.invalidate(patterns, { emitEvent: false });
 		expect(invalidateCache).toHaveBeenCalledWith(
 			patterns,
 			expect.objectContaining({
@@ -214,12 +214,12 @@ describe('configureWPKernel', () => {
 	});
 
 	it('emits custom events through the event bus', () => {
-		const kernel = configureWPKernel({ namespace: 'acme' });
+		const wpk = configureWPKernel({ namespace: 'acme' });
 		const payload = { foo: 'bar' };
 		const bus = getWPKernelEventBus();
 		const emitSpy = jest.spyOn(bus, 'emit');
 
-		kernel.emit('wpk.event', payload);
+		wpk.emit('wpk.event', payload);
 
 		expect(emitSpy).toHaveBeenCalledWith('custom:event', {
 			eventName: 'wpk.event',
@@ -228,15 +228,15 @@ describe('configureWPKernel', () => {
 	});
 
 	it('throws WPKernelError when emit is called with invalid event name', () => {
-		const kernel = configureWPKernel({ namespace: 'acme' });
+		const wpk = configureWPKernel({ namespace: 'acme' });
 
-		expect(() => kernel.emit('', {})).toThrow(WPKernelError);
+		expect(() => wpk.emit('', {})).toThrow(WPKernelError);
 	});
 
 	it('reports UI disabled state by default', () => {
-		const kernel = configureWPKernel({ namespace: 'acme' });
+		const wpk = configureWPKernel({ namespace: 'acme' });
 
-		expect(kernel.ui.isEnabled()).toBe(false);
+		expect(wpk.ui.isEnabled()).toBe(false);
 	});
 
 	it('attaches UI runtime when adapter is provided', () => {
@@ -250,15 +250,15 @@ describe('configureWPKernel', () => {
 		};
 		const attach = jest.fn(() => runtime);
 
-		const kernel = configureWPKernel({
+		const wpk = configureWPKernel({
 			namespace: 'acme',
 			ui: { attach },
 		});
 
-		expect(attach).toHaveBeenCalledWith(kernel, undefined);
-		expect(kernel.hasUIRuntime()).toBe(true);
-		expect(kernel.getUIRuntime()).toBe(runtime);
-		expect(kernel.ui.isEnabled()).toBe(true);
+		expect(attach).toHaveBeenCalledWith(wpk, undefined);
+		expect(wpk.hasUIRuntime()).toBe(true);
+		expect(wpk.getUIRuntime()).toBe(runtime);
+		expect(wpk.ui.isEnabled()).toBe(true);
 	});
 
 	it('allows manual UI runtime attachment', () => {
@@ -272,23 +272,23 @@ describe('configureWPKernel', () => {
 		};
 		const attach = jest.fn(() => runtime);
 
-		const kernel = configureWPKernel({ namespace: 'acme' });
+		const wpk = configureWPKernel({ namespace: 'acme' });
 
-		expect(kernel.hasUIRuntime()).toBe(false);
+		expect(wpk.hasUIRuntime()).toBe(false);
 
-		const attached = kernel.attachUIBindings(attach);
+		const attached = wpk.attachUIBindings(attach);
 
-		expect(attach).toHaveBeenCalledWith(kernel, undefined);
+		expect(attach).toHaveBeenCalledWith(wpk, undefined);
 		expect(attached).toBe(runtime);
-		expect(kernel.getUIRuntime()).toBe(runtime);
-		expect(kernel.ui.isEnabled()).toBe(true);
+		expect(wpk.getUIRuntime()).toBe(runtime);
+		expect(wpk.ui.isEnabled()).toBe(true);
 	});
 
-	it('exposes the shared event bus on the kernel instance', () => {
-		const kernel = configureWPKernel({ namespace: 'acme' });
+	it('exposes the shared event bus on the WP Kernel instance', () => {
+		const wpk = configureWPKernel({ namespace: 'acme' });
 		const bus = getWPKernelEventBus();
 
-		expect(kernel.events).toBe(bus);
+		expect(wpk.events).toBe(bus);
 	});
 
 	it('exposes namespace, reporter, and registry accessors', () => {
@@ -299,15 +299,15 @@ describe('configureWPKernel', () => {
 			dispatch: jest.fn(),
 		} as unknown as WPKernelRegistry;
 
-		const kernel = configureWPKernel({
+		const wpk = configureWPKernel({
 			namespace: 'acme',
 			registry,
 			reporter: mockReporter,
 		});
 
-		expect(kernel.getNamespace()).toBe('acme');
-		expect(kernel.getReporter()).toBe(mockReporter);
-		expect(kernel.getRegistry()).toBe(registry);
+		expect(wpk.getNamespace()).toBe('acme');
+		expect(wpk.getReporter()).toBe(mockReporter);
+		expect(wpk.getRegistry()).toBe(registry);
 	});
 
 	it('falls back to detected namespace when none is provided', () => {
@@ -316,10 +316,10 @@ describe('configureWPKernel', () => {
 		>;
 		detectNamespaceMock.mockReturnValueOnce('fallback.namespace');
 
-		const kernel = configureWPKernel();
+		const wpk = configureWPKernel();
 
 		expect(detectNamespaceMock).toHaveBeenCalled();
-		expect(kernel.getNamespace()).toBe('fallback.namespace');
+		expect(wpk.getNamespace()).toBe('fallback.namespace');
 	});
 
 	it('handles middleware hooks that do not return teardown callbacks', () => {
@@ -333,9 +333,9 @@ describe('configureWPKernel', () => {
 
 		(wpkEventsPlugin as jest.Mock).mockReturnValueOnce({});
 
-		const kernel = configureWPKernel({ namespace: 'acme', registry });
+		const wpk = configureWPKernel({ namespace: 'acme', registry });
 
-		expect(() => kernel.teardown()).not.toThrow();
+		expect(() => wpk.teardown()).not.toThrow();
 	});
 
 	it('normalizes teardown errors that are not Error instances', () => {
@@ -356,9 +356,9 @@ describe('configureWPKernel', () => {
 		process.env.NODE_ENV = 'development';
 
 		try {
-			const kernel = configureWPKernel({ namespace: 'acme', registry });
+			const wpk = configureWPKernel({ namespace: 'acme', registry });
 
-			kernel.teardown();
+			wpk.teardown();
 
 			expect(mockReporter.error).toHaveBeenCalledWith(
 				'WPKernel teardown failed',
@@ -391,13 +391,13 @@ describe('configureWPKernel', () => {
 		process.env.NODE_ENV = 'development';
 
 		try {
-			const kernel = configureWPKernel({
+			const wpk = configureWPKernel({
 				namespace: 'acme',
 				registry,
 				reporter: mockReporter,
 			});
 
-			kernel.teardown();
+			wpk.teardown();
 
 			expect(mockReporter.error).toHaveBeenCalledWith(
 				'WPKernel teardown failed',
@@ -408,16 +408,16 @@ describe('configureWPKernel', () => {
 		}
 	});
 
-	it('defines resources using kernel reporter namespace', () => {
+	it('defines resources using WP Kernel reporter namespace', () => {
 		const childReporter = createMockReporter();
 		mockReporter.child.mockReturnValue(childReporter);
 
-		const kernel = configureWPKernel({
+		const wpk = configureWPKernel({
 			namespace: 'acme',
 			reporter: mockReporter,
 		});
 
-		const resource = kernel.defineResource<{ id: number }>({
+		const resource = wpk.defineResource<{ id: number }>({
 			name: 'thing',
 			routes: {
 				get: { path: '/acme/v1/things/:id', method: 'GET' },
@@ -430,10 +430,10 @@ describe('configureWPKernel', () => {
 	});
 
 	it('respects custom resource reporters when provided', () => {
-		const kernel = configureWPKernel({ namespace: 'acme' });
+		const wpk = configureWPKernel({ namespace: 'acme' });
 		const customReporter = createMockReporter();
 
-		const resource = kernel.defineResource<{ id: number }>({
+		const resource = wpk.defineResource<{ id: number }>({
 			name: 'thing',
 			reporter: customReporter,
 			routes: {
@@ -446,9 +446,9 @@ describe('configureWPKernel', () => {
 	});
 
 	it('preserves explicit resource namespaces supplied in config', () => {
-		const kernel = configureWPKernel({ namespace: 'acme' });
+		const wpk = configureWPKernel({ namespace: 'acme' });
 
-		const resource = kernel.defineResource<{ id: number }>({
+		const resource = wpk.defineResource<{ id: number }>({
 			name: 'thing',
 			namespace: 'custom',
 			routes: {
@@ -465,14 +465,14 @@ describe('configureWPKernel', () => {
 		const registryEntries = new Map<string, unknown>();
 		const customEvents: CustomKernelEvent[] = [];
 		const attach = jest.fn(
-			(kernel: WPKInstance, options?: UIIntegrationOptions) => {
+			(wpk: WPKInstance, options?: UIIntegrationOptions) => {
 				const runtime: WPKernelUIRuntime = {
-					kernel,
-					namespace: kernel.getNamespace(),
-					reporter: kernel.getReporter(),
-					events: kernel.events,
+					kernel: wpk,
+					namespace: wpk.getNamespace(),
+					reporter: wpk.getReporter(),
+					events: wpk.events,
 					options,
-					invalidate: kernel.invalidate.bind(kernel),
+					invalidate: wpk.invalidate.bind(wpk),
 					dataviews: {
 						registry: registryEntries,
 						controllers,
@@ -489,33 +489,27 @@ describe('configureWPKernel', () => {
 						},
 						events: {
 							registered: (payload: unknown) =>
-								kernel.emit('ui:dataviews:registered', payload),
+								wpk.emit('ui:dataviews:registered', payload),
 							unregistered: (payload: unknown) =>
-								kernel.emit(
-									'ui:dataviews:unregistered',
-									payload
-								),
+								wpk.emit('ui:dataviews:unregistered', payload),
 							viewChanged: (payload: unknown) =>
-								kernel.emit(
-									'ui:dataviews:view-changed',
-									payload
-								),
+								wpk.emit('ui:dataviews:view-changed', payload),
 							actionTriggered: (payload: unknown) =>
-								kernel.emit(
+								wpk.emit(
 									'ui:dataviews:action-triggered',
 									payload
 								),
 						},
-						reporter: kernel.getReporter(),
+						reporter: wpk.getReporter(),
 						options: {
 							enable: true,
 							autoRegisterResources: true,
 						},
-						getResourceReporter: () => kernel.getReporter(),
+						getResourceReporter: () => wpk.getReporter(),
 					},
 				} as unknown as WPKernelUIRuntime;
 
-				kernel.events.on('resource:defined', ({ resource }) => {
+				wpk.events.on('resource:defined', ({ resource }) => {
 					const metadata = (
 						resource as {
 							ui?: {
@@ -531,22 +525,19 @@ describe('configureWPKernel', () => {
 					controllers.set(resource.name, metadata);
 					registryEntries.set(resource.name, {
 						resource: resource.name,
-						preferencesKey: `${kernel.getNamespace()}/dataviews/${resource.name}`,
+						preferencesKey: `${wpk.getNamespace()}/dataviews/${resource.name}`,
 					});
 				});
 
-				kernel.events.on(
-					'custom:event',
-					(payload: CustomKernelEvent) => {
-						customEvents.push(payload);
-					}
-				);
+				wpk.events.on('custom:event', (payload: CustomKernelEvent) => {
+					customEvents.push(payload);
+				});
 
 				return runtime;
 			}
 		);
 
-		const kernel = configureWPKernel({
+		const wpk = configureWPKernel({
 			namespace: 'acme',
 			ui: {
 				enable: true,
@@ -561,7 +552,7 @@ describe('configureWPKernel', () => {
 		});
 
 		expect(attach).toHaveBeenCalledWith(
-			kernel,
+			wpk,
 			expect.objectContaining({
 				dataviews: expect.objectContaining({ enable: true }),
 			})
@@ -581,7 +572,7 @@ describe('configureWPKernel', () => {
 			},
 		};
 
-		const resource = kernel.defineResource(
+		const resource = wpk.defineResource(
 			resourceDefinition as unknown as ResourceConfig<
 				unknown,
 				{ search?: string }
@@ -625,9 +616,9 @@ describe('configureWPKernel', () => {
 	});
 
 	it('respects namespace embedded within resource name shorthand', () => {
-		const kernel = configureWPKernel({ namespace: 'acme' });
+		const wpk = configureWPKernel({ namespace: 'acme' });
 
-		const resource = kernel.defineResource<{ id: number }>({
+		const resource = wpk.defineResource<{ id: number }>({
 			name: 'custom:thing',
 			routes: {
 				get: { path: '/custom/v1/things/:id', method: 'GET' },
@@ -639,9 +630,9 @@ describe('configureWPKernel', () => {
 	});
 
 	it('prefers explicit namespace when provided alongside shorthand name syntax', () => {
-		const kernel = configureWPKernel({ namespace: 'acme' });
+		const wpk = configureWPKernel({ namespace: 'acme' });
 
-		const resource = kernel.defineResource<{ id: number }>({
+		const resource = wpk.defineResource<{ id: number }>({
 			name: 'custom:thing',
 			namespace: 'custom-explicit',
 			routes: {

--- a/packages/core/src/data/__tests__/kernelEventsPlugin.test.ts
+++ b/packages/core/src/data/__tests__/kernelEventsPlugin.test.ts
@@ -358,11 +358,11 @@ describe('wpkEventsPlugin', () => {
 			type: 'INIT',
 		});
 
-		const kernelError = new WPKernelError('ServerError', {
+		const wpKernelError = new WPKernelError('ServerError', {
 			message: 'Internal failure',
 		});
 		const event = createActionErrorEvent({
-			error: kernelError,
+			error: wpKernelError,
 			requestId: 'server-failure',
 		});
 

--- a/packages/core/src/data/configure-kernel.ts
+++ b/packages/core/src/data/configure-kernel.ts
@@ -86,7 +86,7 @@ function extractResourceName(name: string): string {
  * invalidation, telemetry, and teardown.
  *
  * @param    options - Runtime configuration including registry, middleware, and UI hooks
- * @return Configured kernel instance with lifecycle helpers
+ * @return Configured WP Kernel instance with lifecycle helpers
  *
  * @example
  * ```ts

--- a/packages/core/src/data/plugins/events.ts
+++ b/packages/core/src/data/plugins/events.ts
@@ -102,7 +102,7 @@ function resolveErrorMessage(error: unknown): string {
 }
 
 /**
- * Bridge kernel lifecycle events into WordPress middleware and notices.
+ * Bridge WP Kernel lifecycle events into WordPress middleware and notices.
  *
  * The plugin mirrors action lifecycle and cache invalidation events onto
  * `wp.hooks` while optionally surfacing admin notices via the core notices
@@ -111,7 +111,7 @@ function resolveErrorMessage(error: unknown): string {
  * @param    options          - Kernel event wiring options
  * @param    options.reporter - Reporter used for diagnostics when notices fire
  * @param    options.registry - Optional WordPress registry for dispatching notices
- * @param    options.events   - Shared kernel event bus instance
+ * @param    options.events   - Shared WP Kernel event bus instance
  * @return Redux middleware with a `destroy()` teardown helper
  * @category Data
  */

--- a/packages/core/src/data/types.ts
+++ b/packages/core/src/data/types.ts
@@ -61,7 +61,7 @@ export interface WPKernelUIRuntime {
 }
 
 export type WPKernelUIAttach = (
-	kernel: WPKInstance,
+	wpKernel: WPKInstance,
 	options?: UIIntegrationOptions
 ) => WPKernelUIRuntime;
 

--- a/packages/core/src/events/bus.ts
+++ b/packages/core/src/events/bus.ts
@@ -53,7 +53,7 @@ type KernelEventName = keyof WPKernelEventMap;
 type Listener<T> = (payload: T) => void;
 
 /**
- * Typed event bus used across the kernel to broadcast lifecycle events and
+ * Typed event bus used across WP Kernel to broadcast lifecycle events and
  * cache invalidation notices.
  *
  * The bus automatically resolves a reporter so listener failures can be logged
@@ -172,7 +172,7 @@ const definedResources: GenericResourceDefinedEvent[] = [];
 const definedActions: ActionDefinedEvent[] = [];
 
 /**
- * Return the shared kernel event bus, creating it lazily on first access.
+ * Return the shared WP Kernel event bus, creating it lazily on first access.
  *
  * @category Events
  */
@@ -184,7 +184,7 @@ export function getWPKernelEventBus(): WPKernelEventBus {
 }
 
 /**
- * Replace the shared kernel event bus. Intended for test suites that need to
+ * Replace the shared WP Kernel event bus. Intended for test suites that need to
  * inspect emitted events.
  *
  * @param    bus - Custom event bus instance

--- a/packages/core/src/http/__tests__/fetch.test.ts
+++ b/packages/core/src/http/__tests__/fetch.test.ts
@@ -504,9 +504,9 @@ describe('transport/fetch', () => {
 			);
 		});
 
-		it('uses kernel reporter when metadata is not provided', async () => {
-			const kernelSpy = createReporterSpy();
-			setWPKernelReporter(kernelSpy.reporter);
+		it('uses WP Kernel reporter when metadata is not provided', async () => {
+			const wpKernelSpy = createReporterSpy();
+			setWPKernelReporter(wpKernelSpy.reporter);
 			mockApiFetch.mockResolvedValue({ id: 7 });
 
 			await fetch({
@@ -514,7 +514,7 @@ describe('transport/fetch', () => {
 				method: 'GET',
 			});
 
-			expect(kernelSpy.logs).toEqual(
+			expect(wpKernelSpy.logs).toEqual(
 				expect.arrayContaining([
 					expect.objectContaining({
 						level: 'debug',

--- a/packages/core/src/http/fetch.ts
+++ b/packages/core/src/http/fetch.ts
@@ -41,10 +41,10 @@ const TRANSPORT_LOG_MESSAGES = {
 } as const;
 
 function resolveTransportReporter(meta?: TransportMeta): Reporter {
-	const kernelReporter = getWPKernelReporter();
+	const wpKernelReporter = getWPKernelReporter();
 	const override = meta?.reporter
 		? meta.reporter.child('transport')
-		: kernelReporter?.child(
+		: wpKernelReporter?.child(
 				meta?.resourceName
 					? `transport.${meta.resourceName}`
 					: 'transport'
@@ -387,14 +387,14 @@ export async function fetch<T = unknown>(
 		return response;
 	} catch (error) {
 		const duration = performance.now() - startTime;
-		const kernelError = normalizeError(
+		const wpKernelError = normalizeError(
 			error,
 			requestId,
 			request.method,
 			fullPath
 		);
 
-		emitErrorEvent(hooks, request, kernelError, duration);
+		emitErrorEvent(hooks, request, wpKernelError, duration);
 		reporter.error(TRANSPORT_LOG_MESSAGES.error, {
 			requestId,
 			method: request.method,
@@ -402,8 +402,8 @@ export async function fetch<T = unknown>(
 			duration,
 			namespace: request.meta?.namespace,
 			resourceName: request.meta?.resourceName,
-			error: kernelError.message,
+			error: wpKernelError.message,
 		});
-		throw kernelError;
+		throw wpKernelError;
 	}
 }

--- a/packages/core/src/namespace/constants.ts
+++ b/packages/core/src/namespace/constants.ts
@@ -56,7 +56,7 @@ export const WPK_INFRASTRUCTURE = {
 	POLICY_EVENT_CHANNEL: `${WPK_NAMESPACE}.capability.events`,
 	/** BroadcastChannel name for action lifecycle events */
 	ACTIONS_CHANNEL: `${WPK_NAMESPACE}.actions`,
-	/** WordPress hooks namespace prefix for kernel events plugin */
+	/** WordPress hooks namespace prefix for WP Kernel events plugin */
 	WP_HOOKS_NAMESPACE_PREFIX: `${WPK_NAMESPACE}/notices`,
 	/** BroadcastChannel message type for action lifecycle events */
 	ACTIONS_MESSAGE_TYPE_LIFECYCLE: `${WPK_NAMESPACE}.action.lifecycle`,
@@ -103,7 +103,7 @@ export type WPKInfrastructureConstant =
 export type WPKEvent = (typeof WPK_EVENTS)[keyof typeof WPK_EVENTS];
 
 /**
- * Configuration sources recognised by kernel tooling.
+ * Configuration sources recognised by WP Kernel tooling.
  *
  * These filenames/keys are consumed by the CLI and runtime config loaders.
  */

--- a/packages/core/src/pipeline/actions/types.ts
+++ b/packages/core/src/pipeline/actions/types.ts
@@ -170,7 +170,7 @@ export interface ActionInvocationDraft<TResult> {
 	durationMs?: number;
 	/** Successful handler result, when available. */
 	result?: TResult;
-	/** Normalized kernel error when execution fails. */
+	/** Normalized WP Kernel error when execution fails. */
 	error?: WPKernelError;
 	/** Final resolved options shared with metadata helpers. */
 	resolvedOptions?: ResolvedActionOptions;

--- a/packages/core/src/reporter/context.ts
+++ b/packages/core/src/reporter/context.ts
@@ -1,25 +1,25 @@
 import type { Reporter } from './types';
 
-let kernelReporter: Reporter | undefined;
+let wpKernelReporter: Reporter | undefined;
 
 /**
- * Register the shared kernel reporter instance.
+ * Register the shared WP Kernel reporter instance.
  *
  * @param    reporter - Reporter to use for subsequent logging
  * @category Reporter
  */
 export function setWPKernelReporter(reporter: Reporter | undefined): void {
-	kernelReporter = reporter;
+	wpKernelReporter = reporter;
 }
 
 /**
- * Retrieve the shared kernel reporter, if configured.
+ * Retrieve the shared WP Kernel reporter, if configured.
  *
  * @return Reporter instance or undefined when not initialised
  * @category Reporter
  */
 export function getWPKernelReporter(): Reporter | undefined {
-	return kernelReporter;
+	return wpKernelReporter;
 }
 
 /**
@@ -28,5 +28,5 @@ export function getWPKernelReporter(): Reporter | undefined {
  * @category Reporter
  */
 export function clearWPKReporter(): void {
-	kernelReporter = undefined;
+	wpKernelReporter = undefined;
 }

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -51,7 +51,7 @@ function logWithLevel(
 }
 
 /**
- * Create a kernel reporter backed by LogLayer transports.
+ * Create a WP Kernel reporter backed by LogLayer transports.
  *
  * The reporter honors namespace, channel, and level options while providing a
  * typed interface for child loggers used across subsystems.

--- a/packages/core/src/resource/__tests__/cache/invalidate.test.ts
+++ b/packages/core/src/resource/__tests__/cache/invalidate.test.ts
@@ -246,7 +246,7 @@ describe('invalidate', () => {
 	});
 
 	describe('reporter instrumentation', () => {
-		it('uses kernel reporter when no override provided', () => {
+		it('uses WP Kernel reporter when no override provided', () => {
 			const { reporter, logs } = createReporterSpy();
 			setWPKernelReporter(reporter);
 
@@ -290,9 +290,9 @@ describe('invalidate', () => {
 		});
 
 		it('prefers explicit reporter override', () => {
-			const kernelSpy = createReporterSpy();
+			const wpKernelSpy = createReporterSpy();
 			const overrideSpy = createReporterSpy();
-			setWPKernelReporter(kernelSpy.reporter);
+			setWPKernelReporter(wpKernelSpy.reporter);
 
 			const mockState = {
 				lists: {
@@ -325,7 +325,7 @@ describe('invalidate', () => {
 					}),
 				])
 			);
-			expect(kernelSpy.logs).toEqual([]);
+			expect(wpKernelSpy.logs).toEqual([]);
 		});
 
 		it('respects silent reporter flag when no override provided', () => {

--- a/packages/core/src/resource/cache.ts
+++ b/packages/core/src/resource/cache.ts
@@ -46,11 +46,11 @@ const CACHE_LOG_MESSAGES = {
 } as const;
 
 function resolveCacheReporter(provided?: Reporter): Reporter {
-	const kernelReporter = getWPKernelReporter();
+	const wpKernelReporter = getWPKernelReporter();
 
 	return resolveReporter({
 		override: provided,
-		runtime: kernelReporter?.child('cache'),
+		runtime: wpKernelReporter?.child('cache'),
 		fallback: () =>
 			createReporter({
 				namespace: WPK_SUBSYSTEM_NAMESPACES.CACHE,

--- a/packages/core/src/resource/types.ts
+++ b/packages/core/src/resource/types.ts
@@ -302,7 +302,7 @@ export type ResourceConfig<
 	 * Optional reporter override for resource instrumentation.
 	 *
 	 * When provided, the resource will emit debug/info/error logs through this
-	 * reporter instead of creating a child reporter from the kernel instance.
+	 * reporter instead of creating a child reporter from the WP Kernel instance.
 	 */
 	reporter?: Reporter;
 


### PR DESCRIPTION
## Summary
- replace legacy "kernel" references in @wpkernel/core docs, comments, and tests with the WP Kernel terminology
- rename shared reporter helpers and runtime fixtures to use wpKernel-prefixed identifiers
- update configureWPKernel tests to reflect the wp-prefixed instance naming conventions

## Testing
- pnpm --filter @wpkernel/core test

------
https://chatgpt.com/codex/tasks/task_e_6905f24d96948325845cbcb08b745c8a