### PR TITLE
Improve CLI integration env isolation

### DIFF
--- a/packages/cli/tests/__tests__/generate-apply.integration.test.ts
+++ b/packages/cli/tests/__tests__/generate-apply.integration.test.ts
@@ -1,0 +1,103 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { runWpk } from '../test-support/runWpk';
+import { withWorkspace } from '../workspace.test-support';
+
+const PHP_JSON_AST_AUTOLOAD = path.resolve(
+	__dirname,
+	'..',
+	'..',
+	'..',
+	'php-json-ast',
+	'vendor',
+	'autoload.php'
+);
+
+jest.setTimeout(300000);
+
+describe('generate + apply integration', () => {
+	it('captures current PHP driver behaviour for generate/apply', async () => {
+		await withWorkspace(
+			async (workspace) => {
+				const initResult = await runWpk(workspace, [
+					'init',
+					'--name',
+					'generate-apply-plugin',
+				]);
+				expect(initResult.code).toBe(0);
+				expect(initResult.stderr).toBe('');
+
+				const traceFile = path.join(
+					workspace,
+					'.wpk',
+					'php-driver.trace.log'
+				);
+				const generateResult = await runWpk(
+					workspace,
+					['generate', '--verbose'],
+					{
+						env: {
+							WPK_PHP_AUTOLOAD: PHP_JSON_AST_AUTOLOAD,
+							PHP_DRIVER_TRACE_FILE: traceFile,
+						},
+					}
+				);
+
+				expect(generateResult.code).toBe(1);
+				expect(generateResult.stdout).toBe('');
+				expect(generateResult.stderr).toContain(
+					'[wpk.php-driver][stderr]'
+				);
+				expect(generateResult.stderr).toContain(
+					'[wpk.php-driver][stdout]'
+				);
+				expect(generateResult.stderr).toContain(
+					'Deprecated: Creation of dynamic property PhpParser'
+				);
+				expect(generateResult.stderr).toContain(
+					'Fatal error: Uncaught Error: Typed property PhpParser'
+				);
+
+				const traceContents = await fs.readFile(traceFile, 'utf8');
+				const traceEvents = traceContents
+					.split(/\r?\n/u)
+					.map((line) => line.trim())
+					.filter(Boolean)
+					.map(
+						(line) =>
+							JSON.parse(line) as {
+								event?: string;
+							}
+					);
+				const eventNames = traceEvents.map((entry) => entry.event);
+				expect(eventNames).toContain('boot');
+				expect(eventNames).toContain('start');
+				expect(eventNames).not.toContain('success');
+				expect(eventNames).not.toContain('failure');
+
+				await expect(
+					fs.access(
+						path.join(workspace, '.wpk', 'apply', 'manifest.json')
+					)
+				).rejects.toMatchObject({ code: 'ENOENT' });
+
+				const applyResult = await runWpk(
+					workspace,
+					['apply', '--yes'],
+					{
+						env: {
+							WPK_PHP_AUTOLOAD: PHP_JSON_AST_AUTOLOAD,
+						},
+					}
+				);
+
+				expect(applyResult.code).toBe(1);
+				// Known bug: the reporter never surfaces apply failures when
+				// the manifest is missing, so both streams remain empty.
+				expect(applyResult.stdout).toBe('');
+				expect(applyResult.stderr).toBe('');
+			},
+			{ chdir: false }
+		);
+	});
+});

--- a/packages/cli/tests/test-support/runWpk.ts
+++ b/packages/cli/tests/test-support/runWpk.ts
@@ -1,0 +1,132 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import packageJson from '../../package.json' assert { type: 'json' };
+import { buildPhpIntegrationEnv } from '../workspace.test-support';
+
+type RunResult = {
+	code: number;
+	stdout: string;
+	stderr: string;
+};
+
+type RunOptions = {
+	env?: NodeJS.ProcessEnv;
+};
+
+const PHP_AUTOLOAD_ENV_KEYS = [
+	'WPK_PHP_AUTOLOAD',
+	'WPK_PHP_AUTOLOAD_PATHS',
+	'PHP_DRIVER_AUTOLOAD',
+	'PHP_DRIVER_AUTOLOAD_PATHS',
+] as const;
+
+function sanitizePhpAutoloadEnv(
+	baseEnv: NodeJS.ProcessEnv,
+	overrides: NodeJS.ProcessEnv | undefined
+): NodeJS.ProcessEnv {
+	const sanitized: NodeJS.ProcessEnv = { ...baseEnv };
+
+	for (const key of PHP_AUTOLOAD_ENV_KEYS) {
+		if (key in sanitized) {
+			delete sanitized[key];
+		}
+	}
+
+	if (overrides) {
+		for (const [key, value] of Object.entries(overrides)) {
+			if (value === undefined) {
+				delete sanitized[key];
+			} else {
+				sanitized[key] = value;
+			}
+		}
+	}
+
+	return sanitized;
+}
+
+type PackageJson = {
+	bin?: Record<string, string> | undefined;
+};
+
+function resolveCliBinPath(): string {
+	const { bin } = packageJson as PackageJson;
+	if (bin) {
+		const explicit = bin.wpk;
+		if (typeof explicit === 'string' && explicit.length > 0) {
+			return explicit;
+		}
+
+		for (const candidate of Object.values(bin)) {
+			if (typeof candidate === 'string' && candidate.length > 0) {
+				return candidate;
+			}
+		}
+	}
+
+	throw new Error('Unable to resolve CLI bin entry from package.json');
+}
+
+const CLI_BIN = path.resolve(__dirname, '..', '..', resolveCliBinPath());
+const CLI_LOADER = path.resolve(__dirname, 'wpk-cli-loader.mjs');
+
+function runProcess(
+	command: string,
+	args: string[],
+	options: { cwd: string; env: NodeJS.ProcessEnv }
+): Promise<RunResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd: options.cwd,
+			env: options.env,
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+
+		let stdout = '';
+		let stderr = '';
+
+		child.stdout?.on('data', (chunk) => {
+			stdout += chunk.toString();
+		});
+
+		child.stderr?.on('data', (chunk) => {
+			stderr += chunk.toString();
+		});
+
+		child.once('error', reject);
+		child.once('close', (code) => {
+			resolve({
+				code: code ?? 0,
+				stdout,
+				stderr,
+			});
+		});
+	});
+}
+
+export function runWpk(
+	workspace: string,
+	args: string[],
+	options: RunOptions = {}
+): Promise<RunResult> {
+	const mergedEnv = sanitizePhpAutoloadEnv(process.env, {
+		...options.env,
+		NODE_ENV: 'test',
+		FORCE_COLOR: '0',
+	});
+	const env = buildPhpIntegrationEnv(mergedEnv);
+
+	const existingNodeOptions = env.NODE_OPTIONS ?? '';
+	const segments: string[] = [];
+	if (existingNodeOptions.length > 0) {
+		segments.push(existingNodeOptions);
+	}
+	segments.push('--no-warnings');
+	segments.push(`--loader ${CLI_LOADER}`);
+	env.NODE_OPTIONS = segments.join(' ');
+
+	return runProcess(process.execPath, [CLI_BIN, ...args], {
+		cwd: workspace,
+		env,
+	});
+}

--- a/packages/cli/tests/tsconfig.json
+++ b/packages/cli/tests/tsconfig.json
@@ -7,7 +7,10 @@
 		"outDir": "../dist-test-support",
 		"noEmit": true
 	},
-	"files": ["../../test-utils/src/next/workspace.test-support.ts"],
+	"files": [
+		"../../test-utils/src/next/workspace.test-support.ts",
+		"../package.json"
+	],
 	"include": ["./**/*.ts"],
 	"references": [
 		{ "path": "../tsconfig.json" },


### PR DESCRIPTION
## Summary
- sanitize the CLI test run helper to strip inherited PHP autoload configuration while still allowing explicit overrides
- tighten the generate/apply integration test assertions to verify the PHP driver reporter output and document the current silent apply failure

## Testing
- pnpm --filter @wpkernel/cli test:integration

------
https://chatgpt.com/codex/tasks/task_e_690682594f2483258e63e536ed7894ee