### PR TITLE
Fix plugin loader to instantiate shim controllers

### DIFF
--- a/packages/cli/src/next/builders/php/__tests__/__snapshots__/pluginLoader.test.ts.snap
+++ b/packages/cli/src/next/builders/php/__tests__/__snapshots__/pluginLoader.test.ts.snap
@@ -187,7 +187,6 @@ exports[`createPhpPluginLoaderHelper queues a plugin loader program with generat
                       "parts": [
                         "Demo",
                         "Plugin",
-                        "Generated",
                         "Rest",
                         "BooksController",
                       ],
@@ -210,7 +209,6 @@ exports[`createPhpPluginLoaderHelper queues a plugin loader program with generat
                       "parts": [
                         "Demo",
                         "Plugin",
-                        "Generated",
                         "Rest",
                         "AuthorsController",
                       ],
@@ -672,7 +670,6 @@ exports[`createPhpPluginLoaderHelper respects custom namespace structures: plugi
                         "Acme",
                         "Demo",
                         "Plugin",
-                        "Generated",
                         "Rest",
                         "JobsController",
                       ],

--- a/packages/cli/src/next/builders/php/pluginLoader.ts
+++ b/packages/cli/src/next/builders/php/pluginLoader.ts
@@ -27,7 +27,7 @@ export function createPhpPluginLoaderHelper(): BuilderHelper {
 
 			const resourceClassNames = ir.resources.map((resource) => {
 				const pascal = toPascalCase(resource.name);
-				return `${ir.php.namespace}\\Generated\\Rest\\${pascal}Controller`;
+				return `${ir.php.namespace}\\Rest\\${pascal}Controller`;
 			});
 
 			// If a plugin.php exists and lacks the WPK guard, assume user-owned and skip generation.


### PR DESCRIPTION
## Summary
- update the PHP plugin loader builder to instantiate REST controllers from the shim namespace
- refresh plugin loader snapshots so the expected controller classes match the shim namespace

## Testing
- `pnpm --filter @wpkernel/cli test -- pluginLoader.test.ts -u`
- `pnpm --filter @wpkernel/cli test -- wpk-bin.integration.test.ts`
- `pnpm --filter @wpkernel/cli test:coverage` *(fails: global function coverage threshold is 87% < required 90%)*

------
https://chatgpt.com/codex/tasks/task_e_6906ffa35abc832597822d1a2f5b604b