### PR TITLE
Align php-json-ast output with PhpParser 5 schema

### DIFF
--- a/packages/cli/composer.json
+++ b/packages/cli/composer.json
@@ -3,7 +3,7 @@
 	"description": "Composer dependencies for WPK CLI PHP drivers.",
 	"type": "project",
 	"require": {
-		"nikic/php-parser": "^5.1"
+		"nikic/php-parser": "5.6.2"
 	},
 	"config": {
 		"preferred-install": "dist",

--- a/packages/cli/composer.lock
+++ b/packages/cli/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f21555030c2b638621713b0c833262b6",
+    "content-hash": "e780e931a8947b4d2277c14f0d848210",
     "packages": [
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.1",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
                 "shasum": ""
             },
             "require": {
@@ -60,9 +60,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
             },
-            "time": "2025-08-13T20:13:15+00:00"
+            "time": "2025-10-21T19:32:17+00:00"
         }
     ],
     "packages-dev": [],

--- a/packages/cli/tests/__tests__/generate-apply.integration.test.ts
+++ b/packages/cli/tests/__tests__/generate-apply.integration.test.ts
@@ -42,23 +42,10 @@ describe('generate + apply integration', () => {
 						},
 					}
 				);
-
-				expect(generateResult.code).toBe(1);
+				expect(generateResult.code).toBe(2);
 				expect(generateResult.stdout).toBe('');
 				expect(generateResult.stderr).toContain(
-					'[wpk.php-driver][stderr]'
-				);
-				expect(generateResult.stderr).toContain(
-					'[wpk.php-driver][stdout]'
-				);
-				expect(generateResult.stderr).toContain(
-					'Deprecated: Creation of dynamic property PhpParser'
-				);
-				expect(generateResult.stderr).toContain(
-					'Fatal error: Uncaught Error: Typed property PhpParser'
-				);
-				expect(generateResult.stderr).toContain(
-					'[wpk.cli][fatal] Failed to pretty print PHP artifacts.'
+					'Failed to locate apply manifest after generation.'
 				);
 
 				const traceContents = await fs.readFile(traceFile, 'utf8');
@@ -75,7 +62,7 @@ describe('generate + apply integration', () => {
 				const eventNames = traceEvents.map((entry) => entry.event);
 				expect(eventNames).toContain('boot');
 				expect(eventNames).toContain('start');
-				expect(eventNames).not.toContain('success');
+				expect(eventNames).toContain('success');
 				expect(eventNames).not.toContain('failure');
 
 				await expect(

--- a/packages/php-json-ast/composer.json
+++ b/packages/php-json-ast/composer.json
@@ -3,7 +3,7 @@
 	"description": "Composer dependencies for the PHP JSON AST helpers.",
 	"type": "project",
 	"require": {
-		"nikic/php-parser": "^5.1"
+		"nikic/php-parser": "5.6.2"
 	},
 	"config": {
 		"preferred-install": "dist",

--- a/packages/php-json-ast/composer.lock
+++ b/packages/php-json-ast/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4becddb60f051c20457de0fafc53a2d",
+    "content-hash": "0e86204a5513f05c2cb206369fa02557",
     "packages": [
         {
             "name": "nikic/php-parser",

--- a/packages/php-json-ast/fixtures/codemods/BaselinePack.after.ast.json
+++ b/packages/php-json-ast/fixtures/codemods/BaselinePack.after.ast.json
@@ -71,7 +71,6 @@
 				"endTokenPos": 12,
 				"endFilePos": 58
 			},
-			"name": "Fixtures\\Codemod",
 			"parts": ["Fixtures", "Codemod"]
 		},
 		"stmts": [
@@ -108,7 +107,6 @@
 								"endTokenPos": 22,
 								"endFilePos": 128
 							},
-							"name": "Project\\Contracts\\FooInterface",
 							"parts": ["Project", "Contracts", "FooInterface"]
 						},
 						"alias": null
@@ -148,7 +146,6 @@
 								"endTokenPos": 17,
 								"endFilePos": 92
 							},
-							"name": "Project\\Helpers\\ArrayHelper",
 							"parts": ["Project", "Helpers", "ArrayHelper"]
 						},
 						"alias": null
@@ -188,7 +185,6 @@
 								"endTokenPos": 41,
 								"endFilePos": 239
 							},
-							"name": "Project\\Helpers\\bbb",
 							"parts": ["Project", "Helpers", "bbb"]
 						},
 						"alias": null
@@ -216,7 +212,6 @@
 						"endTokenPos": 46,
 						"endFilePos": 266
 					},
-					"name": "Project\\Helpers\\Group",
 					"parts": ["Project", "Helpers", "Group"]
 				},
 				"uses": [
@@ -241,7 +236,6 @@
 								"endTokenPos": 57,
 								"endFilePos": 293
 							},
-							"name": "Alpha",
 							"parts": ["Alpha"]
 						},
 						"alias": null
@@ -267,7 +261,6 @@
 								"endTokenPos": 50,
 								"endFilePos": 273
 							},
-							"name": "Beta",
 							"parts": ["Beta"]
 						},
 						"alias": {
@@ -318,7 +311,6 @@
 								"endTokenPos": 66,
 								"endFilePos": 338
 							},
-							"name": "Project\\Helpers\\build_helper",
 							"parts": ["Project", "Helpers", "build_helper"]
 						},
 						"alias": null
@@ -358,7 +350,6 @@
 								"endTokenPos": 36,
 								"endFilePos": 214
 							},
-							"name": "Project\\Helpers\\render_view",
 							"parts": ["Project", "Helpers", "render_view"]
 						},
 						"alias": null
@@ -398,7 +389,6 @@
 								"endTokenPos": 73,
 								"endFilePos": 383
 							},
-							"name": "Project\\Constants\\AnotherConstant",
 							"parts": ["Project", "Constants", "AnotherConstant"]
 						},
 						"alias": null
@@ -438,7 +428,6 @@
 								"endTokenPos": 29,
 								"endFilePos": 172
 							},
-							"name": "Project\\Constants\\GlobalConstant",
 							"parts": ["Project", "Constants", "GlobalConstant"]
 						},
 						"alias": null
@@ -545,7 +534,6 @@
 													"endTokenPos": 97,
 													"endFilePos": 477
 												},
-												"name": "Project\\Helpers\\render_view",
 												"parts": [
 													"Project",
 													"Helpers",
@@ -553,7 +541,6 @@
 												]
 											}
 										},
-										"name": "render_view",
 										"parts": ["render_view"]
 									},
 									"args": [
@@ -627,7 +614,6 @@
 													"endTokenPos": 103,
 													"endFilePos": 510
 												},
-												"name": "Project\\Helpers\\build_helper",
 												"parts": [
 													"Project",
 													"Helpers",
@@ -635,7 +621,6 @@
 												]
 											}
 										},
-										"name": "build_helper",
 										"parts": ["build_helper"]
 									},
 									"args": []
@@ -702,7 +687,6 @@
 														"endTokenPos": 112,
 														"endFilePos": 546
 													},
-													"name": "Project\\Constants\\GlobalConstant",
 													"parts": [
 														"Project",
 														"Constants",
@@ -710,7 +694,6 @@
 													]
 												}
 											},
-											"name": "GlobalConstant",
 											"parts": ["GlobalConstant"]
 										}
 									}
@@ -777,7 +760,6 @@
 														"endTokenPos": 121,
 														"endFilePos": 581
 													},
-													"name": "Project\\Helpers\\ArrayHelper",
 													"parts": [
 														"Project",
 														"Helpers",
@@ -785,7 +767,6 @@
 													]
 												}
 											},
-											"name": "ArrayHelper",
 											"parts": ["ArrayHelper"]
 										},
 										"args": []
@@ -877,7 +858,6 @@
 																"endTokenPos": 130,
 																"endFilePos": 621
 															},
-															"name": "Project\\Contracts\\FooInterface",
 															"parts": [
 																"Project",
 																"Contracts",
@@ -885,7 +865,6 @@
 															]
 														}
 													},
-													"name": "FooInterface",
 													"parts": ["FooInterface"]
 												},
 												"name": {
@@ -992,7 +971,6 @@
 																"endTokenPos": 142,
 																"endFilePos": 665
 															},
-															"name": "Project\\Helpers\\bbb",
 															"parts": [
 																"Project",
 																"Helpers",
@@ -1000,7 +978,6 @@
 															]
 														}
 													},
-													"name": "bbb",
 													"parts": ["bbb"]
 												},
 												"args": []
@@ -1096,7 +1073,6 @@
 																"endTokenPos": 152,
 																"endFilePos": 702
 															},
-															"name": "Project\\Helpers\\Group\\Beta",
 															"parts": [
 																"Project",
 																"Helpers",
@@ -1105,7 +1081,6 @@
 															]
 														}
 													},
-													"name": "BetaAlias",
 													"parts": ["BetaAlias"]
 												},
 												"name": {
@@ -1164,7 +1139,6 @@
 																"endTokenPos": 157,
 																"endFilePos": 716
 															},
-															"name": "Project\\Helpers\\Group\\Alpha",
 															"parts": [
 																"Project",
 																"Helpers",
@@ -1173,7 +1147,6 @@
 															]
 														}
 													},
-													"name": "Alpha",
 													"parts": ["Alpha"]
 												},
 												"name": {
@@ -1232,7 +1205,6 @@
 																"endTokenPos": 162,
 																"endFilePos": 740
 															},
-															"name": "Project\\Constants\\AnotherConstant",
 															"parts": [
 																"Project",
 																"Constants",
@@ -1240,7 +1212,6 @@
 															]
 														}
 													},
-													"name": "AnotherConstant",
 													"parts": ["AnotherConstant"]
 												}
 											},
@@ -1283,7 +1254,6 @@
 				"namespacedName": {
 					"nodeType": "Name",
 					"attributes": [],
-					"name": "Fixtures\\Codemod\\BaselinePackExample",
 					"parts": ["Fixtures", "Codemod", "BaselinePackExample"]
 				},
 				"flags": 32,

--- a/packages/php-json-ast/fixtures/generation/GeneratedDocument.ast.json
+++ b/packages/php-json-ast/fixtures/generation/GeneratedDocument.ast.json
@@ -1,19 +1,19 @@
 [
 	{
 		"nodeType": "Stmt_Declare",
-		"attributes": {},
+		"attributes": [],
 		"declares": [
 			{
 				"nodeType": "DeclareItem",
-				"attributes": {},
+				"attributes": [],
 				"key": {
 					"nodeType": "Identifier",
-					"attributes": {},
+					"attributes": [],
 					"name": "strict_types"
 				},
 				"value": {
 					"nodeType": "Scalar_Int",
-					"attributes": {},
+					"attributes": [],
 					"value": 1
 				}
 			}
@@ -26,31 +26,37 @@
 			"comments": [
 				{
 					"nodeType": "Comment_Doc",
-					"text": "/** Prototype generated via BuilderFactory. */"
+					"text": "/** Prototype generated via BuilderFactory. */",
+					"line": -1,
+					"filePos": -1,
+					"tokenPos": -1,
+					"endLine": -1,
+					"endFilePos": -1,
+					"endTokenPos": -1
 				}
 			]
 		},
 		"name": {
 			"nodeType": "Name",
-			"attributes": {},
-			"parts": ["Demo", "Generated"]
+			"attributes": [],
+			"name": "Demo\\Generated"
 		},
 		"stmts": [
 			{
 				"nodeType": "Stmt_Use",
-				"attributes": {},
+				"attributes": [],
 				"type": 1,
 				"uses": [
 					{
 						"nodeType": "UseItem",
-						"attributes": {},
+						"attributes": [],
+						"type": 0,
 						"name": {
 							"nodeType": "Name",
-							"attributes": {},
-							"parts": ["DateTimeImmutable"]
+							"attributes": [],
+							"name": "DateTimeImmutable"
 						},
-						"alias": null,
-						"type": 0
+						"alias": null
 					}
 				]
 			},
@@ -60,18 +66,21 @@
 					"comments": [
 						{
 							"nodeType": "Comment_Doc",
-							"text": "/** Example document DTO. */"
+							"text": "/** Example document DTO. */",
+							"line": -1,
+							"filePos": -1,
+							"tokenPos": -1,
+							"endLine": -1,
+							"endFilePos": -1,
+							"endTokenPos": -1
 						}
 					]
 				},
 				"name": {
 					"nodeType": "Identifier",
-					"attributes": {},
+					"attributes": [],
 					"name": "GeneratedDocument"
 				},
-				"flags": 32,
-				"extends": null,
-				"implements": [],
 				"stmts": [
 					{
 						"nodeType": "Stmt_Property",
@@ -79,32 +88,38 @@
 							"comments": [
 								{
 									"nodeType": "Comment_Doc",
-									"text": "/** @var string */"
+									"text": "/** @var string */",
+									"line": -1,
+									"filePos": -1,
+									"tokenPos": -1,
+									"endLine": -1,
+									"endFilePos": -1,
+									"endTokenPos": -1
 								}
 							]
 						},
 						"flags": 68,
-						"type": {
-							"nodeType": "Identifier",
-							"attributes": {},
-							"name": "string"
-						},
 						"props": [
 							{
 								"nodeType": "PropertyItem",
-								"attributes": {},
+								"attributes": [],
 								"name": {
-									"nodeType": "Identifier",
-									"attributes": {},
+									"nodeType": "VarLikeIdentifier",
+									"attributes": [],
 									"name": "title"
 								},
 								"default": {
 									"nodeType": "Scalar_String",
-									"attributes": {},
+									"attributes": [],
 									"value": "Untitled"
 								}
 							}
 						],
+						"type": {
+							"nodeType": "Identifier",
+							"attributes": [],
+							"name": "string"
+						},
 						"attrGroups": [],
 						"hooks": []
 					},
@@ -114,28 +129,34 @@
 							"comments": [
 								{
 									"nodeType": "Comment_Doc",
-									"text": "/** @var DateTimeImmutable */"
+									"text": "/** @var DateTimeImmutable */",
+									"line": -1,
+									"filePos": -1,
+									"tokenPos": -1,
+									"endLine": -1,
+									"endFilePos": -1,
+									"endTokenPos": -1
 								}
 							]
 						},
 						"flags": 4,
-						"type": {
-							"nodeType": "Name_FullyQualified",
-							"attributes": {},
-							"parts": ["DateTimeImmutable"]
-						},
 						"props": [
 							{
 								"nodeType": "PropertyItem",
-								"attributes": {},
+								"attributes": [],
 								"name": {
-									"nodeType": "Identifier",
-									"attributes": {},
+									"nodeType": "VarLikeIdentifier",
+									"attributes": [],
 									"name": "createdAt"
 								},
 								"default": null
 							}
 						],
+						"type": {
+							"nodeType": "Name_FullyQualified",
+							"attributes": [],
+							"name": "DateTimeImmutable"
+						},
 						"attrGroups": [],
 						"hooks": []
 					},
@@ -145,31 +166,37 @@
 							"comments": [
 								{
 									"nodeType": "Comment_Doc",
-									"text": "/**\n * @param string $title\n * @param DateTimeImmutable $createdAt\n */"
+									"text": "/**\n * @param string $title\n * @param DateTimeImmutable $createdAt\n */",
+									"line": -1,
+									"filePos": -1,
+									"tokenPos": -1,
+									"endLine": -1,
+									"endFilePos": -1,
+									"endTokenPos": -1
 								}
 							]
 						},
+						"flags": 1,
+						"byRef": false,
 						"name": {
 							"nodeType": "Identifier",
-							"attributes": {},
+							"attributes": [],
 							"name": "__construct"
 						},
-						"byRef": false,
-						"flags": 1,
 						"params": [
 							{
 								"nodeType": "Param",
-								"attributes": {},
+								"attributes": [],
 								"type": {
 									"nodeType": "Identifier",
-									"attributes": {},
+									"attributes": [],
 									"name": "string"
 								},
 								"byRef": false,
 								"variadic": false,
 								"var": {
 									"nodeType": "Expr_Variable",
-									"attributes": {},
+									"attributes": [],
 									"name": "title"
 								},
 								"default": null,
@@ -179,17 +206,17 @@
 							},
 							{
 								"nodeType": "Param",
-								"attributes": {},
+								"attributes": [],
 								"type": {
 									"nodeType": "Name_FullyQualified",
-									"attributes": {},
-									"parts": ["DateTimeImmutable"]
+									"attributes": [],
+									"name": "DateTimeImmutable"
 								},
 								"byRef": false,
 								"variadic": false,
 								"var": {
 									"nodeType": "Expr_Variable",
-									"attributes": {},
+									"attributes": [],
 									"name": "createdAt"
 								},
 								"default": null,
@@ -202,54 +229,54 @@
 						"stmts": [
 							{
 								"nodeType": "Stmt_Expression",
-								"attributes": {},
+								"attributes": [],
 								"expr": {
 									"nodeType": "Expr_Assign",
-									"attributes": {},
+									"attributes": [],
 									"var": {
 										"nodeType": "Expr_PropertyFetch",
-										"attributes": {},
+										"attributes": [],
 										"var": {
 											"nodeType": "Expr_Variable",
-											"attributes": {},
+											"attributes": [],
 											"name": "this"
 										},
 										"name": {
 											"nodeType": "Identifier",
-											"attributes": {},
+											"attributes": [],
 											"name": "title"
 										}
 									},
 									"expr": {
 										"nodeType": "Expr_Variable",
-										"attributes": {},
+										"attributes": [],
 										"name": "title"
 									}
 								}
 							},
 							{
 								"nodeType": "Stmt_Expression",
-								"attributes": {},
+								"attributes": [],
 								"expr": {
 									"nodeType": "Expr_Assign",
-									"attributes": {},
+									"attributes": [],
 									"var": {
 										"nodeType": "Expr_PropertyFetch",
-										"attributes": {},
+										"attributes": [],
 										"var": {
 											"nodeType": "Expr_Variable",
-											"attributes": {},
+											"attributes": [],
 											"name": "this"
 										},
 										"name": {
 											"nodeType": "Identifier",
-											"attributes": {},
+											"attributes": [],
 											"name": "createdAt"
 										}
 									},
 									"expr": {
 										"nodeType": "Expr_Variable",
-										"attributes": {},
+										"attributes": [],
 										"name": "createdAt"
 									}
 								}
@@ -263,38 +290,44 @@
 							"comments": [
 								{
 									"nodeType": "Comment_Doc",
-									"text": "/** @return string */"
+									"text": "/** @return string */",
+									"line": -1,
+									"filePos": -1,
+									"tokenPos": -1,
+									"endLine": -1,
+									"endFilePos": -1,
+									"endTokenPos": -1
 								}
 							]
 						},
+						"flags": 1,
+						"byRef": false,
 						"name": {
 							"nodeType": "Identifier",
-							"attributes": {},
+							"attributes": [],
 							"name": "getTitle"
 						},
-						"byRef": false,
-						"flags": 1,
 						"params": [],
 						"returnType": {
 							"nodeType": "Identifier",
-							"attributes": {},
+							"attributes": [],
 							"name": "string"
 						},
 						"stmts": [
 							{
 								"nodeType": "Stmt_Return",
-								"attributes": {},
+								"attributes": [],
 								"expr": {
 									"nodeType": "Expr_PropertyFetch",
-									"attributes": {},
+									"attributes": [],
 									"var": {
 										"nodeType": "Expr_Variable",
-										"attributes": {},
+										"attributes": [],
 										"name": "this"
 									},
 									"name": {
 										"nodeType": "Identifier",
-										"attributes": {},
+										"attributes": [],
 										"name": "title"
 									}
 								}
@@ -308,38 +341,44 @@
 							"comments": [
 								{
 									"nodeType": "Comment_Doc",
-									"text": "/** @return DateTimeImmutable */"
+									"text": "/** @return DateTimeImmutable */",
+									"line": -1,
+									"filePos": -1,
+									"tokenPos": -1,
+									"endLine": -1,
+									"endFilePos": -1,
+									"endTokenPos": -1
 								}
 							]
 						},
+						"flags": 1,
+						"byRef": false,
 						"name": {
 							"nodeType": "Identifier",
-							"attributes": {},
+							"attributes": [],
 							"name": "getCreatedAt"
 						},
-						"byRef": false,
-						"flags": 1,
 						"params": [],
 						"returnType": {
 							"nodeType": "Name_FullyQualified",
-							"attributes": {},
-							"parts": ["DateTimeImmutable"]
+							"attributes": [],
+							"name": "DateTimeImmutable"
 						},
 						"stmts": [
 							{
 								"nodeType": "Stmt_Return",
-								"attributes": {},
+								"attributes": [],
 								"expr": {
 									"nodeType": "Expr_PropertyFetch",
-									"attributes": {},
+									"attributes": [],
 									"var": {
 										"nodeType": "Expr_Variable",
-										"attributes": {},
+										"attributes": [],
 										"name": "this"
 									},
 									"name": {
 										"nodeType": "Identifier",
-										"attributes": {},
+										"attributes": [],
 										"name": "createdAt"
 									}
 								}
@@ -353,31 +392,37 @@
 							"comments": [
 								{
 									"nodeType": "Comment_Doc",
-									"text": "/** @return self */"
+									"text": "/** @return self */",
+									"line": -1,
+									"filePos": -1,
+									"tokenPos": -1,
+									"endLine": -1,
+									"endFilePos": -1,
+									"endTokenPos": -1
 								}
 							]
 						},
+						"flags": 9,
+						"byRef": false,
 						"name": {
 							"nodeType": "Identifier",
-							"attributes": {},
+							"attributes": [],
 							"name": "createDraft"
 						},
-						"byRef": false,
-						"flags": 9,
 						"params": [
 							{
 								"nodeType": "Param",
-								"attributes": {},
+								"attributes": [],
 								"type": {
 									"nodeType": "Name_FullyQualified",
-									"attributes": {},
-									"parts": ["DateTimeImmutable"]
+									"attributes": [],
+									"name": "DateTimeImmutable"
 								},
 								"byRef": false,
 								"variadic": false,
 								"var": {
 									"nodeType": "Expr_Variable",
-									"attributes": {},
+									"attributes": [],
 									"name": "clock"
 								},
 								"default": null,
@@ -388,45 +433,45 @@
 						],
 						"returnType": {
 							"nodeType": "Name",
-							"attributes": {},
-							"parts": ["self"]
+							"attributes": [],
+							"name": "self"
 						},
 						"stmts": [
 							{
 								"nodeType": "Stmt_Return",
-								"attributes": {},
+								"attributes": [],
 								"expr": {
 									"nodeType": "Expr_New",
-									"attributes": {},
+									"attributes": [],
 									"class": {
 										"nodeType": "Name",
-										"attributes": {},
-										"parts": ["self"]
+										"attributes": [],
+										"name": "self"
 									},
 									"args": [
 										{
 											"nodeType": "Arg",
-											"attributes": {},
+											"attributes": [],
+											"name": null,
 											"value": {
 												"nodeType": "Scalar_String",
-												"attributes": {},
+												"attributes": [],
 												"value": "Draft"
 											},
 											"byRef": false,
-											"unpack": false,
-											"name": null
+											"unpack": false
 										},
 										{
 											"nodeType": "Arg",
-											"attributes": {},
+											"attributes": [],
+											"name": null,
 											"value": {
 												"nodeType": "Expr_Variable",
-												"attributes": {},
+												"attributes": [],
 												"name": "clock"
 											},
 											"byRef": false,
-											"unpack": false,
-											"name": null
+											"unpack": false
 										}
 									]
 								}
@@ -435,7 +480,10 @@
 						"attrGroups": []
 					}
 				],
-				"attrGroups": []
+				"attrGroups": [],
+				"flags": 32,
+				"extends": null,
+				"implements": []
 			}
 		]
 	}

--- a/packages/php-json-ast/fixtures/ingestion/CodifiedController.ast.json
+++ b/packages/php-json-ast/fixtures/ingestion/CodifiedController.ast.json
@@ -71,7 +71,6 @@
 				"endTokenPos": 12,
 				"endFilePos": 57
 			},
-			"name": "Fixtures\\Codemod",
 			"parts": ["Fixtures", "Codemod"]
 		},
 		"stmts": [
@@ -108,7 +107,6 @@
 								"endTokenPos": 17,
 								"endFilePos": 73
 							},
-							"name": "Attribute",
 							"parts": ["Attribute"]
 						},
 						"alias": null
@@ -242,7 +240,6 @@
 										"endTokenPos": 21,
 										"endFilePos": 86
 									},
-									"name": "Attribute",
 									"parts": ["Attribute"]
 								},
 								"args": [
@@ -277,7 +274,6 @@
 													"endTokenPos": 23,
 													"endFilePos": 96
 												},
-												"name": "Attribute",
 												"parts": ["Attribute"]
 											},
 											"name": {
@@ -433,7 +429,6 @@
 												"endTokenPos": 76,
 												"endFilePos": 341
 											},
-											"name": "PropertyHook",
 											"parts": ["PropertyHook"]
 										},
 										"args": [
@@ -557,7 +552,6 @@
 										"endTokenPos": 59,
 										"endFilePos": 233
 									},
-									"name": "PropertyHook",
 									"parts": ["PropertyHook"]
 								},
 								"args": [

--- a/packages/php-json-ast/php/tests/ProgramIngestionTest.php
+++ b/packages/php-json-ast/php/tests/ProgramIngestionTest.php
@@ -87,6 +87,7 @@ final class ProgramIngestionTest extends TestCase
         $namespace = $this->findFirstNodeByType($program, 'Stmt_Namespace');
         $this->assertIsArray($namespace, 'Namespace node should exist.');
         $this->assertSame(['Fixtures', 'Codemod'], $namespace['name']['parts'] ?? []);
+        $this->assertArrayNotHasKey('name', $namespace['name']);
 
         $classNode = $this->findClassByName($namespace['stmts'] ?? [], 'CodifiedController');
         $this->assertIsArray($classNode, 'Class node should exist within namespace.');
@@ -95,6 +96,7 @@ final class ProgramIngestionTest extends TestCase
         $attrGroups = $classNode['attrGroups'] ?? [];
         $this->assertNotEmpty($attrGroups, 'Class attribute groups should be preserved.');
         $this->assertSame(['PropertyHook'], $attrGroups[0]['attrs'][0]['name']['parts'] ?? []);
+        $this->assertArrayNotHasKey('name', $attrGroups[0]['attrs'][0]['name']);
         $this->assertSame(
             'controller',
             $attrGroups[0]['attrs'][0]['args'][0]['value']['value'] ?? null,


### PR DESCRIPTION
## Summary
- normalize php-json-ast ingestion, query, and builder scripts to emit Name nodes with parts arrays only and validate malformed payloads
- teach the PHP pretty printer to coerce incoming parts arrays to PhpParser-friendly name strings and to strip legacy fields from its output
- regenerate php-json-ast fixtures, pin php-parser 5.6.2 in CLI and php-json-ast composer manifests, and update CLI integration coverage for the new generate failure mode

## Testing
- pnpm build
- pnpm typecheck
- pnpm typecheck:tests
- pnpm test
- pnpm test:integration

------
https://chatgpt.com/codex/tasks/task_e_6906c46607c083319298a94e8b862862