### PR TITLE
Surface fatal pipeline errors in CLI test mode

### DIFF
--- a/packages/cli/src/commands/__tests__/fatal.test.ts
+++ b/packages/cli/src/commands/__tests__/fatal.test.ts
@@ -1,0 +1,55 @@
+import { WPK_NAMESPACE } from '@wpkernel/core/contracts';
+import { emitFatalError } from '../fatal';
+
+describe('emitFatalError', () => {
+	let writeSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		writeSpy = jest
+			.spyOn(process.stderr, 'write')
+			.mockImplementation(() => true as unknown as number);
+	});
+
+	afterEach(() => {
+		writeSpy.mockRestore();
+	});
+
+	it('writes the message and serialised object context to stderr', () => {
+		emitFatalError('Example failure', { reason: 'object' });
+
+		expect(writeSpy).toHaveBeenCalledWith(
+			expect.stringContaining(
+				`[${WPK_NAMESPACE}.cli][fatal] Example failure {"reason":"object"}`
+			)
+		);
+	});
+
+	it('writes string context as-is', () => {
+		emitFatalError('Example', 'string-context');
+
+		expect(writeSpy).toHaveBeenCalledWith(
+			expect.stringContaining(
+				`[${WPK_NAMESPACE}.cli][fatal] Example string-context`
+			)
+		);
+	});
+
+	it('falls back to inspect output for circular contexts', () => {
+		const circular: { self?: unknown } = {};
+		circular.self = circular;
+
+		emitFatalError('Circular', circular);
+
+		expect(writeSpy.mock.calls.at(-1)?.[0]).toContain('[Circular');
+	});
+
+	it('uses default fatal message when provided string is empty', () => {
+		emitFatalError('   ', undefined);
+
+		expect(writeSpy).toHaveBeenCalledWith(
+			expect.stringContaining(
+				`[${WPK_NAMESPACE}.cli][fatal] Fatal error.`
+			)
+		);
+	});
+});

--- a/packages/cli/src/commands/apply/errors.ts
+++ b/packages/cli/src/commands/apply/errors.ts
@@ -6,6 +6,7 @@ import {
 	type SerializedError,
 } from '@wpkernel/core/contracts';
 import type { Reporter } from '@wpkernel/core/reporter';
+import { emitFatalError } from '../fatal';
 
 export function determineExitCode(error: unknown): WPKExitCode {
 	if (WPKernelError.isWPKernelError(error)) {
@@ -25,7 +26,9 @@ export function reportFailure(
 	message: string,
 	error: unknown
 ): void {
-	reporter.error(message, serialiseError(error));
+	const payload = serialiseError(error);
+	emitFatalError(message, payload);
+	reporter.error(message, payload);
 }
 
 export function serialiseError(error: unknown): SerializedError {

--- a/packages/cli/src/commands/fatal.ts
+++ b/packages/cli/src/commands/fatal.ts
@@ -1,0 +1,40 @@
+import process from 'node:process';
+import { inspect } from 'node:util';
+import { WPK_NAMESPACE } from '@wpkernel/core/contracts';
+
+const CHANNEL = `${WPK_NAMESPACE}.cli`;
+const PREFIX = `[${CHANNEL}][fatal]`;
+
+function serialiseContext(context: unknown): string | null {
+	if (context === null || typeof context === 'undefined') {
+		return null;
+	}
+
+	if (typeof context === 'string') {
+		return context;
+	}
+
+	try {
+		return JSON.stringify(context);
+	} catch (error) {
+		try {
+			return inspect(context, { depth: 5 });
+		} catch {
+			return inspect(error, { depth: 1 });
+		}
+	}
+}
+
+export function emitFatalError(message: string, context?: unknown): void {
+	const trimmedMessage = message.trim();
+	const payload: string[] = [
+		`${PREFIX} ${trimmedMessage.length > 0 ? trimmedMessage : 'Fatal error.'}`,
+	];
+
+	const contextPayload = serialiseContext(context);
+	if (contextPayload) {
+		payload.push(contextPayload);
+	}
+
+	process.stderr.write(`${payload.join(' ')}\n`);
+}

--- a/packages/cli/tests/__tests__/generate-apply.integration.test.ts
+++ b/packages/cli/tests/__tests__/generate-apply.integration.test.ts
@@ -57,6 +57,9 @@ describe('generate + apply integration', () => {
 				expect(generateResult.stderr).toContain(
 					'Fatal error: Uncaught Error: Typed property PhpParser'
 				);
+				expect(generateResult.stderr).toContain(
+					'[wpk.cli][fatal] Failed to pretty print PHP artifacts.'
+				);
 
 				const traceContents = await fs.readFile(traceFile, 'utf8');
 				const traceEvents = traceContents
@@ -92,10 +95,13 @@ describe('generate + apply integration', () => {
 				);
 
 				expect(applyResult.code).toBe(1);
-				// Known bug: the reporter never surfaces apply failures when
-				// the manifest is missing, so both streams remain empty.
 				expect(applyResult.stdout).toBe('');
-				expect(applyResult.stderr).toBe('');
+				expect(applyResult.stderr).toContain(
+					'[wpk.cli][fatal] Failed to apply workspace patches.'
+				);
+				expect(applyResult.stderr).toContain(
+					'Apply requires a git repository.'
+				);
 			},
 			{ chdir: false }
 		);

--- a/packages/cli/tests/test-support/runWpk.ts
+++ b/packages/cli/tests/test-support/runWpk.ts
@@ -42,6 +42,10 @@ function sanitizePhpAutoloadEnv(
 		}
 	}
 
+	if (!('WPK_CLI_FORCE_SOURCE' in sanitized)) {
+		sanitized.WPK_CLI_FORCE_SOURCE = '1';
+	}
+
 	return sanitized;
 }
 


### PR DESCRIPTION
## Summary
- add a CLI fatal error emitter that always writes to stderr even when reporters are disabled
- harden generate/apply workflows to use the fatal emitter and detect missing apply manifests before proceeding
- update integration/unit coverage and the test harness to expect visible diagnostics from crashes in test mode

## Testing
- pnpm --filter @wpkernel/cli test -- generate.command.test.ts
- pnpm --filter @wpkernel/cli test -- generate-apply.integration.test.ts
- pnpm --filter @wpkernel/cli test -- fatal.test.ts
- pnpm --filter @wpkernel/cli test:coverage *(fails: global functions coverage threshold still set to 90%)*

------
https://chatgpt.com/codex/tasks/task_e_69069b5a06cc8325b2a4f48b49fa9332